### PR TITLE
Add Radial Slit Scan and Glass Bead Curtain shaders

### DIFF
--- a/public/shaders/glass-bead-curtain.wgsl
+++ b/public/shaders/glass-bead-curtain.wgsl
@@ -1,0 +1,108 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let mouse = u.zoom_config.yz;
+
+    // Params
+    let bead_size = mix(10.0, 100.0, u.zoom_params.x);
+    let refraction_str = u.zoom_params.y;
+    let tension = u.zoom_params.z;
+
+    // Mouse Interaction
+    // We displace the UVs used for the grid lookup to simulate the curtain opening
+
+    // Correct mouse position for aspect ratio for distance calculation
+    let aspect = resolution.x / resolution.y;
+    var center = mouse;
+    if (center.x < 0.0) { center = vec2<f32>(0.5, 0.5); } // Default center if no mouse
+
+    let dist_vec = (uv - center) * vec2<f32>(aspect, 1.0);
+    let dist = length(dist_vec);
+
+    // Repel force
+    let repel_radius = 0.3;
+    let interact = smoothstep(repel_radius, 0.0, dist);
+
+    // Displacement direction: away from mouse
+    // Scale by tension
+    let disp = normalize(dist_vec) * interact * tension * 0.2;
+
+    // So active_uv = uv - disp.
+    let active_uv = uv - vec2<f32>(disp.x / aspect, disp.y);
+
+    // Now grid logic on active_uv
+    let px_active = active_uv * resolution;
+    let cell_uv = fract(px_active / bead_size) - 0.5; // -0.5 to 0.5
+
+    // Circular mask for bead
+    // We use cell_uv directly which is proportional to bead size
+    // cell_uv runs from -0.5 to 0.5
+    let r = length(cell_uv);
+
+    var final_uv = active_uv;
+    var alpha = 1.0;
+
+    if (r < 0.5) {
+        // Inside bead: Refract
+        // Sphere height z
+        let z = sqrt(0.25 - r*r);
+        // Normal of sphere
+        let normal = normalize(vec3<f32>(cell_uv, z));
+
+        // Refraction vector (simplified)
+        // Offset UV based on xy normal
+        final_uv = active_uv - normal.xy * refraction_str * 0.5;
+    } else {
+        // Gap
+        // Dim the gaps
+        final_uv = active_uv;
+        alpha = 0.0; // Transparent/Black gaps
+    }
+
+    var color = textureSampleLevel(readTexture, u_sampler, final_uv, 0.0);
+
+    // Apply alpha to darken gaps
+    color = color * alpha;
+
+    // Add simple specular highlight on beads
+    if (r < 0.5) {
+        let light_dir = normalize(vec3<f32>(-0.5, -0.5, 1.0));
+        let z = sqrt(0.25 - r*r);
+        let normal = normalize(vec3<f32>(cell_uv, z));
+        let spec = pow(max(dot(normal, light_dir), 0.0), 20.0);
+        color = color + vec4<f32>(spec * 0.5);
+    }
+
+    textureStore(writeTexture, global_id.xy, color);
+
+    // Pass depth
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(d, 0.0, 0.0, 0.0));
+}

--- a/public/shaders/radial-slit-scan.wgsl
+++ b/public/shaders/radial-slit-scan.wgsl
@@ -1,0 +1,99 @@
+// --- COPY PASTE THIS HEADER INTO EVERY NEW SHADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+// ---------------------------------------------------
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) {
+        return;
+    }
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let time = u.config.x;
+    let mouse = u.zoom_config.yz;
+
+    let scan_speed = u.zoom_params.x;
+    let scan_width = u.zoom_params.y;
+    let decay = u.zoom_params.z;
+    let softness = u.zoom_params.w;
+
+    // Calculate aspect ratio corrected distance from mouse
+    let aspect = resolution.x / resolution.y;
+
+    // Handle mouse not present (negative values)
+    var center = mouse;
+    if (center.x < 0.0) {
+        center = vec2<f32>(0.5, 0.5);
+    }
+
+    let dist_vec = (uv - center) * vec2<f32>(aspect, 1.0);
+    let dist = length(dist_vec);
+
+    // Scan radius moves over time
+    // We want it to loop every few seconds depending on speed
+    // Speed 0 -> Slow, Speed 1 -> Fast
+    let loop_speed = mix(0.1, 2.0, scan_speed);
+    let radius = fract(time * loop_speed);
+
+    // Scale radius to cover screen (max dist from center to corner is approx 1.4 * aspect)
+    let max_dist = 1.5 * aspect;
+    let current_scan_dist = radius * max_dist;
+
+    let delta = abs(dist - current_scan_dist);
+    let width = scan_width * 0.5; // Base width
+
+    let current_color = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    // dataTextureC contains the previous frame (feedback)
+    var history_color = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0);
+
+    // Determine if we are updating this pixel
+    // Using smoothstep for softness
+    let half_width = width * 0.5;
+    let soft_edge = softness * half_width;
+
+    var update_factor = 0.0;
+
+    if (delta < half_width) {
+        if (softness > 0.001) {
+            update_factor = smoothstep(half_width, half_width - soft_edge, delta);
+        } else {
+            update_factor = 1.0;
+        }
+    }
+
+    var final_color = mix(history_color, current_color, update_factor);
+
+    // Apply decay (slowly fade to current time everywhere)
+    if (decay > 0.0) {
+        final_color = mix(final_color, current_color, decay * 0.05);
+    }
+
+    textureStore(writeTexture, global_id.xy, final_color);
+
+    // Write to history for next frame
+    // We use dataTextureA for the "next" history buffer
+    textureStore(dataTextureA, global_id.xy, final_color);
+
+    // Pass depth through
+    let d = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, global_id.xy, vec4<f32>(d, 0.0, 0.0, 0.0));
+}

--- a/shader_definitions/interactive-mouse/glass-bead-curtain.json
+++ b/shader_definitions/interactive-mouse/glass-bead-curtain.json
@@ -1,0 +1,33 @@
+{
+  "id": "glass-bead-curtain",
+  "name": "Glass Bead Curtain",
+  "url": "shaders/glass-bead-curtain.wgsl",
+  "category": "image",
+  "description": "A curtain of refractive glass beads that parts for the cursor.",
+  "params": [
+    {
+      "id": "size",
+      "name": "Bead Size",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "refraction",
+      "name": "Refraction",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "tension",
+      "name": "Interact Tension",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven"
+  ]
+}

--- a/shader_definitions/interactive-mouse/radial-slit-scan.json
+++ b/shader_definitions/interactive-mouse/radial-slit-scan.json
@@ -1,0 +1,41 @@
+{
+  "id": "radial-slit-scan",
+  "name": "Radial Slit Scan",
+  "url": "shaders/radial-slit-scan.wgsl",
+  "category": "image",
+  "description": "A time-displacement effect that radiates from the cursor.",
+  "params": [
+    {
+      "id": "speed",
+      "name": "Scan Speed",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "width",
+      "name": "Scan Width",
+      "default": 0.2,
+      "min": 0.01,
+      "max": 1.0
+    },
+    {
+      "id": "decay",
+      "name": "Fade to Now",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 1.0
+    },
+    {
+      "id": "softness",
+      "name": "Edge Softness",
+      "default": 0.1,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ],
+  "features": [
+    "mouse-driven",
+    "feedback"
+  ]
+}


### PR DESCRIPTION
Implemented two new interactive shaders:
1. **Radial Slit Scan**: A time-displacement effect that radiates from the cursor, using feedback buffers to freeze time in concentric rings.
2. **Glass Bead Curtain**: A grid of refractive glass beads that interactively parts/displaces based on mouse proximity.

Verified file creation and registration in `public/shader-lists/interactive-mouse.json`. Frontend verification script confirmed UI loads but shader list population is limited in the headless environment due to lack of WebGPU support.

---
*PR created automatically by Jules for task [14626020867551932545](https://jules.google.com/task/14626020867551932545) started by @ford442*