### PR TITLE
Add Interactive Halftone Spin and Glitch Cubes shaders

### DIFF
--- a/public/shaders/interactive-glitch-cubes.wgsl
+++ b/public/shaders/interactive-glitch-cubes.wgsl
@@ -1,0 +1,120 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4 (Use these for ANY float sliders)
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Interactive Glitch Cubes
+// Param1: Grid Size
+// Param2: Extrusion Height (Mouse Sensitivity)
+// Param3: Grid Gap
+// Param4: Shadow Strength
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let ar = resolution.x / resolution.y;
+
+    // Parameters
+    let gridSize = 5.0 + u.zoom_params.x * 50.0;
+    let extrusion = u.zoom_params.y;
+    let gapBase = u.zoom_params.z * 0.5; // Max 0.5 gap
+    let shadowStr = u.zoom_params.w;
+
+    // Grid Setup
+    let st = uv * vec2<f32>(ar, 1.0) * gridSize;
+    let i_st = floor(st);
+    let f_st = fract(st);
+
+    // Calculate global center of this tile
+    let tileCenterUV = (i_st + 0.5) / gridSize / vec2<f32>(ar, 1.0);
+
+    // Mouse Interaction
+    let mouse = u.zoom_config.yz;
+    let dist = distance(tileCenterUV, mouse);
+
+    // Height Calculation (Closer to mouse = higher)
+    // Use a smooth bell curve
+    let influence = smoothstep(0.5, 0.0, dist);
+    let height = influence * extrusion * 2.0; // 0.0 to 2.0
+
+    // Visual Scale (Perspective: Higher = Bigger)
+    let baseScale = 1.0 - gapBase;
+    let scale = baseScale * (1.0 + height * 0.3);
+
+    // Parallax Shift
+    // Vector from screen center to tile center
+    let viewVec = tileCenterUV - vec2<f32>(0.5, 0.5);
+    // Shift the "face" outwards based on height
+    let shift = viewVec * height * 0.1;
+
+    // Convert shift to local coords
+    let shiftLocal = shift * vec2<f32>(ar, 1.0) * gridSize;
+    let faceCenter = vec2<f32>(0.5) + shiftLocal;
+
+    // Distance from current pixel to the shifted face center
+    let distFace = abs(f_st - faceCenter);
+    let limit = scale * 0.5;
+
+    var color = vec3<f32>(0.05); // Dark Background
+
+    // Check if pixel is on the Face
+    if (distFace.x < limit && distFace.y < limit) {
+        // Map pixel back to texture space
+        // Normalize pos on face (-0.5 to 0.5)
+        let posOnFace = (f_st - faceCenter) / scale;
+
+        // Sample UV
+        let sampleUV = tileCenterUV + posOnFace / gridSize / vec2<f32>(ar, 1.0);
+
+        // Sample Texture
+        color = textureSampleLevel(readTexture, u_sampler, sampleUV, 0.0).rgb;
+
+        // Lighting: Top face is brighter based on height
+        color += height * 0.1;
+
+    } else {
+        // Draw Shadow/Sides
+        // Simple Drop Shadow logic
+        // Let's assume light is top-left, so shadow is bottom-right relative to tile center?
+        // Or Shadow is underneath the lifted block.
+        // Let's use the 'base' floor position (0.5) for shadow.
+        let shadowCenter = vec2<f32>(0.5) + viewVec * 0.05; // Shadow shift
+        let distShadow = abs(f_st - shadowCenter);
+        let shadowLimit = baseScale * 0.5;
+
+        if (distShadow.x < shadowLimit && distShadow.y < shadowLimit) {
+            color = vec3<f32>(0.0); // Deep Black Shadow
+        }
+
+        // Side Extrusion (Connecting Face to Base)
+        // Only if we want to get fancy. For now, floating tiles is good.
+    }
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(color, 1.0));
+
+    // Depth pass
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(d, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/interactive-halftone-spin.wgsl
+++ b/public/shaders/interactive-halftone-spin.wgsl
@@ -1,0 +1,144 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4 (Use these for ANY float sliders)
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Interactive Halftone Spin
+// Param1: Scale
+// Param2: Rotation Speed (Mouse Influence)
+// Param3: Spread (CMYK separation)
+// Param4: Contrast
+
+fn rgb2cmyk(c: vec3<f32>) -> vec4<f32> {
+    let k = 1.0 - max(max(c.r, c.g), c.b);
+    if (k >= 1.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    }
+    let invK = 1.0 / (1.0 - k);
+    let C = (1.0 - c.r - k) * invK;
+    let M = (1.0 - c.g - k) * invK;
+    let Y = (1.0 - c.b - k) * invK;
+    return vec4<f32>(C, M, Y, k);
+}
+
+fn cmyk2rgb(cmyk: vec4<f32>) -> vec3<f32> {
+    let k = cmyk.w;
+    let invK = 1.0 - k;
+    let r = 1.0 - (cmyk.x * invK + k);
+    let g = 1.0 - (cmyk.y * invK + k);
+    let b = 1.0 - (cmyk.z * invK + k);
+    return clamp(vec3<f32>(r, g, b), vec3<f32>(0.0), vec3<f32>(1.0));
+}
+
+fn rotatedGrid(uv: vec2<f32>, angle: f32, scale: f32) -> f32 {
+    let s = sin(angle);
+    let c = cos(angle);
+    let mat = mat2x2<f32>(c, -s, s, c);
+    let st = mat * uv * scale;
+    // Dot pattern: distance from center of cell
+    let cell = fract(st) - 0.5;
+    return length(cell) * 2.0; // 0.0 to ~1.414
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let uv_aspect = vec2<f32>(uv.x * aspect, uv.y);
+    let mouse = u.zoom_config.yz;
+    let mouse_aspect = vec2<f32>(mouse.x * aspect, mouse.y);
+
+    let scaleParam = u.zoom_params.x * 200.0 + 20.0;
+    let rotParam = u.zoom_params.y * 3.14159 * 2.0; // Max rotation influence
+    let spreadParam = u.zoom_params.z;
+    let contrastParam = u.zoom_params.w * 2.0 + 0.5;
+
+    let dist = distance(uv_aspect, mouse_aspect);
+    let influence = smoothstep(0.4, 0.0, dist);
+
+    // Dynamic rotation based on mouse influence
+    let extraRot = influence * rotParam;
+
+    // Sample source color
+    let texColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
+
+    // Boost contrast
+    let contrastColor = (texColor - 0.5) * contrastParam + 0.5;
+    let cmyk = rgb2cmyk(clamp(contrastColor, vec3<f32>(0.0), vec3<f32>(1.0)));
+
+    // Standard Angles (in radians)
+    // C: 15 deg = 0.261
+    // M: 75 deg = 1.309
+    // Y: 0 deg = 0.0
+    // K: 45 deg = 0.785
+
+    // Apply spread: Shift angles apart based on parameter + mouse
+    let s = spreadParam + influence;
+
+    let angC = 0.261 + extraRot * 1.0;
+    let angM = 1.309 + extraRot * 1.5 * s;
+    let angY = 0.0 + extraRot * 0.5;
+    let angK = 0.785 - extraRot * 1.0 * s;
+
+    // Pattern Values (0.0 center to 1.0 edge)
+    let pC = rotatedGrid(uv_aspect, angC, scaleParam);
+    let pM = rotatedGrid(uv_aspect, angM, scaleParam);
+    let pY = rotatedGrid(uv_aspect, angY, scaleParam);
+    let pK = rotatedGrid(uv_aspect, angK, scaleParam);
+
+    // Thresholding (Halftone function)
+    // If (pattern value) < (ink density), draw ink.
+    // Invert logic: 1.0 - distance.
+    // Let's use simple step: step(pattern, sqrt(density)) for circle area
+
+    // sqrt for area correction
+    let outC = step(pC, sqrt(cmyk.x));
+    let outM = step(pM, sqrt(cmyk.y));
+    let outY = step(pY, sqrt(cmyk.z));
+    let outK = step(pK, sqrt(cmyk.w));
+
+    // Combine (Subtractive mixing)
+    // Start white. Multiply by (1 - Ink) if ink is present?
+    // Wait, step returns 1.0 if ink is present.
+    // Cyan absorbs Red. Magenta absorbs Green. Yellow absorbs Blue. Black absorbs All.
+
+    var finalRGB = vec3<f32>(1.0);
+
+    // Cyan ink subtracts Red
+    finalRGB.r = finalRGB.r * (1.0 - outC);
+    // Magenta ink subtracts Green
+    finalRGB.g = finalRGB.g * (1.0 - outM);
+    // Yellow ink subtracts Blue
+    finalRGB.b = finalRGB.b * (1.0 - outY);
+
+    // Black subtracts all
+    finalRGB = finalRGB * (1.0 - outK);
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(finalRGB, 1.0));
+
+    // Depth pass
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/shader_definitions/interactive-mouse/interactive-glitch-cubes.json
+++ b/shader_definitions/interactive-mouse/interactive-glitch-cubes.json
@@ -1,0 +1,41 @@
+{
+  "id": "interactive-glitch-cubes",
+  "name": "Interactive Glitch Cubes",
+  "url": "shaders/interactive-glitch-cubes.wgsl",
+  "category": "image",
+  "description": "Image is mapped onto a grid of extruded cubes that react to mouse height.",
+  "params": [
+    {
+      "id": "size",
+      "name": "Cube Size",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "extrusion",
+      "name": "Extrusion Height",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "gap",
+      "name": "Grid Gap",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "shadow",
+      "name": "Shadow Strength",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "pseudo-3d"
+  ]
+}

--- a/shader_definitions/interactive-mouse/interactive-halftone-spin.json
+++ b/shader_definitions/interactive-mouse/interactive-halftone-spin.json
@@ -1,0 +1,41 @@
+{
+  "id": "interactive-halftone-spin",
+  "name": "Interactive Halftone Spin",
+  "url": "shaders/interactive-halftone-spin.wgsl",
+  "category": "image",
+  "description": "CMYK halftone pattern where the grid rotation is driven by mouse proximity.",
+  "params": [
+    {
+      "id": "scale",
+      "name": "Dot Scale",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "rotation",
+      "name": "Rotation Speed",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "separation",
+      "name": "CMYK Spread",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "contrast",
+      "name": "Contrast",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "halftone"
+  ]
+}


### PR DESCRIPTION
This PR introduces two new interactive shaders:

1.  **Interactive Halftone Spin:** A CMYK halftone effect where the rotation of the dot grids is driven by mouse proximity, creating dynamic moiré patterns and color shifts.
2.  **Interactive Glitch Cubes:** A pseudo-3D effect that divides the image into a grid of cubes/tiles. The mouse position drives the "height" (extrusion) of the tiles, creating a tactile "keyboard" or "cityscape" feel.

The shader lists have been regenerated to include these new effects in the `interactive-mouse` category.

---
*PR created automatically by Jules for task [12566651836371166623](https://jules.google.com/task/12566651836371166623) started by @ford442*