### PR TITLE
Fix WGSL swizzle assignments

### DIFF
--- a/public/shaders/astral-kaleidoscope-grokcf1.wgsl
+++ b/public/shaders/astral-kaleidoscope-grokcf1.wgsl
@@ -184,7 +184,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // ✨ grokcf1 UPGRADE: Time-driven hue evolution + radius shift
     let timeHue = sin(time * 0.05) * 0.5;
     hsl.x = fract(hsl.x + timeHue + r * hueShift);
-    hsl.s = min(hsl.s * 1.3, 1.0); // Slightly more saturation boost
+    hsl.y = min(hsl.y * 1.3, 1.0); // Slightly more saturation boost
     color = hsl2rgb(hsl);
     
     // -----------------------------------------------------------------

--- a/public/shaders/gen-bismuth-crystal-citadel.wgsl
+++ b/public/shaders/gen-bismuth-crystal-citadel.wgsl
@@ -150,8 +150,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     
     var rd = normalize(vec3<f32>(uv, 1.0));
     
-    rd.yz = rotX * rd.yz;
-    rd.xz = rotY * rd.xz;
+    let temp_rd_yz = rotX * rd.yz;
+    rd.y = temp_rd_yz.x;
+    rd.z = temp_rd_yz.y;
+
+    let temp_rd_xz = rotY * rd.xz;
+    rd.x = temp_rd_xz.x;
+    rd.z = temp_rd_xz.y;
+
     
     let ta = vec3<f32>(0.0, time * 2.0 + 2.0, 0.0);
     let ww = normalize(ta - ro);

--- a/public/shaders/gen-celestial-forge.wgsl
+++ b/public/shaders/gen-celestial-forge.wgsl
@@ -268,8 +268,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let mouseX = (u.zoom_config.y / dims.x) * 2.0 - 1.0;
     let mouseY = (u.zoom_config.z / dims.y) * 2.0 - 1.0;
     
-    ro.yz = rot(mouseY * 1.5) * ro.yz;
-    ro.xz = rot(mouseX * 3.14 + time * 0.1) * ro.xz;
+    let temp_ro_yz = rot(mouseY * 1.5) * ro.yz;
+    ro.y = temp_ro_yz.x;
+    ro.z = temp_ro_yz.y;
+
+    let temp_ro_xz = rot(mouseX * 3.14 + time * 0.1) * ro.xz;
+    ro.x = temp_ro_xz.x;
+    ro.z = temp_ro_xz.y;
+
     
     // Camera look-at
     let ta = vec3<f32>(0.0, 0.0, 0.0);

--- a/public/shaders/gen-fractured-monolith.wgsl
+++ b/public/shaders/gen-fractured-monolith.wgsl
@@ -86,7 +86,10 @@ fn map(p: vec3<f32>) -> vec3<f32> {
     // Levitation bobbing
     bp.y -= sin(time * levSpeed) * 0.5 + 2.0;
     // Slow global rotation
-    bp.xz = rot(time * 0.2 * rotSpeed) * bp.xz;
+    let temp_bp_xz = rot(time * 0.2 * rotSpeed) * bp.xz;
+    bp.x = temp_bp_xz.x;
+    bp.z = temp_bp_xz.y;
+
 
     // Base shape: Tall box
     let baseBox = sdBox(bp, vec3<f32>(1.5, 4.0, 1.5));
@@ -105,8 +108,14 @@ fn map(p: vec3<f32>) -> vec3<f32> {
 
     // Individual piece rotation
     let localRot = (hash31(cellId + vec3<f32>(1.0)) - 0.5) * time * rotSpeed;
-    fp.xz = rot(localRot) * fp.xz;
-    fp.xy = rot(localRot * 0.5) * fp.xy;
+    let temp_fp_xz = rot(localRot) * fp.xz;
+    fp.x = temp_fp_xz.x;
+    fp.z = temp_fp_xz.y;
+
+    let temp_fp_xy = rot(localRot * 0.5) * fp.xy;
+    fp.x = temp_fp_xy.x;
+    fp.y = temp_fp_xy.y;
+
 
     // Carve out cracks
     let crackNoise = noise(bp * 3.0);
@@ -153,8 +162,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let mouseX = (u.zoom_config.y / dims.x) * 2.0 - 1.0;
     let mouseY = (u.zoom_config.z / dims.y) * 2.0 - 1.0;
 
-    ro.yz = rot(mouseY * 1.0) * ro.yz;
-    ro.xz = rot(mouseX * 3.14) * ro.xz;
+    let temp_ro_yz = rot(mouseY * 1.0) * ro.yz;
+    ro.y = temp_ro_yz.x;
+    ro.z = temp_ro_yz.y;
+
+    let temp_ro_xz = rot(mouseX * 3.14) * ro.xz;
+    ro.x = temp_ro_xz.x;
+    ro.z = temp_ro_xz.y;
+
 
     let ta = vec3<f32>(0.0, 2.0, 0.0);
     let ww = normalize(ta - ro);

--- a/public/shaders/gen-magnetic-ferrofluid.wgsl
+++ b/public/shaders/gen-magnetic-ferrofluid.wgsl
@@ -104,8 +104,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let mouseX = (u.zoom_config.y / dims.x) * 2.0 - 1.0;
     let mouseY = (u.zoom_config.z / dims.y) * 2.0 - 1.0;
 
-    ro.yz = rot(mouseY * 1.5) * ro.yz;
-    ro.xz = rot(mouseX * 3.14 + u.config.x * 0.2) * ro.xz;
+    let temp_ro_yz = rot(mouseY * 1.5) * ro.yz;
+    ro.y = temp_ro_yz.x;
+    ro.z = temp_ro_yz.y;
+
+    let temp_ro_xz = rot(mouseX * 3.14 + u.config.x * 0.2) * ro.xz;
+    ro.x = temp_ro_xz.x;
+    ro.z = temp_ro_xz.y;
+
 
     let ta = vec3<f32>(0.0, 0.0, 0.0);
     let ww = normalize(ta - ro);

--- a/public/shaders/gen-micro-cosmos.wgsl
+++ b/public/shaders/gen-micro-cosmos.wgsl
@@ -74,8 +74,14 @@ fn map(pos: vec3<f32>) -> vec2<f32> {
     var localP = q - offset;
 
     // Random rotation
-    localP.xy = rotate2D(localP.xy, time * (0.1 + rand * 0.2) + rand * 6.28);
-    localP.xz = rotate2D(localP.xz, time * (0.05 + rand * 0.1));
+    let temp_localP_xy = rotate2D(localP.xy, time * (0.1 + rand * 0.2) + rand * 6.28);
+    localP.x = temp_localP_xy.x;
+    localP.y = temp_localP_xy.y;
+
+    let temp_localP_xz = rotate2D(localP.xz, time * (0.05 + rand * 0.1));
+    localP.x = temp_localP_xz.x;
+    localP.z = temp_localP_xz.y;
+
 
     // Cell Body (Ellipsoid)
     // Random scale

--- a/public/shaders/gen-quantum-mycelium.wgsl
+++ b/public/shaders/gen-quantum-mycelium.wgsl
@@ -81,9 +81,15 @@ fn map(p: vec3<f32>) -> vec2<f32> {
 
     // Spatial folding for branching illusion
     q = abs(q) - vec3<f32>(1.0 / density, 1.0 / density, 1.0 / density);
-    q.xy = rot(0.5) * q.xy;
+    let temp_q_xy = rot(0.5) * q.xy;
+    q.x = temp_q_xy.x;
+    q.y = temp_q_xy.y;
+
     q = abs(q) - vec3<f32>(0.5 / density, 0.5 / density, 0.5 / density);
-    q.xz = rot(0.3) * q.xz;
+    let temp_q_xz = rot(0.3) * q.xz;
+    q.x = temp_q_xz.x;
+    q.z = temp_q_xz.y;
+
 
     // Base Cylinder SDF
     var d = sdCylinder(q, vec3<f32>(0.0, 0.0, 0.15 / density));

--- a/public/shaders/gen-quantum-neural-lace.wgsl
+++ b/public/shaders/gen-quantum-neural-lace.wgsl
@@ -67,8 +67,14 @@ fn map(p: vec3<f32>) -> vec2<f32> {
     let node_size = cell_size * 0.15;
     // Rotate octahedron slightly over time for dynamic feel
     var p_rot = local_p;
-    p_rot.xz = rotate2D(p_rot.xz, u.config.x * 0.5);
-    p_rot.xy = rotate2D(p_rot.xy, u.config.x * 0.3);
+    let temp_p_rot_xz = rotate2D(p_rot.xz, u.config.x * 0.5);
+    p_rot.x = temp_p_rot_xz.x;
+    p_rot.z = temp_p_rot_xz.y;
+
+    let temp_p_rot_xy = rotate2D(p_rot.xy, u.config.x * 0.3);
+    p_rot.x = temp_p_rot_xy.x;
+    p_rot.y = temp_p_rot_xy.y;
+
 
     let d_node = sdOctahedron(p_rot, node_size);
 

--- a/public/shaders/gen-silica-tsunami.wgsl
+++ b/public/shaders/gen-silica-tsunami.wgsl
@@ -88,8 +88,14 @@ fn map(p: vec3<f32>) -> vec3<f32> {
 
     // Rotate particle based on cell
     let h = hash31(vec3<f32>(cell.x, 0.0, cell.z));
-    bp.xz = rot(g_time * (0.5 + h) + h * 6.28) * bp.xz;
-    bp.xy = rot(g_time * 0.3 + h * 6.28) * bp.xy;
+    let temp_bp_xz = rot(g_time * (0.5 + h) + h * 6.28) * bp.xz;
+    bp.x = temp_bp_xz.x;
+    bp.z = temp_bp_xz.y;
+
+    let temp_bp_xy = rot(g_time * 0.3 + h * 6.28) * bp.xy;
+    bp.x = temp_bp_xy.x;
+    bp.y = temp_bp_xy.y;
+
 
     // Base shape: slightly rounded boxes
     let boxSize = particleDensity * 0.4 * (0.5 + 0.5 * h);
@@ -129,8 +135,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     var ro = vec3<f32>(0.0, 5.0, -10.0);
 
     // Orbit camera with mouse
-    ro.xz = rot(mX * 2.0) * ro.xz;
-    ro.yz = rot(mY * 1.0) * ro.yz;
+    let temp_ro_xz = rot(mX * 2.0) * ro.xz;
+    ro.x = temp_ro_xz.x;
+    ro.z = temp_ro_xz.y;
+
+    let temp_ro_yz = rot(mY * 1.0) * ro.yz;
+    ro.y = temp_ro_yz.x;
+    ro.z = temp_ro_yz.y;
+
 
     let ta = vec3<f32>(0.0, 0.0, 0.0);
     let ww = normalize(ta - ro);

--- a/public/shaders/gen-singularity-forge.wgsl
+++ b/public/shaders/gen-singularity-forge.wgsl
@@ -93,10 +93,22 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     // Camera rotation
     let camRotX = rotate2D(0.3);
     let camRotY = rotate2D(time * 0.1);
-    ro.yz = camRotX * ro.yz;
-    rd.yz = camRotX * rd.yz;
-    ro.xz = camRotY * ro.xz;
-    rd.xz = camRotY * rd.xz;
+    let temp_ro_yz = camRotX * ro.yz;
+    ro.y = temp_ro_yz.x;
+    ro.z = temp_ro_yz.y;
+
+    let temp_rd_yz = camRotX * rd.yz;
+    rd.y = temp_rd_yz.x;
+    rd.z = temp_rd_yz.y;
+
+    let temp_ro_xz = camRotY * ro.xz;
+    ro.x = temp_ro_xz.x;
+    ro.z = temp_ro_xz.y;
+
+    let temp_rd_xz = camRotY * rd.xz;
+    rd.x = temp_rd_xz.x;
+    rd.z = temp_rd_xz.y;
+
 
     // Mouse Interaction - Additional Gravity Well
     let mouseX = (u.zoom_config.y * 2.0 - 1.0) * res.x / res.y;

--- a/public/shaders/gen-stellar-web-loom.wgsl
+++ b/public/shaders/gen-stellar-web-loom.wgsl
@@ -90,7 +90,10 @@ fn map(pos: vec3<f32>) -> vec2<f32> {
     if (mouseDist < 5.0) {
         let pull = singularityPull * (1.0 - smoothstep(0.0, 5.0, mouseDist));
         let theta = pull * 2.0;
-        p.xy = rot2D(theta) * p.xy;
+        let temp_p_xy = rot2D(theta) * p.xy;
+        p.x = temp_p_xy.x;
+        p.y = temp_p_xy.y;
+
         p.x -= g_mouse.x * pull * 2.0;
         p.y -= g_mouse.y * pull * 2.0;
         p.z -= pull * 2.0;


### PR DESCRIPTION
Fix WGSL vector swizzle characters and vector swizzle assignments

WGSL only supports xyzw and rgba swizzle sets, therefore hsl.s is invalid syntax. Swapped to hsl.y.

WGSL also strictly forbids assigning to subset swizzles, such as vec3.yz = vec2. To fix this, a python script was written and run over all shaders to explode such assignments into individual scalar assignments (i.e. vec3.y = vec2.x; vec3.z = vec2.y). This fixes compile errors in multiple generative shaders.

---
*PR created automatically by Jules for task [7587812990727908730](https://jules.google.com/task/7587812990727908730) started by @ford442*