### PR TITLE
Add Stipple Engraving and Double Exposure Zoom shaders

### DIFF
--- a/public/shaders/double-exposure.wgsl
+++ b/public/shaders/double-exposure.wgsl
@@ -1,0 +1,91 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn rotate2d(uv: vec2<f32>, angle: f32) -> vec2<f32> {
+    let c = cos(angle);
+    let s = sin(angle);
+    return vec2<f32>(
+        uv.x * c - uv.y * s,
+        uv.x * s + uv.y * c
+    );
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let resolution = u.config.zw;
+  let uv = vec2<f32>(global_id.xy) / resolution;
+
+  if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+    return;
+  }
+
+  // Params
+  // Zoom: Map 0.0-1.0 to 0.5x - 3.0x
+  let zoomParam = u.zoom_params.x;
+  let zoom = 0.5 + zoomParam * 2.5;
+
+  // Rotation: Map 0.0-1.0 to -PI/4 to PI/4 (approx)
+  let rotParam = u.zoom_params.y;
+  let angle = (rotParam - 0.5) * 1.57; // +/- 45 degrees
+
+  let opacity = u.zoom_params.z;
+  let saturation = u.zoom_params.w;
+
+  // Mouse interaction
+  let mouse = u.zoom_config.yz;
+  let aspect = resolution.x / resolution.y;
+
+  // Sample 1: Base Image
+  let c1 = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+
+  // Sample 2: Transformed Image
+  // Correct aspect ratio for rotation/scale pivot
+  var p = uv - mouse;
+  p.x *= aspect;
+
+  // Rotate
+  p = rotate2d(p, angle);
+
+  // Scale (Zoom)
+  // To zoom IN, we divide the UV coordinates
+  p = p / zoom;
+
+  // Restore aspect and origin
+  p.x /= aspect;
+  let uv2 = p + mouse;
+
+  // Check bounds for uv2 to avoid clamping artifacts if desired,
+  // but textureSampleLevel usually handles clamping or wrapping.
+  // Using u_sampler which usually repeats or clamps.
+  let c2 = textureSampleLevel(readTexture, u_sampler, uv2, 0.0);
+
+  // Blend Logic
+  // Screen Blend: 1 - (1-a)*(1-b)
+  var blended = 1.0 - (1.0 - c1.rgb) * (1.0 - c2.rgb * opacity);
+
+  // Optional Saturation adjustment for the overlay effect
+  let gray = dot(blended, vec3<f32>(0.299, 0.587, 0.114));
+  blended = mix(vec3<f32>(gray), blended, 0.5 + saturation * 0.5);
+
+  textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(blended, 1.0));
+}

--- a/public/shaders/stipple-engraving.wgsl
+++ b/public/shaders/stipple-engraving.wgsl
@@ -1,0 +1,89 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash12(p: vec2<f32>) -> f32 {
+	var p3 = fract(vec3<f32>(p.xyx) * .1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let resolution = u.config.zw;
+  let uv = vec2<f32>(global_id.xy) / resolution;
+
+  if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+    return;
+  }
+
+  // Params
+  let density = u.zoom_params.x * 2.0 + 0.5; // 0.5 to 2.5
+  let contrast = u.zoom_params.y * 2.0 + 0.5;
+  let radius = u.zoom_params.z;
+  let intensity = u.zoom_params.w;
+
+  // Mouse interaction
+  let mouse = u.zoom_config.yz;
+  let aspect = resolution.x / resolution.y;
+  let uvCorrected = vec2<f32>(uv.x * aspect, uv.y);
+  let mouseCorrected = vec2<f32>(mouse.x * aspect, mouse.y);
+  let dist = distance(uvCorrected, mouseCorrected);
+
+  // Sample texture
+  let color = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
+
+  // Calculate Luminance
+  var lum = dot(color, vec3<f32>(0.299, 0.587, 0.114));
+
+  // Apply Contrast
+  lum = (lum - 0.5) * contrast + 0.5;
+
+  // Mouse Spotlight: Brighten the area under the mouse
+  // This effectively reduces the stipple density (more white space)
+  let spotlight = smoothstep(radius, 0.0, dist) * intensity;
+  lum += spotlight;
+  lum = clamp(lum, 0.0, 1.0);
+
+  // Generate Noise
+  // Scale UV by resolution and density for pixel-perfect or scaled noise
+  let noiseUV = uv * resolution * (0.5 / density);
+  let noise = hash12(noiseUV);
+
+  // Stipple Comparison
+  // If noise < luminance, we draw white (paper).
+  // If noise > luminance, we draw black (ink).
+  // But let's allow for some color blending if desired, or strict B&W.
+  // Let's do strict B&W for the "Engraving" look.
+
+  var finalColor = vec3<f32>(0.0);
+  if (noise < lum) {
+    finalColor = vec3<f32>(1.0); // Paper
+  } else {
+    finalColor = vec3<f32>(0.1, 0.1, 0.15); // Ink (dark blueish grey)
+  }
+
+  // Optional: Mix in a bit of original color based on mouse?
+  // No, let's keep it purely stipple for style.
+
+  textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(finalColor, 1.0));
+}

--- a/shader_definitions/interactive-mouse/double-exposure.json
+++ b/shader_definitions/interactive-mouse/double-exposure.json
@@ -1,0 +1,14 @@
+{
+  "id": "double-exposure",
+  "name": "Double Exposure Zoom",
+  "category": "image",
+  "url": "shaders/double-exposure.wgsl",
+  "description": "Blends the image with a zoomed and rotated version of itself, pivoted around the mouse cursor.",
+  "features": ["mouse-driven"],
+  "params": [
+    { "name": "Zoom Level", "id": "zoom", "default": 0.3, "min": 0.0, "max": 1.0 },
+    { "name": "Rotation", "id": "rotation", "default": 0.5, "min": 0.0, "max": 1.0 },
+    { "name": "Opacity", "id": "opacity", "default": 0.6, "min": 0.0, "max": 1.0 },
+    { "name": "Saturation", "id": "saturation", "default": 0.8, "min": 0.0, "max": 1.0 }
+  ]
+}

--- a/shader_definitions/interactive-mouse/stipple-engraving.json
+++ b/shader_definitions/interactive-mouse/stipple-engraving.json
@@ -1,0 +1,14 @@
+{
+  "id": "stipple-engraving",
+  "name": "Stipple Engraving",
+  "category": "image",
+  "url": "shaders/stipple-engraving.wgsl",
+  "description": "Converts the image into a vintage stipple engraving. Mouse proximity acts as a spotlight, revealing details by increasing luminance.",
+  "features": ["mouse-driven"],
+  "params": [
+    { "name": "Density", "id": "density", "default": 0.5, "min": 0.0, "max": 1.0 },
+    { "name": "Contrast", "id": "contrast", "default": 0.5, "min": 0.0, "max": 1.0 },
+    { "name": "Spot Radius", "id": "radius", "default": 0.3, "min": 0.0, "max": 1.0 },
+    { "name": "Spot Brightness", "id": "intensity", "default": 0.5, "min": 0.0, "max": 1.0 }
+  ]
+}


### PR DESCRIPTION
Added two new mouse-responsive shaders: Stipple Engraving and Double Exposure Zoom. These shaders introduce new visual effects and update the shader registry.

---
*PR created automatically by Jules for task [7980194548744450393](https://jules.google.com/task/7980194548744450393) started by @ford442*