### PR TITLE
fix(wasm): update WebGPU RequestAdapter/Device signatures and fix syntax error

### DIFF
--- a/wasm_renderer/main.cpp
+++ b/wasm_renderer/main.cpp
@@ -264,7 +264,7 @@ extern "C" {
         wgpu::Instance instance = wgpu::CreateInstance(nullptr);
         wgpu::RequestAdapterOptions opts{};
         opts.powerPreference = wgpu::PowerPreference::HighPerformance;
-        instance.RequestAdapter(&opts, onAdapterRequest, nullptr);
+        instance.RequestAdapter(&opts, wgpu::CallbackMode::AllowSpontaneous, onAdapterRequest, nullptr);
     }
 
     EMSCRIPTEN_KEEPALIVE
@@ -304,8 +304,9 @@ void onAdapterRequest(WGPURequestAdapterStatus status, WGPUAdapter cAdapter, con
     wgpu::Adapter adapter = wgpu::Adapter::Acquire(cAdapter);
 
     wgpu::DeviceDescriptor devDesc{};
-    adapter.RequestDevice(&devDesc, onDeviceRequest, nullptr);
-  
+    adapter.RequestDevice(&devDesc, wgpu::CallbackMode::AllowSpontaneous, onDeviceRequest, nullptr);
+}
+
 EMSCRIPTEN_KEEPALIVE
 void loadImageData(const uint8_t* data, int width, int height) {
     if (!g_renderer) {


### PR DESCRIPTION
- Added missing `wgpu::CallbackMode::AllowSpontaneous` to `RequestAdapter` and `RequestDevice` calls to comply with updated Emscripten/Dawn C++ bindings.
- Added missing closing brace `}` to `onAdapterRequest` function to resolve cascading function definition errors.

---
*PR created automatically by Jules for task [8582299578388744968](https://jules.google.com/task/8582299578388744968) started by @ford442*