### PR TITLE
Add Neuro-Cosmos shader plan

### DIFF
--- a/new_shader_plan.md
+++ b/new_shader_plan.md
@@ -1,131 +1,86 @@
-# New Shader Plan: Alien Flora
+# New Shader Plan: Generative: Neuro-Cosmos
 
 ## Concept
+A mesmerizing 3D generative visualization of a "Neuro-Cosmos" — a structure that visually bridges the gap between a biological neural network and the cosmic web of the universe. The scene consists of an infinite, self-repeating 3D web of glowing nodes (neurons/stars) connected by filament-like structures (synapses/dark matter bridges), with pulses of energy traveling through them.
 
-**Title**: Alien Flora
-**ID**: `gen-alien-flora`
-**Category**: `generative`
-**Tags**: `nature`, `plants`, `bioluminescent`, `raymarching`, `3d`, `organic`, `forest`
-
-**Description**:
-An infinite, procedurally generated landscape populated by bioluminescent alien vegetation. The scene features rolling hills, glowing mushroom-like structures, and swaying organic forms. The atmosphere is thick with fog and floating spores, creating a mysterious, otherworldly ambiance.
+## Metadata
+- **ID:** `gen-neuro-cosmos`
+- **Name:** Neuro-Cosmos
+- **Category:** Generative
+- **Tags:** ["network", "neural", "cosmic", "web", "3d", "raymarching", "voronoi", "glowing", "cyber"]
 
 ## Features
+1.  **Infinite 3D Web:** Uses 3D Cellular Noise (Voronoi) metrics to generate an organic, interconnected lattice structure.
+    - `F1` (closest feature point) defines the cell centers (Neurons).
+    - `F2 - F1` (difference between second and first closest) defines the cell boundaries (Synaptic Web).
+2.  **Dynamic Energy Pulses:** Signals travel along the web strands, simulated by modulating the emission based on time and distance from cell centers.
+3.  **Volumetric Glow:** A "fog" accumulation step during raymarching or a post-process glow based on the SDF distance to create a dreamy, ethereal atmosphere.
+4.  **Interactive Camera:** Mouse controls the camera orbit (Yaw/Pitch) to explore the structure.
+5.  **Interactive Excitation:** Mouse clicks or proximity could trigger "bursts" of activity in the network.
 
-1.  **Infinite Terrain**: A raymarched ground plane modulated by noise to create rolling hills and valleys.
-2.  **Procedural Vegetation**:
-    *   **Glowing Mushrooms**: Constructed using Signed Distance Functions (SDFs) for caps and stems, seamlessly blended.
-    *   **Swaying Motion**: Vertex displacement applied to the SDFs to simulate wind or underwater currents.
-3.  **Atmospheric Effects**:
-    *   **Distance Fog**: Fades distant objects into the background color to simulate depth and scale.
-    *   **Volumetric Glow**: Accumulates glow from the bioluminescent parts of the plants.
-4.  **Mouse Interaction**:
-    *   **Mouse X**: Rotates the camera view around the scene (Yaw).
-    *   **Mouse Y**: Adjusts the camera height or pitch, allowing views from ground level or above the canopy.
+## Parameters (Uniforms)
+The shader will utilize the standard `Uniforms` struct:
+- `u.config.x` (Time): Drivers the pulse animation and camera drift.
+- `u.zoom_config.yz` (Mouse): Controls camera rotation.
+- `u.zoom_params`:
+    - `x`: **Network Density** (Scales the Voronoi grid).
+    - `y`: **Pulse Speed** (Speed of energy signals).
+    - `z`: **Glow Intensity** (Brightness of the web and nodes).
+    - `w`: **Connection Thickness** (Adjusts the `F2-F1` threshold for web strands).
 
-## Proposed Code Structure (Draft WGSL)
+## Proposed Code Structure
 
+### 1. Hash Function
+Standard 3D hash for Voronoi feature point generation.
 ```wgsl
-// Uniforms structure
-struct Uniforms {
-    config: vec4<f32>,       // time, aspect, resX, resY
-    zoom_config: vec4<f32>,  // mouseX, mouseY, unused, unused
-    zoom_params: vec4<f32>,  // density, swaySpeed, glowIntensity, colorShift
-};
-
-// SDF Primitives
-fn sdSphere(p: vec3<f32>, s: f32) -> f32 { ... }
-fn sdCappedCylinder(p: vec3<f32>, h: f32, r: f32) -> f32 { ... }
-
-// Smooth Min for organic blending
-fn smin(a: f32, b: f32, k: f32) -> f32 { ... }
-
-// Scene Map
-fn map(p: vec3<f32>) -> vec2<f32> {
-    // 1. Terrain
-    let terrainHeight = sin(p.x * 0.1) * sin(p.z * 0.1) * 2.0;
-    let d_terrain = p.y - terrainHeight;
-
-    // 2. Vegetation (Domain Repetition)
-    let cell_size = 8.0;
-    let id = floor(p.xz / cell_size);
-    let q = vec3<f32>(
-        (fract(p.x / cell_size) - 0.5) * cell_size,
-        p.y - terrainHeight, // Plant grows from ground
-        (fract(p.z / cell_size) - 0.5) * cell_size
-    );
-
-    // Randomize per cell
-    let rand = fract(sin(dot(id, vec2<f32>(12.9898, 78.233))) * 43758.5453);
-
-    // Mushroom SDF
-    // Swaying
-    let sway = sin(u.config.x * u.zoom_params.y + p.y) * 0.2;
-    let stem = sdCappedCylinder(q + vec3<f32>(sway, -2.0, 0.0), 2.0, 0.3 + rand * 0.2);
-    let cap = sdSphere(q + vec3<f32>(sway, -4.0 - rand, 0.0), 1.5 + rand);
-    let d_plant = smin(stem, cap, 0.5);
-
-    // Combine
-    let d = min(d_terrain, d_plant);
-    return vec2<f32>(d, 1.0); // 1.0 = material ID
-}
-
-// Main Raymarching Loop
-fn main(...) {
-    // Camera Setup based on Mouse
-    // Raymarch loop
-    // Lighting (Dark ambient + point lights from glowing caps)
-    // Fog application
-    // Output
+fn hash33(p: vec3<f32>) -> vec3<f32> {
+    let p3 = fract(p * vec3<f32>(.1031, .1030, .0973));
+    let p3_mod = p3 + dot(p3, p3.yxz + 33.33);
+    return fract((p3_mod.xxy + p3_mod.yxx) * p3_mod.zyx);
 }
 ```
 
-## JSON Configuration
+### 2. Voronoi / SDF Logic
+Calculate `F1` and `F2` distances to generate the geometry.
+```wgsl
+fn voronoiMap(p: vec3<f32>) -> vec4<f32> {
+    // Returns vec4(d, cell_id_hash, edge_dist, ...)
+    // ... implementation of 3x3x3 neighbor search ...
+    // Calculate d = min(d, distance(p, neighbor_pos))
+    // Keep track of F1 and F2
+    // Result:
+    // Dist to Neuron Surface = F1 - radius
+    // Dist to Synapse = (F2 - F1) - thickness
+    // Smooth min to blend them.
+}
+```
 
-Target file: `shader_definitions/generative/gen-alien-flora.json`
+### 3. Raymarching
+Standard raymarching loop with:
+- `map()` calls.
+- Accumulation of "glow" (translucency/additive color) when the ray is close to geometry, to simulate volume.
+- Early exit on hit or max distance.
 
+### 4. Coloring
+- **Nodes:** Bright white/gold centers fading to blue/purple.
+- **Strands:** Darker blue/cyan, lighting up with pulses.
+- **Pulse Logic:** `sin(dist_along_strand - time * speed)` to modulate brightness.
+
+## JSON Configuration (`gen-neuro-cosmos.json`)
 ```json
 {
-  "id": "gen-alien-flora",
-  "name": "Alien Flora",
-  "url": "shaders/gen-alien-flora.wgsl",
-  "category": "generative",
-  "description": "An infinite procedural forest of bioluminescent alien vegetation with swaying mushrooms and atmospheric fog.",
-  "tags": ["nature", "plants", "bioluminescent", "raymarching", "3d", "organic", "forest"],
-  "features": ["mouse-driven"],
-  "params": [
-    {
-      "id": "param1",
-      "name": "Vegetation Density", // Maps to zoom_params.x (Note: domain repetition size is fixed in code, maybe modulate visible plants)
-      "default": 1.0,
-      "min": 0.0,
-      "max": 1.0,
-      "step": 0.1
-    },
-    {
-      "id": "param2",
-      "name": "Sway Speed", // Maps to zoom_params.y
-      "default": 1.0,
-      "min": 0.0,
-      "max": 5.0,
-      "step": 0.1
-    },
-    {
-      "id": "param3",
-      "name": "Glow Intensity", // Maps to zoom_params.z
-      "default": 1.5,
-      "min": 0.5,
-      "max": 3.0,
-      "step": 0.1
-    },
-    {
-      "id": "param4",
-      "name": "Color Shift", // Maps to zoom_params.w
-      "default": 0.0,
-      "min": 0.0,
-      "max": 1.0,
-      "step": 0.05
+  "name": "Neuro-Cosmos",
+  "id": "gen-neuro-cosmos",
+  "type": "generative",
+  "source": "shaders/gen-neuro-cosmos.wgsl",
+  "uniforms": {
+    "zoom_params": {
+      "x": 1.0,
+      "y": 1.0,
+      "z": 0.5,
+      "w": 0.1
     }
-  ]
+  },
+  "tags": ["network", "neural", "cosmic", "3d", "generative"]
 }
 ```


### PR DESCRIPTION
Added a detailed plan for a new generative shader "Neuro-Cosmos" to `new_shader_plan.md`. The plan describes a 3D raymarched scene visualizing a cosmic neural network using cellular noise metrics, with features for interactive camera control and energy pulses. It includes proposed WGSL code snippets and JSON configuration.

---
*PR created automatically by Jules for task [1056575867183238850](https://jules.google.com/task/1056575867183238850) started by @ford442*