### PR TITLE
fix: Resolve WGSL compiler error in vhs-tracking shader

### DIFF
--- a/public/shaders/vhs-tracking.wgsl
+++ b/public/shaders/vhs-tracking.wgsl
@@ -32,7 +32,7 @@ fn hash2(p: vec2<f32>) -> f32 {
 }
 
 fn hash3(p: vec3<f32>) -> f32 {
-    return fract(sin(dot(p, vec2<f32>(12.9898, 78.233))) * 43758.5453);
+    return fract(sin(dot(p, vec3<f32>(12.9898, 78.233, 45.164))) * 43758.5453);
 }
 
 // Simple noise function


### PR DESCRIPTION
Fixed the WGSL compilation error that was preventing the `vhs-tracking` shader from working.

The error was caused by a dimension mismatch within the `hash3` function, where the `dot()` product was called with a `vec3<f32>` (the parameter `p`) and a `vec2<f32>` (a hardcoded magic number constant).

The fix was to update the second argument to be a `vec3<f32>` by adding a third pseudo-random float component (`45.164`). Tests and builds confirmed that this resolves the compile error.

---
*PR created automatically by Jules for task [17739364005077968175](https://jules.google.com/task/17739364005077968175) started by @ford442*