### PR TITLE
Add Sequin Flip and Foil Impression shaders

### DIFF
--- a/public/shaders/foil-impression.wgsl
+++ b/public/shaders/foil-impression.wgsl
@@ -1,0 +1,122 @@
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 30>,
+};
+
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+
+// Hash function
+fn hash(p: vec2<f32>) -> f32 {
+    var p3 = fract(vec3<f32>(p.xyx) * 0.1031);
+    p3 = p3 + dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+fn noise(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let u = f * f * (3.0 - 2.0 * f);
+    return mix(mix(hash(i + vec2<f32>(0.0, 0.0)), hash(i + vec2<f32>(1.0, 0.0)), u.x),
+               mix(hash(i + vec2<f32>(0.0, 1.0)), hash(i + vec2<f32>(1.0, 1.0)), u.x), u.y);
+}
+
+fn fbm(p: vec2<f32>) -> f32 {
+    var v = 0.0;
+    var a = 0.5;
+    var shift = vec2<f32>(100.0);
+    var rot = mat2x2<f32>(cos(0.5), sin(0.5), -sin(0.5), cos(0.5));
+    var x = p;
+    for (var i = 0; i < 5; i++) {
+        v = v + a * noise(x);
+        x = rot * x * 2.0 + shift;
+        a = a * 0.5;
+    }
+    return v;
+}
+
+fn getLuma(color: vec3<f32>) -> f32 {
+  return dot(color, vec3<f32>(0.299, 0.587, 0.114));
+}
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let dims = vec2<i32>(textureDimensions(writeTexture));
+  if (global_id.x >= u32(dims.x) || global_id.y >= u32(dims.y)) {
+    return;
+  }
+  let coord = vec2<i32>(global_id.xy);
+  let uv = vec2<f32>(coord) / vec2<f32>(dims);
+  let aspect = f32(dims.x) / f32(dims.y);
+
+  // Params
+  let radius = mix(0.05, 0.5, u.zoom_params.x);
+  let roughness = u.zoom_params.y; // Frequency of foil noise
+  let relief = u.zoom_params.z; // Strength of image emboss
+  let color_mix_amt = u.zoom_params.w;
+
+  let mouse = u.zoom_config.yz;
+  let mouse_aspect = vec2<f32>(mouse.x * aspect, mouse.y);
+  let uv_aspect = vec2<f32>(uv.x * aspect, uv.y);
+
+  let dist = distance(uv_aspect, mouse_aspect);
+  let press_factor = smoothstep(radius, radius * 0.5, dist); // 1.0 at center, 0.0 outside
+
+  // 1. Generate Foil Normal
+  // High frequency noise
+  let noise_freq = mix(10.0, 100.0, roughness);
+  // Calculate noise gradient for normal
+  let eps = 0.001;
+  let n_val = fbm(uv * noise_freq);
+  let n_x = fbm((uv + vec2<f32>(eps, 0.0)) * noise_freq) - n_val;
+  let n_y = fbm((uv + vec2<f32>(0.0, eps)) * noise_freq) - n_val;
+
+  var foil_normal = normalize(vec3<f32>(-n_x * 20.0, -n_y * 20.0, 1.0));
+
+  // 2. Generate Image Relief Normal
+  // Sample neighbors for Sobel
+  let px = 1.0 / vec2<f32>(dims);
+  let l_x1 = getLuma(textureSampleLevel(readTexture, u_sampler, uv - vec2<f32>(px.x, 0.0), 0.0).rgb);
+  let l_x2 = getLuma(textureSampleLevel(readTexture, u_sampler, uv + vec2<f32>(px.x, 0.0), 0.0).rgb);
+  let l_y1 = getLuma(textureSampleLevel(readTexture, u_sampler, uv - vec2<f32>(0.0, px.y), 0.0).rgb);
+  let l_y2 = getLuma(textureSampleLevel(readTexture, u_sampler, uv + vec2<f32>(0.0, px.y), 0.0).rgb);
+
+  let dx = (l_x1 - l_x2) * mix(1.0, 10.0, relief);
+  let dy = (l_y1 - l_y2) * mix(1.0, 10.0, relief);
+
+  let image_normal = normalize(vec3<f32>(dx, dy, 1.0));
+
+  // 3. Mix Normals
+  // Combine: Where pressed, we see Image Normal. Where not, Foil Normal.
+  let final_normal = normalize(mix(foil_normal, image_normal, press_factor));
+
+  // 4. Color
+  let img_color = textureSampleLevel(readTexture, u_sampler, uv, 0.0).rgb;
+  let foil_base = vec3<f32>(0.7, 0.7, 0.75); // Silver
+
+  // If pressed, show more image color. If not, silver.
+  let target_color = mix(foil_base, img_color, color_mix_amt);
+  let final_albedo = mix(foil_base, target_color, press_factor);
+
+  // 5. Lighting
+  let light_dir = normalize(vec3<f32>(0.5, -0.5, 1.0));
+  let view_dir = vec3<f32>(0.0, 0.0, 1.0);
+  let half_dir = normalize(light_dir + view_dir);
+
+  let NdotL = max(0.0, dot(final_normal, light_dir));
+  let NdotH = max(0.0, dot(final_normal, half_dir));
+
+  let spec_pow = mix(30.0, 10.0, press_factor);
+  let spec = pow(NdotH, spec_pow) * 0.8;
+
+  var col = final_albedo * (0.3 + 0.7 * NdotL) + vec3<f32>(spec);
+
+  // Tone mapping / clamp
+  col = clamp(col, vec3<f32>(0.0), vec3<f32>(1.0));
+
+  textureStore(writeTexture, coord, vec4<f32>(col, 1.0));
+}

--- a/public/shaders/sequin-flip.wgsl
+++ b/public/shaders/sequin-flip.wgsl
@@ -1,0 +1,139 @@
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 30>,
+};
+
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+
+fn mod(x: vec2<f32>, y: vec2<f32>) -> vec2<f32> {
+  return x - y * floor(x / y);
+}
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let dims = vec2<i32>(textureDimensions(writeTexture));
+  if (global_id.x >= u32(dims.x) || global_id.y >= u32(dims.y)) {
+    return;
+  }
+  let coord = vec2<i32>(global_id.xy);
+  let uv = vec2<f32>(coord) / vec2<f32>(dims);
+
+  let aspect = f32(dims.x) / f32(dims.y);
+  var uv_corrected = uv;
+  uv_corrected.x *= aspect;
+
+  // Params
+  let grid_size = mix(10.0, 50.0, u.zoom_params.x);
+  let brush_size = mix(0.1, 0.5, u.zoom_params.y);
+  let shine = u.zoom_params.z;
+  let gold_mix = u.zoom_params.w;
+
+  let mouse = u.zoom_config.yz;
+  let mouse_corrected = vec2<f32>(mouse.x * aspect, mouse.y);
+
+  // Staggered Grid (Circle Packing)
+  let row_height = 0.866; // sin(60)
+  var grid_uv = uv_corrected * grid_size;
+
+  // Determine row
+  let row = floor(grid_uv.y / row_height);
+
+  // Shift x if row is odd
+  let is_odd = mod(vec2<f32>(row), vec2<f32>(2.0)).x;
+  if (is_odd > 0.5) {
+      grid_uv.x += 0.5;
+  }
+
+  let cell_id = floor(grid_uv);
+  let local_uv = fract(grid_uv) * 2.0 - 1.0; // -1 to 1
+
+  // Reconstruct center
+  var world_center = vec2<f32>(cell_id.x + 0.5 - (is_odd * 0.5), (cell_id.y + 0.5) * row_height) / grid_size;
+
+  // Distance to mouse from sequin center
+  let dist = distance(world_center, mouse_corrected);
+
+  // Influence (0 to 1)
+  let influence = smoothstep(brush_size + 0.1, brush_size - 0.1, dist);
+
+  // Rotation angle (radians)
+  // 0 -> Image, PI -> Back
+  let angle = influence * 3.14159;
+
+  // Circle mask
+  let radius = length(local_uv);
+  if (radius > 0.9) {
+      // Gaps
+      textureStore(writeTexture, coord, vec4<f32>(0.0, 0.0, 0.0, 1.0));
+      return;
+  }
+
+  let cos_a = cos(angle);
+  let sin_a = sin(angle);
+
+  // Project to surface
+  // y_surf = y_screen / cos(angle)
+  // Limit cos_a to avoid division by zero
+  let cos_clamped = sign(cos_a) * max(abs(cos_a), 0.01);
+  let tex_y = local_uv.y / cos_clamped;
+
+  if (abs(tex_y) > 0.9) {
+       // Clipped by disk tilt
+       textureStore(writeTexture, coord, vec4<f32>(0.0, 0.0, 0.0, 1.0));
+       return;
+  }
+
+  var col = vec3<f32>(0.0);
+  var normal = vec3<f32>(0.0, 0.0, 1.0);
+
+  if (cos_a >= 0.0) {
+      // Front: Image
+      var sample_uv = world_center;
+      sample_uv.x /= aspect;
+      // Clamp UV
+      sample_uv = clamp(sample_uv, vec2<f32>(0.0), vec2<f32>(1.0));
+
+      col = textureSampleLevel(readTexture, u_sampler, sample_uv, 0.0).rgb;
+
+      // Plastic sphere normal
+      let sphere_z = sqrt(max(0.0, 1.0 - local_uv.x*local_uv.x - tex_y*tex_y));
+      normal = vec3<f32>(local_uv.x, tex_y, sphere_z);
+  } else {
+      // Back: Metal
+      let metal_col = mix(vec3<f32>(0.8, 0.8, 0.9), vec3<f32>(1.0, 0.8, 0.2), gold_mix);
+      col = metal_col;
+
+      // Faceted normal
+      let noise_n = sin(local_uv.x * 20.0) * sin(tex_y * 20.0);
+      let sphere_z = sqrt(max(0.0, 1.0 - local_uv.x*local_uv.x - tex_y*tex_y));
+      normal = normalize(vec3<f32>(local_uv.x + noise_n*0.2, tex_y + noise_n*0.2, sphere_z));
+  }
+
+  // Rotate normal
+  var rot_normal = normal;
+  rot_normal.y = normal.y * cos_a - normal.z * sin_a;
+  rot_normal.z = normal.y * sin_a + normal.z * cos_a;
+  rot_normal = normalize(rot_normal);
+
+  // Light
+  let light_dir = normalize(vec3<f32>(0.2, -0.5, 1.0));
+  let view_dir = vec3<f32>(0.0, 0.0, 1.0);
+  let half_vec = normalize(light_dir + view_dir);
+
+  let NdotL = max(0.0, dot(rot_normal, light_dir));
+  let NdotH = max(0.0, dot(rot_normal, half_vec));
+  let spec = pow(NdotH, 20.0) * shine;
+
+  // Fresnel/Rim
+  let rim = 1.0 - max(0.0, dot(rot_normal, view_dir));
+  col += vec3<f32>(rim * 0.2);
+
+  col = col * (0.3 + 0.7 * NdotL) + vec3<f32>(spec);
+
+  textureStore(writeTexture, coord, vec4<f32>(col, 1.0));
+}

--- a/shader_definitions/interactive-mouse/foil-impression.json
+++ b/shader_definitions/interactive-mouse/foil-impression.json
@@ -1,0 +1,40 @@
+{
+  "id": "foil-impression",
+  "name": "Foil Impression",
+  "url": "shaders/foil-impression.wgsl",
+  "category": "image",
+  "description": "Simulates a metallic foil surface. Pressing with the mouse flattens the foil to reveal the image relief and color.",
+  "params": [
+    {
+      "id": "pressure_radius",
+      "name": "Pressure Size",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "foil_roughness",
+      "name": "Foil Crinkle",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "relief_strength",
+      "name": "Image Emboss",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "color_reveal",
+      "name": "Color Mix",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}

--- a/shader_definitions/interactive-mouse/sequin-flip.json
+++ b/shader_definitions/interactive-mouse/sequin-flip.json
@@ -1,0 +1,40 @@
+{
+  "id": "sequin-flip",
+  "name": "Sequin Flip",
+  "url": "shaders/sequin-flip.wgsl",
+  "category": "image",
+  "description": "Simulates reversible sequins that flip to reveal a metallic back when brushed by the mouse.",
+  "params": [
+    {
+      "id": "grid_size",
+      "name": "Grid Size",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "flip_radius",
+      "name": "Brush Size",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "specular",
+      "name": "Shine",
+      "default": 0.7,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "back_color",
+      "name": "Gold/Silver",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}


### PR DESCRIPTION
This PR adds two new mouse-responsive shaders:
1.  **Sequin Flip**: Simulates a grid of reversible sequins. As the mouse moves over them, they rotate to reveal a metallic back-face or the front-face image.
2.  **Foil Impression**: Simulates a silver foil covering the image. "Pressing" (moving the mouse near) flattens the foil to reveal the embossed image and its colors.

Both shaders are stateless and configured via the standard JSON definition system.

---
*PR created automatically by Jules for task [5954706042471129437](https://jules.google.com/task/5954706042471129437) started by @ford442*