### PR TITLE
Add Quantum Superposition and Cyber Hex Armor Shaders

### DIFF
--- a/public/shaders/cyber-hex-armor.wgsl
+++ b/public/shaders/cyber-hex-armor.wgsl
@@ -1,0 +1,143 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=HexSize, y=GlowIntensity, z=RevealRadius, w=Generic
+  ripples: array<vec4<f32>, 50>,
+};
+
+// Hexagon SDF (Distance from center to edge)
+fn hexDist(p: vec2<f32>) -> f32 {
+    var p2 = abs(p);
+    // dot product with (1, sqrt(3)) normalized
+    let c = dot(p2, normalize(vec2<f32>(1.0, 1.7320508)));
+    return max(c, p2.x);
+}
+
+// Hexagon Grid Logic
+// Returns: vec4(local_uv.x, local_uv.y, id.x, id.y)
+fn hexCoords(uv: vec2<f32>) -> vec4<f32> {
+    let r = vec2<f32>(1.0, 1.7320508);
+    let h = r * 0.5;
+
+    let a = uv - (floor(uv / r + 0.5) * r);
+    let b = uv - (floor((uv - h) / r + 0.5) * r + h);
+
+    let gv = select(b, a, dot(a, a) < dot(b, b));
+    let id = uv - gv;
+
+    return vec4<f32>(gv.x, gv.y, id.x, id.y);
+}
+
+fn hash12(p: vec2<f32>) -> f32 {
+    var p3  = fract(vec3<f32>(p.xyx) * .1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+
+    // Correct aspect ratio for grid
+    let aspect = resolution.x / resolution.y;
+    let gridUV = vec2<f32>(uv.x * aspect, uv.y);
+    let mousePos = u.zoom_config.yz;
+    let mouseGridPos = vec2<f32>(mousePos.x * aspect, mousePos.y);
+
+    // Params
+    let hexSize = 20.0 + u.zoom_params.x * 50.0;
+    let glowIntensity = u.zoom_params.y * 2.0;
+    let revealRadius = 0.1 + u.zoom_params.z * 0.5;
+
+    // Scale UV for hex grid
+    let scaledUV = gridUV * hexSize;
+    let hc = hexCoords(scaledUV);
+    let localUV = hc.xy;
+    let id = hc.zw;
+
+    // Calculate hex center in world space (approx)
+    let hexCenter = id / hexSize;
+
+    // Distance from mouse to hex center
+    let distToMouse = length(hexCenter - mouseGridPos);
+
+    // Calculate "Openness" of the armor
+    // Near mouse = Open (scale 0), Far = Closed (scale 1)
+    // Add some noise/randomness to the opening
+    let noise = hash12(id);
+    let opening = smoothstep(revealRadius, revealRadius + 0.2 + noise * 0.1, distToMouse);
+
+    // If mouse is offscreen, everything is closed
+    let effectiveOpen = select(opening, 1.0, mousePos.x < 0.0);
+
+    // Scale the hex visually based on openness
+    // We want the hex to shrink as it opens
+    let hexScale = effectiveOpen; // 0.0 to 1.0
+
+    // SDF of hexagon
+    // Radius of standard hex in this grid system is roughly 0.5 (h.y is 0.866)
+    // Let's normalize it roughly
+    let dist = hexDist(localUV);
+
+    // Edge thickness
+    let border = 0.05;
+    let radius = 0.5 * hexScale - border;
+
+    var finalColor = vec4<f32>(0.0);
+
+    if (radius < 0.0) {
+        // Hex is completely vanished
+        finalColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    } else {
+        // Smoothstep for anti-aliasing edge
+        let edge = smoothstep(radius, radius + 0.05, dist);
+
+        if (edge < 0.5) {
+            // Inside Hex Armor
+            // Create a tech texture
+            let techColor = vec3<f32>(0.1, 0.12, 0.15); // Dark blue-grey
+            let highlight = smoothstep(0.4, 0.5, dist) * glowIntensity; // Glow at edge
+
+            // Add some "circuit" details inside
+            let detail = step(0.9, fract(localUV.x * 10.0 + localUV.y * 10.0));
+
+            let armorColor = techColor + vec3<f32>(0.0, 0.8, 1.0) * highlight + vec3<f32>(detail * 0.05);
+
+            finalColor = vec4<f32>(armorColor, 1.0);
+
+        } else {
+            // Outside Hex (Gap) -> Show Image
+            // Add a glow from the hex border onto the image
+            let glow = exp(-20.0 * (dist - radius)) * glowIntensity;
+            let imgColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+
+            finalColor = imgColor + vec4<f32>(0.0, 0.5, 1.0, 0.0) * glow;
+        }
+    }
+
+    // Pass-through depth
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(d, 0.0, 0.0, 0.0));
+
+    textureStore(writeTexture, global_id.xy, finalColor);
+}

--- a/public/shaders/quantum-superposition.wgsl
+++ b/public/shaders/quantum-superposition.wgsl
@@ -1,0 +1,115 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
+  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  zoom_params: vec4<f32>,  // x=ChaosSpeed, y=ChaosAmount, z=StabilityRadius, w=RGBSplit
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash13(p: vec3<f32>) -> f32 {
+    var p3  = fract(p * .1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+fn random2(p: vec2<f32>) -> vec2<f32> {
+    return fract(sin(vec2<f32>(dot(p, vec2<f32>(127.1, 311.7)), dot(p, vec2<f32>(269.5, 183.3)))) * 43758.5453);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let time = u.config.x;
+    let mousePos = u.zoom_config.yz;
+
+    // Parameters
+    let chaosSpeed = u.zoom_params.x * 20.0;
+    let chaosAmount = u.zoom_params.y; // 0.0 to 1.0
+    let stabilityRadius = u.zoom_params.z; // 0.0 to 1.0
+    let rgbSplitStr = u.zoom_params.w * 0.05;
+
+    // Calculate stability field (mouse influence)
+    let aspect = resolution.x / resolution.y;
+    let mouseVec = (uv - mousePos);
+    let dist = length(vec2<f32>(mouseVec.x * aspect, mouseVec.y));
+
+    // Smoothstep creates a soft boundary for stability
+    // Closer to mouse = 0.0 (stable), Further = 1.0 (unstable)
+    let stability = smoothstep(stabilityRadius, stabilityRadius + 0.2, dist);
+
+    // If mouse is offscreen (-1.0), everything is unstable
+    let effectiveStability = select(stability, 1.0, mousePos.x < 0.0);
+
+    // Chaos time modulation
+    let chaosTime = floor(time * chaosSpeed);
+
+    // Random offset for glitch
+    // We use floor(uv * blocks) to create blocky artifacts
+    let blockSize = 20.0 + (1.0 - effectiveStability) * 50.0;
+    let blockUV = floor(uv * blockSize) / blockSize;
+
+    // Random value per block per time step
+    let rnd = hash13(vec3<f32>(blockUV, chaosTime));
+
+    // Determine if this pixel is glitching
+    // It glitches if the random value is less than the chaos amount masked by stability
+    let isGlitch = select(0.0, 1.0, rnd < (chaosAmount * effectiveStability));
+
+    var finalColor = vec4<f32>(0.0);
+
+    if (isGlitch > 0.5) {
+        // Glitch Mode:
+        // 1. Color Inversion or Shift
+        // 2. Spatial Displacement
+        // 3. RGB Split
+
+        let shift = (random2(blockUV + vec2<f32>(chaosTime)) - vec2<f32>(0.5)) * 0.1 * effectiveStability;
+
+        let rUV = clamp(uv + shift + vec2<f32>(rgbSplitStr, 0.0), vec2<f32>(0.0), vec2<f32>(1.0));
+        let gUV = clamp(uv + shift, vec2<f32>(0.0), vec2<f32>(1.0));
+        let bUV = clamp(uv + shift - vec2<f32>(rgbSplitStr, 0.0), vec2<f32>(0.0), vec2<f32>(1.0));
+
+        let r = textureSampleLevel(readTexture, u_sampler, rUV, 0.0).r;
+        let g = textureSampleLevel(readTexture, u_sampler, gUV, 0.0).g;
+        let b = textureSampleLevel(readTexture, u_sampler, bUV, 0.0).b;
+
+        // Occasional color inversion
+        if (rnd < 0.2) {
+            finalColor = vec4<f32>(1.0 - r, 1.0 - g, 1.0 - b, 1.0);
+        } else {
+            finalColor = vec4<f32>(r, g, b, 1.0);
+        }
+
+        // Add some noise overlay
+        finalColor = finalColor + vec4<f32>((rnd - 0.5) * 0.2);
+
+    } else {
+        // Stable Mode (Clean Image)
+        finalColor = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    }
+
+    // Pass-through depth
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(d, 0.0, 0.0, 0.0));
+
+    textureStore(writeTexture, global_id.xy, finalColor);
+}

--- a/shader_definitions/interactive-mouse/cyber-hex-armor.json
+++ b/shader_definitions/interactive-mouse/cyber-hex-armor.json
@@ -1,0 +1,34 @@
+{
+  "id": "cyber-hex-armor",
+  "name": "Cyber Hex Armor",
+  "url": "shaders/cyber-hex-armor.wgsl",
+  "category": "image",
+  "description": "A hexagonal tech armor overlay that retracts when the mouse approaches.",
+  "params": [
+    {
+      "id": "hex_size",
+      "name": "Hex Size",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "glow_intensity",
+      "name": "Glow Intensity",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "reveal_radius",
+      "name": "Reveal Radius",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "overlay"
+  ]
+}

--- a/shader_definitions/interactive-mouse/quantum-superposition.json
+++ b/shader_definitions/interactive-mouse/quantum-superposition.json
@@ -1,0 +1,41 @@
+{
+  "id": "quantum-superposition",
+  "name": "Quantum Superposition",
+  "url": "shaders/quantum-superposition.wgsl",
+  "category": "image",
+  "description": "Image vibrates between states, stabilizing when observed (mouse hover).",
+  "params": [
+    {
+      "id": "chaos_speed",
+      "name": "Oscillation Speed",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "chaos_amount",
+      "name": "Chaos Probability",
+      "default": 0.7,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "stability_radius",
+      "name": "Observation Radius",
+      "default": 0.2,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "rgb_split",
+      "name": "RGB Split",
+      "default": 0.3,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "glitch"
+  ]
+}


### PR DESCRIPTION
This PR adds two new shaders to the `interactive-mouse` collection:

1.  **Quantum Superposition**: A shader that simulates a quantum state where the image glitches and vibrates between two states (normal and inverted/shifted). The mouse acts as an "observer," collapsing the wavefunction and stabilizing the image in a radius around the cursor.
2.  **Cyber Hex Armor**: A visual effect that overlays a hexagonal grid "armor" on the image. As the mouse moves, the armor plates retract (scale down) to reveal the underlying image, creating a sci-fi reveal effect.

Both shaders are registered in the shader list and are configurable via parameters.

---
*PR created automatically by Jules for task [9260928084591529916](https://jules.google.com/task/9260928084591529916) started by @ford442*