### PR TITLE
Add new interactive shaders: Radial Hex Lens and Sphere Projection

### DIFF
--- a/public/shaders/radial-hex-lens.wgsl
+++ b/public/shaders/radial-hex-lens.wgsl
@@ -1,0 +1,86 @@
+struct Uniforms {
+    time: f32,
+    resolution: vec2<f32>,
+    mouse: vec2<f32>,
+    scale: f32,
+    radius: f32,
+    distortion: f32,
+};
+
+@group(0) @binding(0) var<uniform> uni: Uniforms;
+@group(0) @binding(1) var mySampler: sampler;
+@group(0) @binding(2) var myTexture: texture_2d<f32>;
+
+fn get_hex_center(uv: vec2<f32>, scale: f32) -> vec2<f32> {
+    let r = vec2<f32>(1.0, 1.7320508); // 1.0, sqrt(3.0)
+    let h = r * 0.5;
+
+    // Divide space into a grid
+    let spacing = vec2<f32>(scale, scale * r.y);
+
+    let a = (fract(uv / spacing) - 0.5) * spacing;
+    let b = (fract((uv - spacing * 0.5) / spacing) - 0.5) * spacing;
+
+    let center_a = uv - a;
+    let center_b = uv - b;
+
+    if (dot(a, a) < dot(b, b)) {
+        return center_a;
+    } else {
+        return center_b;
+    }
+}
+
+@fragment
+fn main(@builtin(position) FragCoord: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = FragCoord.xy / uni.resolution;
+    var uv_corrected = uv;
+    uv_corrected.x = uv_corrected.x * (uni.resolution.x / uni.resolution.y); // Fix aspect for math
+
+    let mouse_corrected = vec2<f32>(
+        uni.mouse.x * (uni.resolution.x / uni.resolution.y),
+        uni.mouse.y
+    );
+
+    // Lens Distortion
+    let offset = uv_corrected - mouse_corrected;
+    let dist = length(offset);
+
+    // Nonlinear zoom: bulge out near mouse
+    // Map dist to new_dist
+    let effect_radius = uni.radius * 1.5; // Scale up a bit to be useful
+    let strength = uni.distortion;
+
+    // Simple bulge: displacement direction is -offset (pull in) or +offset (push out)
+    // Fisheye usually pulls UVs inward to zoom center.
+    // New UV = Center + Offset * (1.0 - Strength * Falloff)
+
+    let falloff = smoothstep(effect_radius, 0.0, dist);
+    let zoom_factor = 1.0 - strength * falloff * 0.5; // Max 0.5x zoom (2x mag)
+
+    let distorted_pos = mouse_corrected + offset * zoom_factor;
+
+    // Back to 0-1 UV space for sampling?
+    // Wait, hex grid needs aspect corrected space to be regular hexes.
+
+    // Hex Pixelate
+    // Map 0.0-1.0 slider to useful scale (e.g. 0.01 to 0.1)
+    let hex_size = mix(0.01, 0.1, uni.scale);
+
+    // Determine hex center in aspect-corrected space
+    let center = get_hex_center(distorted_pos, hex_size);
+
+    // Convert back to UV space
+    var sample_uv = center;
+    sample_uv.x = sample_uv.x / (uni.resolution.x / uni.resolution.y);
+
+    // Edge darkening for hexes (optional, adds style)
+    let dist_to_center = length(distorted_pos - center);
+    let hex_mask = smoothstep(hex_size * 0.5, hex_size * 0.45, dist_to_center);
+
+    // Sample texture
+    // Mirror repeat to handle edges
+    let color = textureSample(myTexture, mySampler, sample_uv);
+
+    return color * hex_mask;
+}

--- a/public/shaders/sphere-projection.wgsl
+++ b/public/shaders/sphere-projection.wgsl
@@ -1,0 +1,113 @@
+struct Uniforms {
+    time: f32,
+    resolution: vec2<f32>,
+    mouse: vec2<f32>,
+    zoom: f32,
+    rotation: f32,
+    light: f32,
+};
+
+@group(0) @binding(0) var<uniform> uni: Uniforms;
+@group(0) @binding(1) var mySampler: sampler;
+@group(0) @binding(2) var myTexture: texture_2d<f32>;
+
+const PI: f32 = 3.14159265359;
+
+@fragment
+fn main(@builtin(position) FragCoord: vec4<f32>) -> @location(0) vec4<f32> {
+    // Normalized device coordinates (-1 to 1)
+    let uv = (FragCoord.xy * 2.0 - uni.resolution.xy) / min(uni.resolution.x, uni.resolution.y);
+
+    // Camera Setup
+    // Camera is at (0, 0, -dist) look at (0, 0, 0)
+    // Zoom param controls distance. Default zoom 1.0 -> dist 2.5
+    let dist = 3.0 / max(0.01, uni.zoom);
+    let ro = vec3<f32>(0.0, 0.0, -dist);
+    let rd = normalize(vec3<f32>(uv, 1.0)); // FOV related to Z component
+
+    // Sphere Intersection
+    // Sphere center (0,0,0), radius 1.0
+    let radius = 1.0;
+
+    // Ray-Sphere intersection analytic solution
+    // |ro + t*rd|^2 = r^2
+    // dot(ro, ro) + 2*t*dot(ro, rd) + t^2*dot(rd, rd) = r^2
+    // t^2 + 2*b*t + c = 0
+
+    let b = dot(ro, rd);
+    let c = dot(ro, ro) - radius * radius;
+    let h = b * b - c;
+
+    if (h < 0.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0); // Background color
+    }
+
+    let t = -b - sqrt(h);
+    let p = ro + rd * t;
+    let n = normalize(p); // Normal is just p for unit sphere at origin
+
+    // UV Mapping (Equirectangular)
+    // Map normal to longitude/latitude
+    // atan2(z, x) returns angle in [-PI, PI]
+    // acos(y) returns angle in [0, PI]
+
+    // We want to rotate the sphere based on mouse.
+    // Instead of rotating geometry, we offset the UVs.
+
+    // Interaction: Mouse X rotates Yaw (Longitude), Mouse Y rotates Pitch (Latitude)
+    let mouse_rot_x = (uni.mouse.x - 0.5) * 2.0 * PI; // -PI to PI
+    let mouse_rot_y = (uni.mouse.y - 0.5) * PI;       // -PI/2 to PI/2
+
+    // Auto rotation
+    let auto_rot = uni.time * uni.rotation;
+
+    // Note: To properly rotate 3D, we should rotate the Normal 'n' using a rotation matrix
+    // BEFORE mapping to UV. UV offset is a cheap hack that distorts at poles.
+    // Let's do proper rotation matrix for Yaw (Y-axis) and Pitch (X-axis).
+
+    // Rotate Y (Yaw) - controlled by Mouse X + Auto
+    let yaw = -mouse_rot_x - auto_rot;
+    let cy = cos(yaw);
+    let sy = sin(yaw);
+    let rotY = mat3x3<f32>(
+        cy, 0.0, sy,
+        0.0, 1.0, 0.0,
+        -sy, 0.0, cy
+    );
+
+    // Rotate X (Pitch) - controlled by Mouse Y
+    let pitch = mouse_rot_y;
+    let cx = cos(pitch);
+    let sx = sin(pitch);
+    let rotX = mat3x3<f32>(
+        1.0, 0.0, 0.0,
+        0.0, cx, -sx,
+        0.0, sx, cx
+    );
+
+    let n_rot = rotX * (rotY * n);
+
+    // Standard mapping
+    let u = atan2(n_rot.z, n_rot.x) / (2.0 * PI) + 0.5;
+    let v = acos(clamp(n_rot.y, -1.0, 1.0)) / PI;
+
+    // Sample texture
+    // Fix mirror/repeat issues at seam?
+    // Texture sampler usually handles wrapping if set to 'repeat'.
+    // If clamped, we might see a seam. Assuming standard sampler is Repeat or Clamp.
+    // Use fract just in case.
+    let tex_uv = vec2<f32>(fract(u), clamp(v, 0.0, 1.0));
+
+    var color = textureSample(myTexture, mySampler, tex_uv);
+
+    // Lighting
+    // Directional light from camera view (0,0,-1) roughly
+    let lightDir = normalize(vec3<f32>(-0.5, 0.5, -1.0));
+    let diff = max(0.0, dot(n, lightDir));
+
+    // Ambient
+    let ambient = 0.2;
+    let lighting = mix(1.0, ambient + diff, uni.light);
+
+    return vec4<f32>(color.rgb * lighting, 1.0);
+}

--- a/shader_definitions/interactive-mouse/radial-hex-lens.json
+++ b/shader_definitions/interactive-mouse/radial-hex-lens.json
@@ -1,0 +1,31 @@
+{
+  "id": "radial-hex-lens",
+  "name": "Radial Hex Lens",
+  "url": "shaders/radial-hex-lens.wgsl",
+  "category": "image",
+  "description": "A hexagonal mosaic that distorts and magnifies around the mouse position.",
+  "features": ["mouse-driven"],
+  "params": [
+    {
+      "id": "scale",
+      "name": "Hex Scale",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "radius",
+      "name": "Lens Radius",
+      "default": 0.4,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "distortion",
+      "name": "Distortion",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ]
+}

--- a/shader_definitions/interactive-mouse/sphere-projection.json
+++ b/shader_definitions/interactive-mouse/sphere-projection.json
@@ -1,0 +1,31 @@
+{
+  "id": "sphere-projection",
+  "name": "Sphere Projection",
+  "url": "shaders/sphere-projection.wgsl",
+  "category": "image",
+  "description": "Projects the image onto a 3D sphere that can be rotated with the mouse.",
+  "features": ["mouse-driven", "3d"],
+  "params": [
+    {
+      "id": "zoom",
+      "name": "Sphere Zoom",
+      "default": 0.6,
+      "min": 0.1,
+      "max": 2.0
+    },
+    {
+      "id": "rotation",
+      "name": "Spin Speed",
+      "default": 0.0,
+      "min": -1.0,
+      "max": 1.0
+    },
+    {
+      "id": "light",
+      "name": "Lighting",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ]
+}


### PR DESCRIPTION
Added two new mouse-interactive shaders:
1. **Radial Hex Lens**: A hexagonal mosaic that distorts and zooms based on mouse position.
2. **Sphere Projection**: Projects the image onto a rotatable 3D sphere.

Both are registered in `interactive-mouse` category and verified to load in the UI.

---
*PR created automatically by Jules for task [3912743563992628318](https://jules.google.com/task/3912743563992628318) started by @ford442*