### PR TITLE
Fix: Resolve image loading loop, crash, and blinking issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,11 +408,11 @@ function MainApp() {
                         setMousePosition={setMousePosition}
                         isMouseDown={isMouseDown}
                         setIsMouseDown={setIsMouseDown}
-                        onInit={() => {
-                        if(rendererRef.current) {
-                            setAvailableModes(rendererRef.current.getAvailableModes());
-                        }
-                        }}
+                        onInit={useCallback(() => {
+                            if(rendererRef.current) {
+                                setAvailableModes(rendererRef.current.getAvailableModes());
+                            }
+                        }, [])}
                         inputSource={inputSource}
                         selectedVideo={selectedVideo}
                         videoSourceUrl={videoSourceUrl}


### PR DESCRIPTION
1.  **Fix Infinite Re-init Loop:** Wrapped `onInit` callback in `App.tsx` with `useCallback` to prevent the `WebGPUCanvas` component from constantly destroying and re-initializing the renderer on every state change.
2.  **Fix "Instance reference" Crash:** Replaced `fetch` + `createImageBitmap` with `new Image()` + `decode()` in `Renderer.ts`. This resolves the "valid external Instance reference no longer exists" WebGPU error by using a more stable DOM element source.
3.  **Fix Blinking/Blank Screen:** Implemented a "copy-then-swap" pattern in `loadImage`. The new texture is fully created and populated before the old one is destroyed, eliminating the visual gap (blinking) during image transitions.