### PR TITLE
Add 4 New Creative Shaders

### DIFF
--- a/public/shaders/ascii-shockwave.wgsl
+++ b/public/shaders/ascii-shockwave.wgsl
@@ -1,0 +1,116 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4 (Use these for ANY float sliders)
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Simple hash for noise
+fn hash(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(12.9898, 78.233))) * 43758.5453);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = u.zoom_config.yz;
+    let time = u.config.x;
+
+    // Shockwave logic
+    let aspect = resolution.x / resolution.y;
+    let uv_aspect = vec2<f32>(uv.x * aspect, uv.y);
+    let mouse_aspect = vec2<f32>(mouse.x * aspect, mouse.y);
+
+    let dist = distance(uv_aspect, mouse_aspect);
+
+    // Wave parameters
+    let wave_speed = 2.0;
+    let max_radius = 2.0;
+    let current_radius = fract(time * wave_speed / max_radius) * max_radius; // Loop the wave
+    // Alternatively, just base it on distance from mouse, always active?
+    // Let's make it a continuous pulse from the mouse.
+
+    let pulse = sin(dist * 20.0 - time * 10.0); // -1 to 1
+
+    // Define "ASCII" region - where the pulse is high
+    let is_ascii = pulse > 0.5;
+
+    var final_color = vec4<f32>(0.0);
+
+    if (is_ascii) {
+        // Quantize coordinates
+        let cells = 80.0;
+        let cell_size = 1.0 / cells;
+        let grid_uv = floor(uv * cells) / cells;
+        let center_uv = grid_uv + cell_size * 0.5;
+
+        let color = textureSampleLevel(readTexture, u_sampler, center_uv, 0.0);
+        let luminance = dot(color.rgb, vec3<f32>(0.299, 0.587, 0.114));
+
+        // Procedural "character"
+        let local_uv = fract(uv * cells); // 0 to 1 inside cell
+        // Simple pattern based on luminance
+        // If lum > 0.5, draw a box, else draw a dot
+        var char_mask = 0.0;
+        if (luminance > 0.8) {
+            // Fill
+            char_mask = 1.0;
+        } else if (luminance > 0.5) {
+            // Box outline
+            let border = 0.1;
+            if (local_uv.x < border || local_uv.x > 1.0-border || local_uv.y < border || local_uv.y > 1.0-border) {
+                char_mask = 1.0;
+            }
+        } else if (luminance > 0.2) {
+            // Cross
+            if (abs(local_uv.x - local_uv.y) < 0.1 || abs(local_uv.x - (1.0 - local_uv.y)) < 0.1) {
+                char_mask = 1.0;
+            }
+        } else {
+            // Dot
+            if (distance(local_uv, vec2<f32>(0.5)) < 0.2) {
+                char_mask = 1.0;
+            }
+        }
+
+        // Matrix Green style
+        final_color = vec4<f32>(0.0, luminance * char_mask, 0.0, 1.0);
+        // Mix a bit of original color so it's not purely green
+        final_color = mix(final_color, color * char_mask, 0.3);
+
+    } else {
+        // Normal image
+        final_color = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    }
+
+    // Add a glowing ring at the transition
+    let glow = smoothstep(0.4, 0.5, pulse) * smoothstep(0.6, 0.5, pulse);
+    final_color = final_color + vec4<f32>(0.0, 1.0, 0.0, 0.0) * glow;
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), final_color);
+
+    // Pass depth
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/glitch-slice-mirror.wgsl
+++ b/public/shaders/glitch-slice-mirror.wgsl
@@ -1,0 +1,86 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4 (Use these for ANY float sliders)
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(12.9898, 78.233))) * 43758.5453);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = u.zoom_config.yz;
+    let time = u.config.x;
+
+    // Mirror Logic
+    // Mirror the left side onto the right side, pivoted at mouse.x
+    var target_uv = uv;
+    if (uv.x > mouse.x) {
+        target_uv.x = mouse.x - (uv.x - mouse.x);
+    }
+
+    // Glitch Logic near seam
+    let dist_to_seam = abs(uv.x - mouse.x);
+    let glitch_width = 0.1;
+
+    var color = vec4<f32>(0.0);
+
+    if (dist_to_seam < glitch_width) {
+        // Intensity fades out as we move away from seam
+        let intensity = (1.0 - dist_to_seam / glitch_width);
+
+        // Blocky noise
+        let block_size = vec2<f32>(0.05, 0.02);
+        let seed = floor(uv / block_size) + time;
+        let noise = hash(seed);
+
+        if (noise > 0.8) {
+            // Horizontal displacement
+            target_uv.x = target_uv.x + (noise - 0.5) * 0.1 * intensity;
+        }
+
+        // Chromatic Aberration
+        let split = 0.02 * intensity * noise;
+        let r = textureSampleLevel(readTexture, u_sampler, target_uv + vec2<f32>(split, 0.0), 0.0).r;
+        let g = textureSampleLevel(readTexture, u_sampler, target_uv, 0.0).g;
+        let b = textureSampleLevel(readTexture, u_sampler, target_uv - vec2<f32>(split, 0.0), 0.0).b;
+        color = vec4<f32>(r, g, b, 1.0);
+
+        // Scanline darkening
+        if (sin(uv.y * 200.0) > 0.9) {
+            color = color * 0.5;
+        }
+    } else {
+        color = textureSampleLevel(readTexture, u_sampler, target_uv, 0.0);
+    }
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), color);
+
+    // Pass depth (using distorted UV)
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, target_uv, 0.0).r;
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/polka-dot-reveal.wgsl
+++ b/public/shaders/polka-dot-reveal.wgsl
@@ -1,0 +1,73 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4 (Use these for ANY float sliders)
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = u.zoom_config.yz;
+
+    // Calculate distance influence
+    let aspect = resolution.x / resolution.y;
+    let dist = distance(vec2<f32>(uv.x * aspect, uv.y), vec2<f32>(mouse.x * aspect, mouse.y));
+
+    // Map distance to grid density
+    // Close = high density (small dots, e.g. 200)
+    // Far = low density (big dots, e.g. 20)
+    let density = mix(200.0, 20.0, smoothstep(0.0, 0.8, dist));
+
+    let grid_uv = floor(uv * density) / density;
+    let cell_center = grid_uv + (0.5 / density);
+
+    // Sample color at cell center
+    let color = textureSampleLevel(readTexture, u_sampler, cell_center, 0.0);
+    let lum = dot(color.rgb, vec3<f32>(0.299, 0.587, 0.114));
+
+    // Determine dot radius based on luminance
+    // Max radius is half cell width (0.5 in local coords)
+    let max_radius = 0.5;
+    let radius = lum * max_radius; // Darker = smaller dots? Or Brighter = bigger dots? Standard halftone is bigger = darker (ink).
+    // Let's do: Brighter = bigger dots (additive light model)
+
+    // Local UV in cell [0, 1]
+    let local_uv = fract(uv * density);
+    let dist_to_center = distance(local_uv, vec2<f32>(0.5));
+
+    var final_color = vec4<f32>(0.0); // Black background
+
+    // Smooth circle
+    let aa = 0.1 * density / 50.0; // Anti-aliasing width adjusted by density
+    let circle = 1.0 - smoothstep(radius - aa, radius + aa, dist_to_center);
+
+    final_color = mix(vec4<f32>(0.0, 0.0, 0.0, 1.0), color, circle);
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), final_color);
+
+    // Pass depth
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/rgb-ripple-waves.wgsl
+++ b/public/shaders/rgb-ripple-waves.wgsl
@@ -1,0 +1,84 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>; // Use for persistence/trail history
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>; // Or generic object data
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount/Generic1, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4 (Use these for ANY float sliders)
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = u.zoom_config.yz;
+    let time = u.config.x;
+
+    // Correct aspect ratio for distance calculation
+    let aspect = resolution.x / resolution.y;
+    let uv_aspect = vec2<f32>(uv.x * aspect, uv.y);
+    let mouse_aspect = vec2<f32>(mouse.x * aspect, mouse.y);
+
+    let dist = distance(uv_aspect, mouse_aspect);
+
+    // Parameters
+    let frequency = 50.0;
+    let speed = 5.0;
+    let amplitude = 0.02 * exp(-dist * 2.0); // Decay with distance
+
+    // Phase shifts for RGB
+    let phase_r = 0.0;
+    let phase_g = 1.0; // Phase offset
+    let phase_b = 2.0; // Phase offset
+
+    // Calculate waves
+    let wave_r = sin(dist * frequency - time * speed + phase_r);
+    let wave_g = sin(dist * frequency - time * speed + phase_g);
+    let wave_b = sin(dist * frequency - time * speed + phase_b);
+
+    // Displace UVs
+    var displacement_r = vec2<f32>(0.0);
+    var displacement_g = vec2<f32>(0.0);
+    var displacement_b = vec2<f32>(0.0);
+
+    if (dist > 0.001) {
+        // Calculate direction in aspect-corrected space for circular ripples
+        let dir_aspect = normalize(uv_aspect - mouse_aspect);
+        // Convert direction back to UV space (undo aspect correction)
+        let dir_uv = vec2<f32>(dir_aspect.x / aspect, dir_aspect.y);
+
+        displacement_r = dir_uv * wave_r * amplitude;
+        displacement_g = dir_uv * wave_g * amplitude;
+        displacement_b = dir_uv * wave_b * amplitude;
+    }
+
+    let r = textureSampleLevel(readTexture, u_sampler, uv + displacement_r, 0.0).r;
+    let g = textureSampleLevel(readTexture, u_sampler, uv + displacement_g, 0.0).g;
+    let b = textureSampleLevel(readTexture, u_sampler, uv + displacement_b, 0.0).b;
+
+    let final_color = vec4<f32>(r, g, b, 1.0);
+
+    textureStore(writeTexture, vec2<i32>(global_id.xy), final_color);
+
+    // Pass through depth
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
+}

--- a/shader_definitions/artistic/polka-dot-reveal.json
+++ b/shader_definitions/artistic/polka-dot-reveal.json
@@ -1,0 +1,7 @@
+{
+  "id": "polka-dot-reveal",
+  "name": "Polka Dot Reveal",
+  "url": "shaders/polka-dot-reveal.wgsl",
+  "category": "image",
+  "description": "Interactive halftone effect where mouse proximity increases the dot density, revealing more detail."
+}

--- a/shader_definitions/distortion/glitch-slice-mirror.json
+++ b/shader_definitions/distortion/glitch-slice-mirror.json
@@ -1,0 +1,7 @@
+{
+  "id": "glitch-slice-mirror",
+  "name": "Glitch Slice Mirror",
+  "url": "shaders/glitch-slice-mirror.wgsl",
+  "category": "image",
+  "description": "Mirrors the image at the mouse position with digital glitch artifacts along the seam."
+}

--- a/shader_definitions/interactive-mouse/rgb-ripple-waves.json
+++ b/shader_definitions/interactive-mouse/rgb-ripple-waves.json
@@ -1,0 +1,7 @@
+{
+  "id": "rgb-ripple-waves",
+  "name": "RGB Ripple Waves",
+  "url": "shaders/rgb-ripple-waves.wgsl",
+  "category": "image",
+  "description": "Separates RGB channels into distinct ripple waves emanating from the mouse cursor."
+}

--- a/shader_definitions/visual-effects/ascii-shockwave.json
+++ b/shader_definitions/visual-effects/ascii-shockwave.json
@@ -1,0 +1,7 @@
+{
+  "id": "ascii-shockwave",
+  "name": "ASCII Shockwave",
+  "url": "shaders/ascii-shockwave.wgsl",
+  "category": "image",
+  "description": "A matrix-style digital shockwave that quantizes the image into procedural characters."
+}


### PR DESCRIPTION
Added 4 new creative shaders:
1. RGB Ripple Waves (interactive-mouse): Separates RGB channels into distinct ripples.
2. ASCII Shockwave (visual-effects): Matrix-style shockwave with character quantization.
3. Polka Dot Reveal (artistic): Interactive halftone density control.
4. Glitch Slice Mirror (distortion): Mirrors image at mouse X with glitch artifacts.

Registered new shaders in public/shader-lists via generation script.

---
*PR created automatically by Jules for task [5811582768038019930](https://jules.google.com/task/5811582768038019930) started by @ford442*