### PR TITLE
Add 4 new interactive shaders

### DIFF
--- a/public/shaders/crystal-facets.wgsl
+++ b/public/shaders/crystal-facets.wgsl
@@ -1,0 +1,119 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash11(p: f32) -> f32 {
+    var p2 = fract(p * .1031);
+    p2 *= p2 + 33.33;
+    p2 *= p2 + p2;
+    return fract(p2);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let mouse = u.zoom_config.yz;
+
+    // Params
+    // x: Facet Count (e.g. 3 to 12)
+    // y: Refraction Strength
+    // z: Rotation Speed / Offset
+    // w: Center Zoom / Size
+
+    let facetCount = floor(mix(3.0, 16.0, u.zoom_params.x));
+    let refraction = u.zoom_params.y * 0.1;
+    let rotation = u.zoom_params.z * 6.28 + u.config.x * 0.1; // Base rotation + time
+    let zoom = mix(1.0, 0.5, u.zoom_params.w);
+
+    // Coordinate relative to mouse/center
+    // Use mouse as the "cut" center
+    let center = mouse;
+    var dir = (uv - center);
+    dir.x *= aspect;
+
+    let dist = length(dir);
+    var angle = atan2(dir.y, dir.x);
+
+    // Apply rotation
+    angle += rotation;
+
+    // Quantize angle to create facets
+    let sector = floor(angle / (6.28318 / facetCount));
+    let sectorAngle = sector * (6.28318 / facetCount);
+
+    // Each facet has a random tilt/offset based on its ID (sector)
+    let facetID = sector;
+    let randomTilt = (hash11(facetID) - 0.5) * 2.0; // -1 to 1
+
+    // New UV calculation
+    // We want to sample the texture as if looking through a prism face.
+    // The face might be tilted, causing a shift.
+    // The shift depends on the facet ID.
+
+    // Offset vector for this facet
+    let offsetDir = vec2<f32>(cos(sectorAngle), sin(sectorAngle));
+
+    // Chromatic aberration: different offsets for R, G, B
+    let rOffset = offsetDir * refraction * (1.0 + randomTilt * 0.5);
+    let gOffset = offsetDir * refraction * 0.5; // Less shift
+    let bOffset = offsetDir * refraction * (0.0 - randomTilt * 0.5);
+
+    // Zoom effect per facet
+    // Sample closer to center based on zoom
+    // We modify the distance
+    let distDistorted = pow(dist, zoom); // Bulge or pinch
+
+    // Reconstruct coordinate
+    // Rotate back? Or just use the original angle but quantized?
+    // Let's use the original angle for continuity within the facet, but shifted
+
+    // Actually, "Facet" means the image is discontinuous at boundaries.
+    // So we should sample based on the sector center angle + local UV?
+    // Or just distort the global UV.
+
+    let baseUV = center + vec2<f32>(cos(angle - rotation), sin(angle - rotation)) * distDistorted / vec2<f32>(aspect, 1.0);
+
+    // Sample
+    let r = textureSampleLevel(readTexture, u_sampler, baseUV - rOffset, 0.0).r;
+    let g = textureSampleLevel(readTexture, u_sampler, baseUV - gOffset, 0.0).g;
+    let b = textureSampleLevel(readTexture, u_sampler, baseUV - bOffset, 0.0).b;
+
+    // Add facet edges (lines)
+    // Distance to nearest sector boundary
+    let angleLocal = fract(angle / (6.28318 / facetCount)); // 0 to 1
+    let edge = min(angleLocal, 1.0 - angleLocal);
+    let edgeStrength = smoothstep(0.02, 0.0, edge);
+
+    var color = vec3<f32>(r, g, b);
+
+    // Add shine to edges
+    color += vec3<f32>(edgeStrength * 0.5);
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(color, 1.0));
+
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/rgb-topology.wgsl
+++ b/public/shaders/rgb-topology.wgsl
@@ -1,0 +1,94 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let mouse = u.zoom_config.yz;
+
+    // Params
+    let density = mix(10.0, 100.0, u.zoom_params.x);
+    let parallax = u.zoom_params.y * 0.1;
+    let lineThickness = u.zoom_params.z * 0.2 + 0.05;
+    let glow = u.zoom_params.w;
+
+    // Parallax logic
+    // Mouse determines view angle
+    // Mouse center (0.5, 0.5) is neutral
+    let tilt = (mouse - vec2<f32>(0.5)) * vec2<f32>(aspect, 1.0) * parallax;
+
+    // We sample R, G, B at different offsets to simulate depth layering
+    // Let R be top (closest), G middle, B bottom (furthest)
+    // Or R, G, B as layers.
+
+    // Offsets
+    let offsetR = tilt * 1.0;
+    let offsetG = tilt * 0.5;
+    let offsetB = tilt * 0.0; // Base layer
+
+    // Sample
+    // We want the contour of Red at uv+offsetR
+    // But wait, if we look from an angle, the red layer should be shifted relative to where we are?
+    // Let's just shift the UV lookup.
+
+    let rVal = textureSampleLevel(readTexture, u_sampler, uv + offsetR, 0.0).r;
+    let gVal = textureSampleLevel(readTexture, u_sampler, uv + offsetG, 0.0).g;
+    let bVal = textureSampleLevel(readTexture, u_sampler, uv + offsetB, 0.0).b;
+
+    // Generate contours
+    // sin(val * density)
+
+    // Function to get line strength
+    // abs(sin(val * density)) < thickness -> line
+    let rLine = smoothstep(lineThickness, 0.0, abs(sin(rVal * density + u.config.x)));
+    let gLine = smoothstep(lineThickness, 0.0, abs(sin(gVal * density + u.config.x * 1.1))); // slightly different phase
+    let bLine = smoothstep(lineThickness, 0.0, abs(sin(bVal * density + u.config.x * 0.9)));
+
+    // Composite
+    // Additive blending of lines
+    var finalColor = vec3<f32>(0.0);
+
+    finalColor += vec3<f32>(rLine, 0.0, 0.0);
+    finalColor += vec3<f32>(0.0, gLine, 0.0);
+    finalColor += vec3<f32>(0.0, 0.0, bLine);
+
+    // Add glow
+    // Glow is based on the value itself
+    if (glow > 0.0) {
+        finalColor += vec3<f32>(rVal, 0.0, 0.0) * glow * 0.5;
+        finalColor += vec3<f32>(0.0, gVal, 0.0) * glow * 0.5;
+        finalColor += vec3<f32>(0.0, 0.0, bVal) * glow * 0.5;
+    }
+
+    // Background dimming
+    finalColor += vec3<f32>(0.05); // Dark background
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(finalColor, 1.0));
+
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/scanline-drift.wgsl
+++ b/public/shaders/scanline-drift.wgsl
@@ -1,0 +1,96 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash11(p: f32) -> f32 {
+    var p2 = fract(p * .1031);
+    p2 *= p2 + 33.33;
+    p2 *= p2 + p2;
+    return fract(p2);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let time = u.config.x;
+    let mouse = u.zoom_config.yz;
+
+    // Params
+    let driftSpeed = u.zoom_params.x * 2.0;
+    let lineHeight = mix(0.001, 0.1, u.zoom_params.y); // Height of the scanline strip
+    let jitter = u.zoom_params.z * 0.1;
+    let colorShift = u.zoom_params.w * 0.05;
+
+    // Determine which horizontal strip we are in
+    let stripId = floor(uv.y / lineHeight);
+
+    // Each strip drifts independently based on time and its ID
+    let stripRand = hash11(stripId);
+
+    // Mouse Interaction:
+    // Mouse Y selects a "bad" zone with more drift?
+    // Or mouse proximity increases jitter.
+    let distY = abs(uv.y - mouse.y);
+    let mouseEffect = smoothstep(0.2, 0.0, distY); // Stronger near mouse Y
+
+    // Calculate horizontal offset
+    // Sine wave movement + random jitter
+    var offset = sin(time * driftSpeed + stripRand * 6.28) * jitter;
+
+    // Add mouse influence
+    offset += (hash11(stripId + time) - 0.5) * mouseEffect * jitter * 2.0;
+
+    // Color separation (drift R, G, B differently)
+    let rOffset = offset + colorShift;
+    let gOffset = offset;
+    let bOffset = offset - colorShift;
+
+    // Sample with wrap around or clamp?
+    // Usually glitch effects wrap.
+    let rUV = vec2<f32>(fract(uv.x + rOffset), uv.y);
+    let gUV = vec2<f32>(fract(uv.x + gOffset), uv.y);
+    let bUV = vec2<f32>(fract(uv.x + bOffset), uv.y);
+
+    let r = textureSampleLevel(readTexture, u_sampler, rUV, 0.0).r;
+    let g = textureSampleLevel(readTexture, u_sampler, gUV, 0.0).g;
+    let b = textureSampleLevel(readTexture, u_sampler, bUV, 0.0).b;
+
+    // Scanline darkness (optional)
+    // Make boundaries between strips dark
+    let stripUVy = fract(uv.y / lineHeight);
+    let lineDark = smoothstep(0.0, 0.1, stripUVy) * smoothstep(1.0, 0.9, stripUVy);
+    // Actually standard scanline look is better:
+    // let scanline = sin(uv.y * resolution.y * 0.5) * 0.1;
+
+    var color = vec3<f32>(r, g, b);
+
+    // Apply line separation darkness
+    color *= mix(0.8, 1.0, lineDark);
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(color, 1.0));
+
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/steamy-glass.wgsl
+++ b/public/shaders/steamy-glass.wgsl
@@ -1,0 +1,104 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Feedback buffer for fog
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>; // Previous frame of dataTextureA
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash12(p: vec2<f32>) -> f32 {
+	var p3  = fract(vec3<f32>(p.xyx) * .1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let mouse = u.zoom_config.yz;
+
+    // Params
+    let fogDensity = u.zoom_params.x;
+    let fadeSpeed = u.zoom_params.y * 0.05; // Slow fade back
+    let wipeRadius = u.zoom_params.z * 0.3 + 0.05;
+    let blurAmount = u.zoom_params.w;
+
+    // Read previous fog state (from dataTextureC which should be the readable version of previous frame A)
+    // Note: dataTextureC corresponds to previous frame's dataTextureA in the pipeline usually.
+    // If not, we might need to check how feedback works. Assuming dataTextureC is the read texture for feedback.
+
+    // Sample previous fog value. 1.0 = full fog, 0.0 = clear.
+    let prevFog = textureSampleLevel(dataTextureC, non_filtering_sampler, uv, 0.0).r;
+
+    // Calculate new fog value
+    // Fog naturally increases (returns)
+    var newFog = min(prevFog + fadeSpeed * 0.1, 1.0);
+    // Or just fade towards 1.0?
+    // Let's create noise for the fog pattern
+    let fogNoise = hash12(uv * 50.0 + u.config.x * 0.01);
+
+    // Wipe logic
+    let distVec = (uv - mouse) * vec2<f32>(aspect, 1.0);
+    let dist = length(distVec);
+
+    // If close to mouse, clear the fog
+    // Smoothstep for soft edge brush
+    let wipe = smoothstep(wipeRadius, wipeRadius - 0.1, dist);
+
+    // Apply wipe (subtract from fog)
+    // If we wipe, fog goes to 0.0
+    newFog = max(0.0, newFog - wipe);
+
+    // Write new fog state to feedback buffer
+    textureStore(dataTextureA, global_id.xy, vec4<f32>(newFog, 0.0, 0.0, 1.0));
+
+    // Render Logic
+    // Sample clear image
+    let clearColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
+
+    // Sample blurred image (fake blur by sampling mipmap or offset)
+    // Simple blur: average 4 neighbors
+    let offset = blurAmount * 0.01;
+    var blurColor = vec3<f32>(0.0);
+    blurColor += textureSampleLevel(readTexture, u_sampler, uv + vec2<f32>(offset, 0.0), 0.0).rgb;
+    blurColor += textureSampleLevel(readTexture, u_sampler, uv - vec2<f32>(offset, 0.0), 0.0).rgb;
+    blurColor += textureSampleLevel(readTexture, u_sampler, uv + vec2<f32>(0.0, offset), 0.0).rgb;
+    blurColor += textureSampleLevel(readTexture, u_sampler, uv - vec2<f32>(0.0, offset), 0.0).rgb;
+    blurColor *= 0.25;
+
+    // Mix based on fog
+    // Fog makes it blurry and whiter/greyer
+    let fogColor = vec3<f32>(0.9, 0.95, 1.0); // Steam color
+
+    // Mix clear and blur
+    var finalColor = mix(clearColor, blurColor, newFog * blurAmount);
+
+    // Add fog overlay (whiteness)
+    finalColor = mix(finalColor, fogColor, newFog * fogDensity * 0.5);
+
+    // Add drips? Too complex for now.
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(finalColor, 1.0));
+
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/shader_definitions/distortion/crystal-facets.json
+++ b/shader_definitions/distortion/crystal-facets.json
@@ -1,0 +1,38 @@
+{
+  "id": "crystal-facets",
+  "name": "Crystal Facets",
+  "category": "distortion",
+  "url": "shaders/crystal-facets.wgsl",
+  "description": "Simulates a radial cut crystal or diamond lens. The image is split into angular facets that refract light differently based on mouse interaction.",
+  "params": [
+    {
+      "name": "Facet Count",
+      "id": "zoomParam1",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Refraction",
+      "id": "zoomParam2",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Rotation",
+      "id": "zoomParam3",
+      "default": 0.1,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Center Zoom",
+      "id": "zoomParam4",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": ["mouse-driven"]
+}

--- a/shader_definitions/retro-glitch/scanline-drift.json
+++ b/shader_definitions/retro-glitch/scanline-drift.json
@@ -1,0 +1,38 @@
+{
+  "id": "scanline-drift",
+  "name": "Scanline Drift",
+  "category": "retro-glitch",
+  "url": "shaders/scanline-drift.wgsl",
+  "description": "Horizontal segments of the image drift left and right, simulating a bad video signal or tracking error.",
+  "params": [
+    {
+      "name": "Drift Speed",
+      "id": "zoomParam1",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Line Height",
+      "id": "zoomParam2",
+      "default": 0.1,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Jitter Amount",
+      "id": "zoomParam3",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Color Shift",
+      "id": "zoomParam4",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": ["mouse-driven"]
+}

--- a/shader_definitions/simulation/steamy-glass.json
+++ b/shader_definitions/simulation/steamy-glass.json
@@ -1,0 +1,38 @@
+{
+  "id": "steamy-glass",
+  "name": "Steamy Glass",
+  "category": "simulation",
+  "url": "shaders/steamy-glass.wgsl",
+  "description": "Simulates a foggy window that can be wiped clean with the mouse. The steam slowly returns over time.",
+  "params": [
+    {
+      "name": "Fog Density",
+      "id": "zoomParam1",
+      "default": 0.8,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Fade Speed",
+      "id": "zoomParam2",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Wipe Radius",
+      "id": "zoomParam3",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Blur Amount",
+      "id": "zoomParam4",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": ["mouse-driven", "feedback"]
+}

--- a/shader_definitions/visual-effects/rgb-topology.json
+++ b/shader_definitions/visual-effects/rgb-topology.json
@@ -1,0 +1,38 @@
+{
+  "id": "rgb-topology",
+  "name": "RGB Topology",
+  "category": "visual-effects",
+  "url": "shaders/rgb-topology.wgsl",
+  "description": "Visualizes the image as 3D topographic maps, one for each color channel (Red, Green, Blue). The layers are offset based on mouse tilt.",
+  "params": [
+    {
+      "name": "Contour Density",
+      "id": "zoomParam1",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Parallax Height",
+      "id": "zoomParam2",
+      "default": 0.4,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Line Thickness",
+      "id": "zoomParam3",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "name": "Glow",
+      "id": "zoomParam4",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": ["mouse-driven"]
+}


### PR DESCRIPTION
This PR adds four new interactive shaders to the library:
1. **Crystal Facets** (`distortion`): Simulates a kaleidoscope-like radial refraction through a cut gemstone.
2. **Steamy Glass** (`simulation`): A foggy window simulation where the mouse acts as a wiper, and fog slowly returns. Uses feedback buffers.
3. **RGB Topology** (`visual-effects`): Visualizes the R, G, and B channels as distinct 3D topographic maps with parallax tilt.
4. **Scanline Drift** (`retro-glitch`): A "bad tracking" effect where horizontal segments of the image drift independently.

The shaders are registered in the `public/shader-lists` JSON files.

---
*PR created automatically by Jules for task [8052630453300755553](https://jules.google.com/task/8052630453300755553) started by @ford442*