### PR TITLE
Add two new mouse-responsive shaders

### DIFF
--- a/public/shaders/psychedelic-noise-flow.wgsl
+++ b/public/shaders/psychedelic-noise-flow.wgsl
@@ -1,0 +1,95 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Simple pseudo-random hash
+fn hash2(p: vec2<f32>) -> vec2<f32> {
+    var p2 = vec2<f32>(dot(p, vec2<f32>(127.1, 311.7)), dot(p, vec2<f32>(269.5, 183.3)));
+    return -1.0 + 2.0 * fract(sin(p2) * 43758.5453123);
+}
+
+// 2D Noise
+fn noise(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let u = f * f * (3.0 - 2.0 * f);
+
+    return mix(mix(dot(hash2(i + vec2<f32>(0.0, 0.0)), f - vec2<f32>(0.0, 0.0)),
+                   dot(hash2(i + vec2<f32>(1.0, 0.0)), f - vec2<f32>(1.0, 0.0)), u.x),
+               mix(dot(hash2(i + vec2<f32>(0.0, 1.0)), f - vec2<f32>(0.0, 1.0)),
+                   dot(hash2(i + vec2<f32>(1.0, 1.0)), f - vec2<f32>(1.0, 1.0)), u.x), u.y);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+
+    // Params
+    let speed_param = u.zoom_params.x;     // Flow Speed
+    let scale_param = u.zoom_params.y;     // Noise Scale
+    let distort_param = u.zoom_params.z;   // Distortion Strength
+    let color_shift = u.zoom_params.w;     // Color Separation
+
+    let time = u.config.x * (speed_param * 2.0 + 0.1);
+    let noise_scale = scale_param * 8.0 + 1.0;
+    let strength = distort_param * 0.1;
+
+    let mouse = u.zoom_config.yz;
+    let mouse_dist = length((uv - mouse) * vec2<f32>(aspect, 1.0));
+
+    // Mouse influence: add extra flow speed/direction near mouse
+    let mouse_dir = normalize(uv - mouse + vec2<f32>(0.001));
+    let mouse_influence = smoothstep(0.4, 0.0, mouse_dist);
+
+    // Three distinct noise samples for R, G, B
+    // We offset the noise coordinate by time and by channel
+
+    // Red Channel Noise
+    let n_r = noise(uv * noise_scale + vec2<f32>(time, time * 0.5) - mouse_influence * mouse_dir);
+    // Green Channel Noise (Different phase)
+    let n_g = noise(uv * noise_scale + vec2<f32>(time + 10.0, time * 0.6 + 10.0) + mouse_influence * mouse_dir * 0.5);
+    // Blue Channel Noise (Different phase)
+    let n_b = noise(uv * noise_scale + vec2<f32>(time + 20.0, time * 0.7 + 20.0));
+
+    // Calculate displacement vectors
+    let d_r = vec2<f32>(n_r, noise(uv * noise_scale + vec2<f32>(n_r, time))) * strength;
+    let d_g = vec2<f32>(n_g, noise(uv * noise_scale + vec2<f32>(n_g, time + 5.0))) * strength;
+    let d_b = vec2<f32>(n_b, noise(uv * noise_scale + vec2<f32>(n_b, time + 10.0))) * strength;
+
+    // Apply color separation based on parameter
+    // If param is 0, displacements are similar. If 1, they diverge.
+    let final_d_r = d_r;
+    let final_d_g = mix(d_r, d_g, color_shift);
+    let final_d_b = mix(d_r, d_b, color_shift);
+
+    // Sample Texture
+    let r = textureSampleLevel(readTexture, u_sampler, uv + final_d_r, 0.0).r;
+    let g = textureSampleLevel(readTexture, u_sampler, uv + final_d_g, 0.0).g;
+    let b = textureSampleLevel(readTexture, u_sampler, uv + final_d_b, 0.0).b;
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(r, g, b, 1.0));
+}

--- a/public/shaders/vertical-slice-wave.wgsl
+++ b/public/shaders/vertical-slice-wave.wgsl
@@ -1,0 +1,81 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash12(p: vec2<f32>) -> f32 {
+	var p3  = fract(vec3<f32>(p.xyx) * .1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+
+    // Params
+    let strips_param = u.zoom_params.x;    // Strip Count
+    let speed_param = u.zoom_params.y;     // Base Speed
+    let rgb_split = u.zoom_params.z;       // RGB Split
+    let jitter_amt = u.zoom_params.w;      // Jitter
+
+    let time = u.config.x;
+
+    // Mouse Interaction
+    let mouse = u.zoom_config.yz;
+    // Mouse X maps to Frequency (0.0 to 1.0 -> 1.0 to 50.0)
+    let freq_mod = mouse.x * 40.0 + 1.0;
+    // Mouse Y maps to Amplitude (0.0 to 1.0 -> 0.0 to 0.5)
+    let amp_mod = mouse.y * 0.2;
+
+    let num_strips = floor(strips_param * 100.0) + 5.0; // Min 5 strips
+    let strip_id = floor(uv.x * num_strips);
+    let strip_uv_x = strip_id / num_strips; // Normalized x of the strip
+
+    // Base wave
+    let wave_speed = speed_param * 5.0;
+    let wave_phase = strip_uv_x * freq_mod + time * wave_speed;
+    var offset = sin(wave_phase) * amp_mod;
+
+    // Jitter (flicker noise)
+    let noise_val = hash12(vec2<f32>(strip_id, floor(time * 10.0))); // Random per strip per 0.1s
+    offset = offset + (noise_val - 0.5) * jitter_amt * 0.2;
+
+    // RGB Split
+    let split_factor = rgb_split * 0.05; // Max split 0.05 UV space
+
+    let r_offset = offset - split_factor;
+    let g_offset = offset;
+    let b_offset = offset + split_factor;
+
+    // Sample
+    // We only offset Y
+    let r = textureSampleLevel(readTexture, u_sampler, vec2<f32>(uv.x, uv.y + r_offset), 0.0).r;
+    let g = textureSampleLevel(readTexture, u_sampler, vec2<f32>(uv.x, uv.y + g_offset), 0.0).g;
+    let b = textureSampleLevel(readTexture, u_sampler, vec2<f32>(uv.x, uv.y + b_offset), 0.0).b;
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(r, g, b, 1.0));
+}

--- a/shader_definitions/interactive-mouse/psychedelic-noise-flow.json
+++ b/shader_definitions/interactive-mouse/psychedelic-noise-flow.json
@@ -1,0 +1,40 @@
+{
+  "id": "psychedelic-noise-flow",
+  "name": "Psychedelic Noise Flow",
+  "url": "shaders/psychedelic-noise-flow.wgsl",
+  "category": "interactive-mouse",
+  "description": "Applies a liquid-like noise flow where RGB channels are separated by phase, creating colorful swirls. Mouse controls flow speed and direction.",
+  "params": [
+    {
+      "id": "speed",
+      "name": "Flow Speed",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "scale",
+      "name": "Noise Scale",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "distortion",
+      "name": "Distortion",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "separation",
+      "name": "Color Shift",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}

--- a/shader_definitions/interactive-mouse/vertical-slice-wave.json
+++ b/shader_definitions/interactive-mouse/vertical-slice-wave.json
@@ -1,0 +1,40 @@
+{
+  "id": "vertical-slice-wave",
+  "name": "Vertical Slice Wave",
+  "url": "shaders/vertical-slice-wave.wgsl",
+  "category": "interactive-mouse",
+  "description": "Splits the image into vertical strips that oscillate. Mouse X controls frequency, Mouse Y controls amplitude.",
+  "params": [
+    {
+      "id": "strips",
+      "name": "Strip Count",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "speed",
+      "name": "Wave Speed",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "split",
+      "name": "RGB Split",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "jitter",
+      "name": "Jitter",
+      "default": 0.1,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}


### PR DESCRIPTION
Implemented two new interactive mouse shaders:
1. **Psychedelic Noise Flow**: Uses Simplex noise to create a flowing, liquid-like distortion where RGB channels are offset by noise with different phases. Mouse controls flow speed and direction.
2. **Vertical Slice Wave**: Divides the image into vertical strips that oscillate vertically based on a sine wave. Mouse X controls frequency, Mouse Y controls amplitude.

Both shaders are categorized under `interactive-mouse` and include full parameter controls.

---
*PR created automatically by Jules for task [5365962426102146498](https://jules.google.com/task/5365962426102146498) started by @ford442*