### PR TITLE
Add new interactive shaders

### DIFF
--- a/public/shaders/luma-topography.wgsl
+++ b/public/shaders/luma-topography.wgsl
@@ -1,0 +1,102 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=MouseDown
+  zoom_params: vec4<f32>,  // x=Strength, y=Radius, z=Aberration, w=Darkness
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn getLuma(color: vec3<f32>) -> f32 {
+    return dot(color, vec3<f32>(0.299, 0.587, 0.114));
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    let uv = vec2<f32>(global_id.xy) / resolution;
+
+    // Safety check
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    // Parameters
+    let heightScale = u.zoom_params.x * 20.0 + 1.0; // range 1.0 to 21.0
+    let lightIntensity = u.zoom_params.y * 2.0;
+    let shininess = u.zoom_params.z * 32.0 + 1.0;
+    let ambient = u.zoom_params.w;
+
+    let mousePos = u.zoom_config.yz;
+
+    // Aspect ratio correction for vectors
+    let aspect = resolution.x / resolution.y;
+
+    // Sample center
+    let color = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
+    let luma = getLuma(color);
+
+    // Calculate Normal using manual derivatives
+    let texelSize = 1.0 / resolution;
+
+    // Sample neighbors (clamping is handled by texture sampling usually, or we assume safe)
+    let lumaRight = getLuma(textureSampleLevel(readTexture, u_sampler, uv + vec2<f32>(texelSize.x, 0.0), 0.0).rgb);
+    let lumaTop = getLuma(textureSampleLevel(readTexture, u_sampler, uv + vec2<f32>(0.0, texelSize.y), 0.0).rgb);
+
+    let dX = (lumaRight - luma);
+    let dY = (lumaTop - luma);
+
+    // Construct Normal
+    // Slope is (dX, dY). Normal is perpendicular.
+    // If surface is z = f(x,y), normal is (-df/dx, -df/dy, 1) normalized.
+    var normal = normalize(vec3<f32>(-dX * heightScale, -dY * heightScale, 1.0));
+
+    // Lighting
+    // Light position is mousePos with some height Z
+    let lightHeight = 0.2; // Fixed height above surface
+
+    // Vector from pixel to light (correcting for aspect ratio in XY plane)
+    let pixelPos3D = vec3<f32>(uv.x * aspect, uv.y, luma * 0.2); // Elevate pixel slightly based on luma
+    let lightPos3D = vec3<f32>(mousePos.x * aspect, mousePos.y, lightHeight);
+
+    let L = normalize(lightPos3D - pixelPos3D);
+
+    // View vector (assume looking straight down)
+    let V = vec3<f32>(0.0, 0.0, 1.0);
+
+    // Diffuse
+    let diff = max(dot(normal, L), 0.0);
+
+    // Specular (Blinn-Phong)
+    let H = normalize(L + V);
+    let spec = pow(max(dot(normal, H), 0.0), shininess);
+
+    // Attenuation based on distance to mouse
+    let dist = distance(vec2<f32>(uv.x * aspect, uv.y), vec2<f32>(mousePos.x * aspect, mousePos.y));
+    let atten = 1.0 / (1.0 + dist * 5.0);
+
+    let lightColor = vec3<f32>(1.0, 0.95, 0.8); // Warm light
+
+    let finalDiffuse = diff * lightColor * lightIntensity * atten;
+    let finalSpecular = spec * lightColor * lightIntensity * atten;
+
+    // Combine
+    // We modulate the original color by the lighting
+    let litColor = color * (vec3<f32>(ambient) + finalDiffuse) + finalSpecular;
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(litColor, 1.0));
+}

--- a/public/shaders/oscilloscope-overlay.wgsl
+++ b/public/shaders/oscilloscope-overlay.wgsl
@@ -1,0 +1,83 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=MouseDown
+  zoom_params: vec4<f32>,  // x=Strength, y=Radius, z=Aberration, w=Darkness
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn getLuma(color: vec3<f32>) -> f32 {
+    return dot(color, vec3<f32>(0.299, 0.587, 0.114));
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    let uv = vec2<f32>(global_id.xy) / resolution;
+
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    // Params
+    let amplitude = u.zoom_params.x; // 0.0 to 1.0
+    let thickness = max(0.001, u.zoom_params.y * 0.02); // scale thickness
+    let waveOpacity = u.zoom_params.z;
+    let scanLineAlpha = u.zoom_params.w;
+
+    let mousePos = u.zoom_config.yz;
+    let scanY = mousePos.y; // The Y coordinate we are scanning
+
+    // Sample original image
+    let color = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
+
+    // 1. Draw Scan Line (Horizontal line at mousePos.y)
+    let distScan = abs(uv.y - scanY);
+    let scanLine = smoothstep(thickness, 0.0, distScan) * scanLineAlpha;
+    let scanColor = vec3<f32>(1.0, 0.2, 0.2); // Red line for the scanner
+
+    // 2. Draw Waveform
+    // We want to visualize the luminance of the pixels at (x, scanY)
+    // We sample the texture at the current x, but at the scanY height
+    let scanSample = textureSampleLevel(readTexture, u_sampler, vec2<f32>(uv.x, scanY), 0.0).rgb;
+    let scanLuma = getLuma(scanSample);
+
+    // Map luminance to Y position (centered at 0.5)
+    let waveY = 0.5 + (scanLuma - 0.5) * amplitude;
+
+    let distWave = abs(uv.y - waveY);
+    let waveVal = smoothstep(thickness, 0.0, distWave);
+
+    let waveColor = vec3<f32>(0.2, 1.0, 0.5); // Green phosphor color
+
+    // Composite
+    var finalColor = color;
+
+    // Add Scan Line
+    finalColor = mix(finalColor, scanColor, scanLine);
+
+    // Add Waveform
+    // Additive blending for "glowing" look
+    finalColor = finalColor + waveColor * waveVal * waveOpacity;
+
+    // Add faint grid?
+    // let gridY = abs(uv.y - 0.5) < 0.002 ? 0.2 : 0.0;
+    // finalColor += vec3<f32>(gridY);
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(finalColor, 1.0));
+}

--- a/shader_definitions/interactive-mouse/luma-topography.json
+++ b/shader_definitions/interactive-mouse/luma-topography.json
@@ -1,0 +1,41 @@
+{
+  "id": "luma-topography",
+  "name": "Luma Topography",
+  "url": "shaders/luma-topography.wgsl",
+  "category": "image",
+  "description": "Visualizes the image as a 3D terrain map where brightness determines height. The mouse controls a dynamic light source.",
+  "params": [
+    {
+      "id": "height",
+      "name": "Relief Height",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "intensity",
+      "name": "Light Intensity",
+      "default": 0.8,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "shininess",
+      "name": "Shininess",
+      "default": 0.4,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "ambient",
+      "name": "Ambient Light",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "lighting"
+  ]
+}

--- a/shader_definitions/interactive-mouse/oscilloscope-overlay.json
+++ b/shader_definitions/interactive-mouse/oscilloscope-overlay.json
@@ -1,0 +1,41 @@
+{
+  "id": "oscilloscope-overlay",
+  "name": "Oscilloscope Overlay",
+  "url": "shaders/oscilloscope-overlay.wgsl",
+  "category": "image",
+  "description": "Overlays a real-time luminance waveform of the image scanline at the mouse cursor's vertical position.",
+  "params": [
+    {
+      "id": "amplitude",
+      "name": "Amplitude",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "thickness",
+      "name": "Line Thickness",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "opacity",
+      "name": "Wave Opacity",
+      "default": 0.8,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "scan_alpha",
+      "name": "Scanline Alpha",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "overlay"
+  ]
+}


### PR DESCRIPTION
Added two new mouse-responsive shaders: Luma Topography (3D terrain lighting) and Oscilloscope Overlay (luminance waveform). Registered them via the generation script.

---
*PR created automatically by Jules for task [13351032460794374588](https://jules.google.com/task/13351032460794374588) started by @ford442*