### PR TITLE
Add Infinite Spiral Zoom and Reactive Glass Grid shaders

### DIFF
--- a/public/shaders/infinite-spiral-zoom.wgsl
+++ b/public/shaders/infinite-spiral-zoom.wgsl
@@ -1,0 +1,87 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=FrameCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=MouseDown
+  zoom_params: vec4<f32>,  // x=ZoomSpeed, y=SpiralTwist, z=Branches, w=CenterOffset
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    let time = u.config.x;
+
+    // Normalize coordinates
+    let uv = vec2<f32>(global_id.xy) / resolution;
+
+    // Mouse position
+    let mouse = u.zoom_config.yz;
+
+    // Parameters
+    let zoom_speed = (u.zoom_params.x - 0.5) * 4.0; // -2.0 to 2.0
+    let twist = (u.zoom_params.y - 0.5) * 3.14159; // -PI/2 to PI/2
+    let branches = floor(u.zoom_params.z * 5.0) + 1.0; // 1 to 6
+    let offset_val = u.zoom_params.w;
+
+    let aspect = resolution.x / resolution.y;
+
+    // Vector from mouse to pixel
+    var p = uv - mouse;
+    p.x *= aspect;
+
+    // Avoid singularity
+    let r = length(p);
+    if (r < 0.001) {
+        textureStore(writeTexture, global_id.xy, vec4<f32>(0.0, 0.0, 0.0, 1.0));
+        return;
+    }
+
+    let angle = atan2(p.y, p.x);
+
+    // Log-Polar Transformation
+    // u = log(r)
+    // v = angle
+
+    var u_coord = log(r);
+    var v_coord = angle / 6.28318; // 0 to 1 range approx (actually -0.5 to 0.5)
+
+    // Apply twist (shear in log-polar space)
+    v_coord += u_coord * twist * 0.2;
+
+    // Apply zoom (movement along log-r axis)
+    u_coord -= time * zoom_speed;
+
+    // Scale for tiling
+    let uv_mapped = vec2<f32>(u_coord, v_coord * branches);
+
+    // Convert back to wrapping UVs (fract for tiling)
+    var final_uv = fract(uv_mapped);
+
+    // Add center offset distortion to make it look less like a tunnel and more like Droste
+    // This is a stylistic choice to break the perfect symmetry slightly
+    final_uv += vec2<f32>(offset_val * 0.1 * sin(v_coord * 10.0), 0.0);
+    final_uv = fract(final_uv);
+
+    let color = textureSampleLevel(readTexture, u_sampler, final_uv, 0.0);
+
+    textureStore(writeTexture, global_id.xy, color);
+
+    // Preserve depth
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, final_uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(d, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/reactive-glass-grid.wgsl
+++ b/public/shaders/reactive-glass-grid.wgsl
@@ -1,0 +1,99 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=FrameCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=MouseDown
+  zoom_params: vec4<f32>,  // x=Density, y=Refraction, z=Glow, w=EdgeSmooth
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = u.zoom_config.yz;
+    let aspect = resolution.x / resolution.y;
+
+    // Parameters
+    let density = u.zoom_params.x * 50.0 + 5.0; // 5 to 55
+    let refr_strength = u.zoom_params.y * 0.1;
+    let glow_strength = u.zoom_params.z;
+    let edge_smooth = u.zoom_params.w * 0.4 + 0.01;
+
+    // Grid calculations
+    let grid_uv = uv * density;
+    let cell_id = floor(grid_uv);
+    let cell_uv = fract(grid_uv); // 0.0 to 1.0 inside cell
+
+    // Cell center in screen UV space
+    let cell_center = (cell_id + 0.5) / density;
+
+    // Distance from mouse to this cell (using aspect corrected distance)
+    let dist_vec = (cell_center - mouse) * vec2<f32>(aspect, 1.0);
+    let dist_to_mouse = length(dist_vec);
+
+    // Mouse influence falls off with distance
+    let influence = smoothstep(0.5, 0.0, dist_to_mouse);
+
+    // Calculate a pseudo-normal for the glass tile (pillow shape)
+    // 0.5 at center, -0.5 at left/bottom, 0.5 at right/top
+    let local_p = cell_uv - 0.5;
+
+    // Tilt the normal based on mouse position?
+    // Let's just do a simple lens refraction per tile + offset by mouse
+
+    // Displace lookup based on local curvature (glass block effect)
+    var displacement = local_p * refr_strength * (1.0 + influence * 2.0);
+
+    // Add some chromatic aberration near mouse
+    let aberration = influence * refr_strength * 0.5;
+
+    // Sample texture
+    let final_uv = uv - displacement;
+    let r_uv = final_uv + aberration;
+    let b_uv = final_uv - aberration;
+
+    var color = vec4<f32>(
+        textureSampleLevel(readTexture, u_sampler, r_uv, 0.0).r,
+        textureSampleLevel(readTexture, u_sampler, final_uv, 0.0).g,
+        textureSampleLevel(readTexture, u_sampler, b_uv, 0.0).b,
+        1.0
+    );
+
+    // Tile Edges (Grout/Bevel)
+    // Distance from center 0..0.5
+    let d_edge = max(abs(local_p.x), abs(local_p.y)); // Chebyshev distance 0..0.5
+    // Smoothstep for edge darkening
+    let edge_mask = 1.0 - smoothstep(0.5 - edge_smooth, 0.5, d_edge);
+
+    color = color * edge_mask;
+
+    // Add glow/emission based on influence
+    // Use a warm color or the pixel color
+    let glow_color = vec3<f32>(0.2, 0.6, 1.0) * glow_strength * influence;
+
+    // Add glow to the tile edges specifically?
+    let edge_glow = (1.0 - edge_mask) * influence * glow_strength * 2.0;
+
+    color = vec4<f32>(color.rgb + glow_color + edge_glow, 1.0);
+
+    textureStore(writeTexture, global_id.xy, color);
+
+    // Pass depth
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, final_uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(d, 0.0, 0.0, 0.0));
+}

--- a/shader_definitions/interactive-mouse/infinite-spiral-zoom.json
+++ b/shader_definitions/interactive-mouse/infinite-spiral-zoom.json
@@ -1,0 +1,40 @@
+{
+  "id": "infinite-spiral-zoom",
+  "name": "Infinite Spiral Zoom",
+  "url": "shaders/infinite-spiral-zoom.wgsl",
+  "category": "image",
+  "description": "Applies a complex log-polar mapping to create an infinite spiral zoom into the mouse cursor.",
+  "params": [
+    {
+      "id": "zoom_speed",
+      "name": "Zoom Speed",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "spiral_angle",
+      "name": "Spiral Twist",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "branches",
+      "name": "Branches",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "center_offset",
+      "name": "Center Offset",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}

--- a/shader_definitions/interactive-mouse/reactive-glass-grid.json
+++ b/shader_definitions/interactive-mouse/reactive-glass-grid.json
@@ -1,0 +1,40 @@
+{
+  "id": "reactive-glass-grid",
+  "name": "Reactive Glass Grid",
+  "url": "shaders/reactive-glass-grid.wgsl",
+  "category": "image",
+  "description": "A grid of refractive glass tiles that light up and distort based on mouse proximity.",
+  "params": [
+    {
+      "id": "tile_size",
+      "name": "Tile Density",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "refraction",
+      "name": "Refraction",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "glow",
+      "name": "Glow Intensity",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "edge_smooth",
+      "name": "Edge Smoothness",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}


### PR DESCRIPTION
Implemented two new mouse-responsive shaders: Infinite Spiral Zoom and Reactive Glass Grid. Included JSON definitions and registered them in the shader list. Ensured no regressions by restoring accidentally overwritten existing shaders.

---
*PR created automatically by Jules for task [2498226784967063914](https://jules.google.com/task/2498226784967063914) started by @ford442*