### PR TITLE
Add Retro Game Boy and Crumpled Paper shaders

### DIFF
--- a/public/shaders/crumpled-paper.wgsl
+++ b/public/shaders/crumpled-paper.wgsl
@@ -1,0 +1,168 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time
+  zoom_config: vec4<f32>,  // y=MouseX, z=MouseY
+  zoom_params: vec4<f32>,  // x=Scale, y=Depth, z=SmoothRadius, w=LightStrength
+  ripples: array<vec4<f32>, 50>,
+};
+
+// --- Noise Functions ---
+
+fn hash21(p: vec2<f32>) -> f32 {
+    let h = dot(p, vec2<f32>(127.1, 311.7));
+    return fract(sin(h) * 43758.5453123);
+}
+
+fn valueNoise2D(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+
+    // Four corners
+    let a = hash21(i + vec2<f32>(0.0, 0.0));
+    let b = hash21(i + vec2<f32>(1.0, 0.0));
+    let c = hash21(i + vec2<f32>(0.0, 1.0));
+    let d = hash21(i + vec2<f32>(1.0, 1.0));
+
+    // Smooth interpolation
+    let u = f * f * (3.0 - 2.0 * f);
+
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+// 5-Octave FBM
+fn fbm5(p: vec2<f32>) -> f32 {
+    var sum = 0.0;
+    var amp = 1.0;
+    var freq = 1.0;
+    var maxAmp = 0.0;
+
+    for (var i: i32 = 0; i < 5; i = i + 1) {
+        sum = sum + amp * valueNoise2D(p * freq);
+        maxAmp = maxAmp + amp;
+        freq = freq * 2.0;
+        amp = amp * 0.5; // persistence
+    }
+
+    return sum / maxAmp;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let aspect = resolution.x / resolution.y;
+    let mouse = u.zoom_config.yz; // 0..1
+
+    // Params
+    let scale = mix(2.0, 10.0, u.zoom_params.x); // Crumple frequency
+    let depth = u.zoom_params.y;                 // Crumple amplitude
+    let smoothRadius = u.zoom_params.z * 0.5;    // Mouse ironing radius
+    let lightStrength = u.zoom_params.w;
+
+    // Calculate Height Map
+    // We use FBM noise.
+    let noiseVal = fbm5(uv * scale + vec2<f32>(12.3, 45.6));
+
+    // Crumple Logic:
+    // Crumpled paper has sharp creases. We can map the noise to create ridges.
+    // 1.0 - abs(noise - 0.5) * 2.0 creates ridges.
+    let ridge = pow(1.0 - abs(noiseVal - 0.5) * 2.0, 2.0);
+
+    // Combine base noise and ridges
+    var height = mix(noiseVal, ridge, 0.6) * depth;
+
+    // Mouse Interaction (Smoothing/Ironing)
+    // Distance to mouse
+    let distVec = (uv - mouse) * vec2<f32>(aspect, 1.0);
+    let dist = length(distVec);
+    // Fix: smoothstep edges must be e0 < e1. We want 1.0 when dist=0, 0.0 when dist=radius.
+    // Use 1.0 - smoothstep(0, radius, dist).
+    // Ensure smoothRadius is > 0 to avoid undefined behavior.
+    let sr = max(0.001, smoothRadius);
+    let smoothFactor = 1.0 - smoothstep(0.0, sr, dist);
+
+    // Reduce height where mouse is (flatten the paper)
+    height = height * (1.0 - smoothFactor);
+
+    // Calculate Normal
+    // Since we don't have analytical derivative easily, we sample neighboring heights.
+    // However, recalculating FBM 2 more times per pixel is expensive.
+    // A cheaper way is to assume the derivative of noise is somewhat related to its value or use a cheaper noise for derivative.
+    // But for quality, let's recalculate FBM for neighbors.
+    // Wait, let's optimize: only 1 sample if we assume lighting comes from top-left constant?
+    // No, we need normals for dynamic lighting.
+
+    let eps = 0.005; // sampling step
+
+    // Helper to get height at offset
+    // (Inlined for simplicity or we define function but requires passing uniforms)
+    // We just reuse logic approx.
+    let nR = fbm5((uv + vec2<f32>(eps, 0.0)) * scale + vec2<f32>(12.3, 45.6));
+    let rR = pow(1.0 - abs(nR - 0.5) * 2.0, 2.0);
+    let hR = mix(nR, rR, 0.6) * depth;
+    // Apply smoothing to neighbor too
+    let distR = length(((uv + vec2<f32>(eps, 0.0)) - mouse) * vec2<f32>(aspect, 1.0));
+    let smoothR = 1.0 - smoothstep(0.0, sr, distR);
+    let finalHR = hR * (1.0 - smoothR);
+
+    let nU = fbm5((uv + vec2<f32>(0.0, eps)) * scale + vec2<f32>(12.3, 45.6));
+    let rU = pow(1.0 - abs(nU - 0.5) * 2.0, 2.0);
+    let hU = mix(nU, rU, 0.6) * depth;
+    let distU = length(((uv + vec2<f32>(0.0, eps)) - mouse) * vec2<f32>(aspect, 1.0));
+    let smoothU = 1.0 - smoothstep(0.0, sr, distU);
+    let finalHU = hU * (1.0 - smoothU);
+
+    let dX = (finalHR - height) / eps;
+    let dY = (finalHU - height) / eps;
+
+    let normal = normalize(vec3<f32>(-dX, -dY, 1.0));
+
+    // Lighting
+    let lightDir = normalize(vec3<f32>(0.5, -0.5, 1.0)); // Top-right light
+    let diffuse = max(dot(normal, lightDir), 0.0);
+
+    // Ambient occlusion in creases (where height is low?)
+    // Actually where ridge is sharp.
+    // Let's just map height to ambient. Lower parts are darker.
+    let ambient = 0.5 + 0.5 * height;
+
+    let lighting = ambient * 0.5 + diffuse * 0.8;
+
+    // Apply texture distortion
+    // Refract texture based on normal xy
+    let distortStr = 0.02 * depth;
+    let finalUV = uv + normal.xy * distortStr;
+
+    let texColor = textureSampleLevel(readTexture, u_sampler, clamp(finalUV, vec2<f32>(0.0), vec2<f32>(1.0)), 0.0).rgb;
+
+    // Mix lighting
+    // If lightStrength is 0, we see pure image. If 1, we see paper texture heavily applied.
+    // Paper is usually white.
+    // Let's multiply image by lighting (modulate).
+    var finalColor = texColor * mix(1.0, lighting, lightStrength);
+
+    // Add specular highlight for shiny paper?
+    // Maybe paper is matte.
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(finalColor, 1.0));
+
+    let depthVal = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depthVal, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/retro-gameboy.wgsl
+++ b/public/shaders/retro-gameboy.wgsl
@@ -1,0 +1,127 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=MouseDown
+  zoom_params: vec4<f32>,  // x=PixelSize, y=Contrast, z=GridStrength, w=ShadowOffset
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Retro GB Palette
+// 0: Darkest (0x0F, 0x38, 0x0F) -> (15, 56, 15)
+// 1: Dark    (0x30, 0x62, 0x30) -> (48, 98, 48)
+// 2: Light   (0x8B, 0xAC, 0x0F) -> (139, 172, 15)
+// 3: Lightest(0x9B, 0xBC, 0x0F) -> (155, 188, 15)
+fn get_palette(intensity: f32) -> vec3<f32> {
+    let col0 = vec3<f32>(15.0, 56.0, 15.0) / 255.0;
+    let col1 = vec3<f32>(48.0, 98.0, 48.0) / 255.0;
+    let col2 = vec3<f32>(139.0, 172.0, 15.0) / 255.0;
+    let col3 = vec3<f32>(155.0, 188.0, 15.0) / 255.0;
+
+    // Quantize intensity to 4 levels
+    let val = clamp(intensity, 0.0, 1.0) * 3.0;
+    let idx = floor(val);
+    let frac = fract(val);
+
+    // Hard steps usually look more "retro", but let's allow slight mix for smoothness if desired?
+    // The prompt asks for "retro game boy", so hard quantization is better.
+    if (idx < 0.5) { return col0; }
+    if (idx < 1.5) { return col1; }
+    if (idx < 2.5) { return col2; }
+    return col3;
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let time = u.config.x;
+    let mouse = u.zoom_config.yz; // 0..1
+
+    // Parameters
+    // Pixel Size: 1.0 (coarse) to 0.0 (native resolution)
+    // We map 0..1 to a divider.
+    let pSizeParam = u.zoom_params.x;
+    let pixelDiv = mix(1.0, 16.0, pSizeParam); // 1.0 = native, 16.0 = very blocky
+    // Actually, "Pixel Size" implies blockiness.
+    // If pSizeParam is 0, we want high res (divider 1).
+    // If pSizeParam is 1, we want low res (divider large).
+    // BUT typically pixel shaders work better if we define "pixels per screen" or "size of pixel".
+    // Let's use pixel block size in screen pixels.
+    let blockSize = max(1.0, floor(pSizeParam * 10.0 + 1.0));
+
+    // Quantize UVs
+    let quantizedPos = floor(vec2<f32>(global_id.xy) / blockSize) * blockSize;
+    let quantizedUV = quantizedPos / resolution;
+
+    // Parameters continued
+    let contrast = u.zoom_params.y; // Base contrast
+    let gridStrength = u.zoom_params.z;
+    let shadowOffset = u.zoom_params.w;
+
+    // Mouse Interaction
+    // Mouse X adds to Contrast (centered at 0.5)
+    // Mouse Y adds to Brightness
+    let mContrast = (mouse.x - 0.5) * 2.0; // -1 to 1
+    let mBright = (mouse.y - 0.5) * 1.0;   // -0.5 to 0.5
+
+    let finalContrast = clamp(contrast + mContrast * 0.5, 0.0, 2.0);
+    let finalBright = mBright;
+
+    // Sample Image
+    let rawColor = textureSampleLevel(readTexture, u_sampler, quantizedUV, 0.0).rgb;
+
+    // Ghosting / Shadow
+    // We sample a second time with a slight offset to simulate LCD lag/ghosting
+    let offsetUV = quantizedUV - vec2<f32>(shadowOffset * 0.01, 0.0);
+    let shadowColor = textureSampleLevel(readTexture, u_sampler, offsetUV, 0.0).rgb;
+
+    // Convert to Grayscale (Luminance)
+    let lumRaw = dot(rawColor, vec3<f32>(0.299, 0.587, 0.114));
+    let lumShadow = dot(shadowColor, vec3<f32>(0.299, 0.587, 0.114));
+
+    // Apply Contrast & Brightness
+    let cLumRaw = (lumRaw - 0.5) * finalContrast + 0.5 + finalBright;
+    let cLumShadow = (lumShadow - 0.5) * finalContrast + 0.5 + finalBright;
+
+    // Mix Shadow (LCD Response Time simulation)
+    // Darker pixels linger. We use a simple mix.
+    let finalLum = mix(cLumRaw, cLumShadow, 0.3 * shadowOffset);
+
+    // Map to Palette
+    let paletteColor = get_palette(finalLum);
+
+    // Apply Pixel Grid
+    // Darken the edges of the blocks
+    var grid = 1.0;
+    if (blockSize > 1.5 && gridStrength > 0.0) {
+        let pixelPos = vec2<f32>(global_id.xy) % blockSize;
+        // Simple 1px line at bottom and right
+        let border = step(blockSize - 1.0, pixelPos.x) + step(blockSize - 1.0, pixelPos.y);
+        grid = 1.0 - clamp(border, 0.0, 1.0) * gridStrength * 0.5;
+    }
+
+    var finalColor = paletteColor * grid;
+
+    textureStore(writeTexture, global_id.xy, vec4<f32>(finalColor, 1.0));
+
+    // Pass depth
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, quantizedUV, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/shader_definitions/image/crumpled-paper.json
+++ b/shader_definitions/image/crumpled-paper.json
@@ -1,0 +1,14 @@
+{
+    "id": "crumpled-paper",
+    "name": "Crumpled Paper",
+    "category": "image",
+    "description": "Simulates the look of crumpled paper with interactive smoothing.",
+    "url": "shaders/crumpled-paper.wgsl",
+    "features": ["mouse-driven"],
+    "params": [
+        { "id": "scale", "name": "Crumple Scale", "default": 0.5, "min": 0.0, "max": 1.0 },
+        { "id": "depth", "name": "Crumple Depth", "default": 0.5, "min": 0.0, "max": 1.0 },
+        { "id": "smooth_radius", "name": "Smooth Radius", "default": 0.3, "min": 0.0, "max": 1.0 },
+        { "id": "light_strength", "name": "Light Strength", "default": 0.5, "min": 0.0, "max": 1.0 }
+    ]
+}

--- a/shader_definitions/image/retro-gameboy.json
+++ b/shader_definitions/image/retro-gameboy.json
@@ -1,0 +1,14 @@
+{
+    "id": "retro-gameboy",
+    "name": "Retro Game Boy",
+    "category": "image",
+    "description": "Simulates a classic handheld green dot-matrix display.",
+    "url": "shaders/retro-gameboy.wgsl",
+    "features": ["mouse-driven"],
+    "params": [
+        { "id": "pixel_size", "name": "Pixel Size", "default": 0.5, "min": 0.0, "max": 1.0 },
+        { "id": "contrast", "name": "Contrast", "default": 0.5, "min": 0.0, "max": 1.0 },
+        { "id": "grid_strength", "name": "Grid Strength", "default": 0.5, "min": 0.0, "max": 1.0 },
+        { "id": "shadow_offset", "name": "Shadow Offset", "default": 0.3, "min": 0.0, "max": 1.0 }
+    ]
+}


### PR DESCRIPTION
Added two new interactive shaders:
1.  **Retro Game Boy**: Simulates the classic green dot-matrix display with pixelation, palette mapping, ghosting, and interactive contrast/brightness.
2.  **Crumpled Paper**: Simulates a crumpled paper surface using FBM noise for height mapping and normals, with an interactive "ironing" effect where the mouse smoothes the paper.

Files added:
- `shader_definitions/image/retro-gameboy.json`
- `public/shaders/retro-gameboy.wgsl`
- `shader_definitions/image/crumpled-paper.json`
- `public/shaders/crumpled-paper.wgsl`

Updated:
- `public/shader-lists/image.json` (via script)

Addressed code review feedback regarding `smoothstep` parameter order.

---
*PR created automatically by Jules for task [8813635131820056639](https://jules.google.com/task/8813635131820056639) started by @ford442*