### PR TITLE
Add 4 New Interactive Mouse Shaders

### DIFF
--- a/public/shaders/lighthouse-reveal.wgsl
+++ b/public/shaders/lighthouse-reveal.wgsl
@@ -1,0 +1,82 @@
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Lighthouse Reveal
+// Param 1: Beam Length (Radius)
+// Param 2: Beam Width (Angle)
+// Param 3: Edge Softness
+// Param 4: Ambient Light
+
+fn get_mouse() -> vec2<f32> {
+    var mouse = u.zoom_config.yz;
+    if (mouse.x < 0.0) { return vec2<f32>(0.5, 0.5); }
+    return mouse;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+
+    // Correct UV for aspect ratio for distance calculations
+    let uv_aspect = vec2<f32>(uv.x * aspect, uv.y);
+    let mouse = get_mouse();
+    let mouse_aspect = vec2<f32>(mouse.x * aspect, mouse.y);
+
+    let radius = u.zoom_params.x;
+    let beam_width = u.zoom_params.y; // 0.05 to 1.0 (roughly radians / PI)
+    let softness = u.zoom_params.z;
+    let ambient = u.zoom_params.w;
+    let time = u.config.x;
+
+    let dist = distance(uv_aspect, mouse_aspect);
+    let angle = atan2(uv_aspect.y - mouse_aspect.y, uv_aspect.x - mouse_aspect.x);
+
+    // Rotation speed
+    let rotation = time * 2.0;
+
+    // Normalize angle difference to -PI to PI
+    var angle_diff = angle - rotation;
+    let pi = 3.14159265;
+    angle_diff = (fract((angle_diff / (2.0 * pi)) + 0.5) - 0.5) * 2.0 * pi;
+
+    // Calculate Beam Mask
+    // Angular falloff
+    let angle_dist = abs(angle_diff);
+    let angle_mask = 1.0 - smoothstep(beam_width * pi * 0.5, (beam_width * pi * 0.5) + softness + 0.01, angle_dist);
+
+    // Radial falloff
+    let radial_mask = 1.0 - smoothstep(radius, radius + softness + 0.01, dist);
+
+    // Combined mask
+    let mask = angle_mask * radial_mask;
+
+    // Apply lighting
+    let texColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    let finalColor = mix(texColor.rgb * ambient, texColor.rgb, mask);
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(finalColor, 1.0));
+}

--- a/public/shaders/pixel-stretch-cross.wgsl
+++ b/public/shaders/pixel-stretch-cross.wgsl
@@ -1,0 +1,86 @@
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Pixel Stretch Cross
+// Param 1: Stretch Width
+// Param 2: Decay
+// Param 3: Mix Strength
+// Param 4: Opacity
+
+fn get_mouse() -> vec2<f32> {
+    var mouse = u.zoom_config.yz;
+    if (mouse.x < 0.0) { return vec2<f32>(0.5, 0.5); }
+    return mouse;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = get_mouse();
+
+    let stretch_width = u.zoom_params.x;
+    let decay = u.zoom_params.y * 10.0;
+    let mix_strength = u.zoom_params.z;
+    let opacity = u.zoom_params.w;
+
+    var finalColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+
+    // Stretch Horizontal (sample from mouse.x)
+    let dist_x = abs(uv.x - mouse.x);
+    if (abs(uv.y - mouse.y) < stretch_width) {
+        // We are in the horizontal bar
+        // We want to smear the pixel at mouse.x outwards
+        let smear_uv = vec2<f32>(mouse.x, uv.y);
+        let smear_col = textureSampleLevel(readTexture, u_sampler, smear_uv, 0.0);
+
+        // Distance from center of cross
+        let d = abs(uv.x - mouse.x);
+        let factor = exp(-d * decay);
+
+        finalColor = mix(finalColor, smear_col, factor * mix_strength);
+    }
+
+    // Stretch Vertical (sample from mouse.y)
+    let dist_y = abs(uv.y - mouse.y);
+    if (abs(uv.x - mouse.x) < stretch_width) {
+        // We are in the vertical bar
+        let smear_uv = vec2<f32>(uv.x, mouse.y);
+        let smear_col = textureSampleLevel(readTexture, u_sampler, smear_uv, 0.0);
+
+        let d = abs(uv.y - mouse.y);
+        let factor = exp(-d * decay);
+
+        // Additive or Max? Let's use mix.
+        // If we are near center, we might have already mixed horizontal.
+        // Let's take the max of the factors?
+        finalColor = mix(finalColor, smear_col, factor * mix_strength);
+    }
+
+    // Global Opacity
+    finalColor = mix(textureSampleLevel(readTexture, u_sampler, uv, 0.0), finalColor, opacity);
+
+    textureStore(writeTexture, global_id.xy, finalColor);
+}

--- a/public/shaders/polar-warp-interactive.wgsl
+++ b/public/shaders/polar-warp-interactive.wgsl
@@ -1,0 +1,97 @@
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Polar Warp Interactive
+// Param 1: Zoom
+// Param 2: Spiral Twist
+// Param 3: Repeats
+// Param 4: Radial Offset
+
+fn get_mouse() -> vec2<f32> {
+    var mouse = u.zoom_config.yz;
+    if (mouse.x < 0.0) { return vec2<f32>(0.5, 0.5); }
+    return mouse;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let mouse = get_mouse();
+
+    // Center coordinates on mouse
+    // Adjust for aspect to keep circular symmetry
+    var diff = uv - mouse;
+    diff.x *= aspect;
+
+    // To Polar
+    var radius = length(diff);
+    var angle = atan2(diff.y, diff.x);
+
+    let zoom = 0.1 + u.zoom_params.x * 2.0; // Avoid division by zero
+    let spiral = u.zoom_params.y * 5.0;
+    let repeats = max(1.0, u.zoom_params.z);
+    let offset = u.zoom_params.w;
+
+    // Distort Polar
+    // New Radius mapping
+    var r_new = pow(radius, 1.0/zoom);
+    r_new = r_new - offset;
+
+    // Spiral: add angle based on radius
+    angle = angle + (radius * spiral);
+
+    // Repeat texture radially
+    // We map polar (r, theta) back to Cartesian (u, v) for texture lookup?
+    // Actually, "Polar Warp" usually means mapping the image *as if* it were polar.
+    // Standard effect: UV.x = angle, UV.y = radius
+    // Let's implement the tunnel effect:
+
+    let tunnel_u = (angle / 3.14159265) * repeats + u.config.x * 0.1; // Rotate over time
+    let tunnel_v = 1.0 / (r_new + 0.001); // Perspective
+
+    // Let's try a different approach: Coordinate Remapping
+    // Map (r, theta) back to (x, y) but distorted.
+
+    let distorted_uv = vec2<f32>(
+        tunnel_u,
+        tunnel_v
+    );
+
+    // Wrap UVs
+    let final_uv = fract(distorted_uv);
+
+    // Use mirrored repeat for smoother edges
+    let mirror_uv = abs(final_uv * 2.0 - 1.0); // 0..1..0 triangle wave
+    // Actually fract is fine for tunnel.
+
+    let col = textureSampleLevel(readTexture, u_sampler, final_uv, 0.0);
+
+    // Fade out center singularity
+    let fade = smoothstep(0.0, 0.1, radius);
+
+    textureStore(writeTexture, global_id.xy, col * fade);
+}

--- a/public/shaders/split-dimension.wgsl
+++ b/public/shaders/split-dimension.wgsl
@@ -1,0 +1,112 @@
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Split Dimension
+// Param 1: Glitch Intensity
+// Param 2: Color Shift
+// Param 3: Negative Strength
+// Param 4: Split Angle
+
+fn get_mouse() -> vec2<f32> {
+    var mouse = u.zoom_config.yz;
+    if (mouse.x < 0.0) { return vec2<f32>(0.5, 0.5); }
+    return mouse;
+}
+
+fn hash(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(12.9898, 78.233))) * 43758.5453);
+}
+
+fn noise(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let u = f * f * (3.0 - 2.0 * f);
+    return mix(mix(hash(i + vec2<f32>(0.0, 0.0)), hash(i + vec2<f32>(1.0, 0.0)), u.x),
+               mix(hash(i + vec2<f32>(0.0, 1.0)), hash(i + vec2<f32>(1.0, 1.0)), u.x), u.y);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let mouse = get_mouse();
+
+    let glitch_amt = u.zoom_params.x;
+    let color_shift = u.zoom_params.y;
+    let neg_str = u.zoom_params.z;
+    let angle_param = u.zoom_params.w; // -1 to 1
+
+    let time = u.config.x;
+
+    // Calculate Split Line
+    // Use dot product with normal vector
+    // angle 0 = vertical split (normal = 1,0)
+    let angle = angle_param * 3.14159 * 0.5; // -90 to 90 deg
+    let normal = vec2<f32>(cos(angle), sin(angle));
+
+    // Point on line: mouse
+    // Distance from line = dot(uv - mouse, normal)
+    // Adjust aspect for correct visual angle
+    let p_vec = vec2<f32>((uv.x - mouse.x) * aspect, uv.y - mouse.y);
+    let d = dot(p_vec, normal);
+
+    var finalColor = vec4<f32>(0.0);
+
+    if (d < 0.0) {
+        // Dimension A: Normal
+        finalColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    } else {
+        // Dimension B: Glitched / Negative
+
+        // Glitch Offset
+        var glitch_uv = uv;
+        if (glitch_amt > 0.0) {
+            let n = noise(vec2<f32>(uv.y * 50.0, time * 20.0)); // Horizontal strips
+            if (n > 0.8) {
+                glitch_uv.x += (n - 0.5) * glitch_amt * 0.2;
+            }
+        }
+
+        // RGB Split
+        var col = vec3<f32>(0.0);
+        let shift = color_shift * 0.05;
+        col.r = textureSampleLevel(readTexture, u_sampler, glitch_uv + vec2<f32>(shift, 0.0), 0.0).r;
+        col.g = textureSampleLevel(readTexture, u_sampler, glitch_uv, 0.0).g;
+        col.b = textureSampleLevel(readTexture, u_sampler, glitch_uv - vec2<f32>(shift, 0.0), 0.0).b;
+
+        // Negative
+        col = mix(col, 1.0 - col, neg_str);
+
+        finalColor = vec4<f32>(col, 1.0);
+
+        // Add split line highlight
+        if (d < 0.01) {
+            finalColor += vec4<f32>(0.5, 0.5, 0.5, 0.0);
+        }
+    }
+
+    textureStore(writeTexture, global_id.xy, finalColor);
+}

--- a/shader_definitions/interactive-mouse/lighthouse-reveal.json
+++ b/shader_definitions/interactive-mouse/lighthouse-reveal.json
@@ -1,0 +1,38 @@
+{
+  "id": "lighthouse-reveal",
+  "name": "Lighthouse Reveal",
+  "url": "shaders/lighthouse-reveal.wgsl",
+  "category": "image",
+  "description": "A rotating beam of light that reveals the image, emanating from the mouse position.",
+  "features": ["mouse-driven"],
+  "params": [
+    {
+      "id": "radius",
+      "name": "Beam Length",
+      "default": 0.8,
+      "min": 0.0,
+      "max": 1.5
+    },
+    {
+      "id": "width",
+      "name": "Beam Width",
+      "default": 0.2,
+      "min": 0.05,
+      "max": 1.0
+    },
+    {
+      "id": "softness",
+      "name": "Edge Softness",
+      "default": 0.1,
+      "min": 0.0,
+      "max": 0.5
+    },
+    {
+      "id": "ambient",
+      "name": "Ambient Light",
+      "default": 0.1,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ]
+}

--- a/shader_definitions/interactive-mouse/pixel-stretch-cross.json
+++ b/shader_definitions/interactive-mouse/pixel-stretch-cross.json
@@ -1,0 +1,38 @@
+{
+  "id": "pixel-stretch-cross",
+  "name": "Pixel Stretch Cross",
+  "url": "shaders/pixel-stretch-cross.wgsl",
+  "category": "image",
+  "description": "Stretches pixels from the mouse position to the screen edges in a cross pattern.",
+  "features": ["mouse-driven"],
+  "params": [
+    {
+      "id": "width",
+      "name": "Stretch Width",
+      "default": 0.05,
+      "min": 0.0,
+      "max": 0.2
+    },
+    {
+      "id": "decay",
+      "name": "Decay",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "mix_strength",
+      "name": "Mix Strength",
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "opacity",
+      "name": "Opacity",
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ]
+}

--- a/shader_definitions/interactive-mouse/polar-warp-interactive.json
+++ b/shader_definitions/interactive-mouse/polar-warp-interactive.json
@@ -1,0 +1,38 @@
+{
+  "id": "polar-warp-interactive",
+  "name": "Polar Warp",
+  "url": "shaders/polar-warp-interactive.wgsl",
+  "category": "image",
+  "description": "Maps the image to polar coordinates centered on the mouse, creating a tunnel or funhouse mirror effect.",
+  "features": ["mouse-driven"],
+  "params": [
+    {
+      "id": "zoom",
+      "name": "Zoom",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "spiral",
+      "name": "Spiral Twist",
+      "default": 0.0,
+      "min": -1.0,
+      "max": 1.0
+    },
+    {
+      "id": "repeats",
+      "name": "Repeats",
+      "default": 1.0,
+      "min": 1.0,
+      "max": 5.0
+    },
+    {
+      "id": "offset",
+      "name": "Radial Offset",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ]
+}

--- a/shader_definitions/interactive-mouse/split-dimension.json
+++ b/shader_definitions/interactive-mouse/split-dimension.json
@@ -1,0 +1,38 @@
+{
+  "id": "split-dimension",
+  "name": "Split Dimension",
+  "url": "shaders/split-dimension.wgsl",
+  "category": "image",
+  "description": "Splits the screen into two dimensions. One side is normal, the other is a glitched negative. The split follows the mouse.",
+  "features": ["mouse-driven", "glitch"],
+  "params": [
+    {
+      "id": "glitch",
+      "name": "Glitch Intensity",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "shift",
+      "name": "Color Shift",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "negative",
+      "name": "Negative Str",
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "angle",
+      "name": "Split Angle",
+      "default": 0.0,
+      "min": -1.0,
+      "max": 1.0
+    }
+  ]
+}


### PR DESCRIPTION
Added 4 new mouse-responsive shaders:
1. Lighthouse Reveal: Rotating light beam.
2. Polar Warp: Tunnel/Funhouse mirror effect.
3. Pixel Stretch Cross: Slit-scan like stretching at mouse crosshair.
4. Split Dimension: Split screen with glitch/negative effect.

---
*PR created automatically by Jules for task [9087950852826808518](https://jules.google.com/task/9087950852826808518) started by @ford442*