### PR TITLE
Replace shader API with static JSON configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ import { RenderMode, ShaderEntry, ShaderCategory, InputSource, SlotParams } from
 import { Alucinate, AIStatus, ImageRecord, ShaderRecord } from './AutoDJ';
 import { pipeline, env } from '@xenova/transformers';
 import { SyncMessage, FullState, SYNC_CHANNEL_NAME } from './syncTypes';
-import { listShaders } from './services/shaderApi';
+// @ts-ignore
+import shaderCoordinates from './shader_coordinates.json';
 import './style.css';
 
 // --- Webcam Fun Shaders ---
@@ -293,26 +294,23 @@ function MainApp() {
 
     // --- Load Available Shaders ---
     useEffect(() => {
-        const loadAvailableShaders = async () => {
-            try {
-                const shaders = await listShaders();
-                // Convert API response to ShaderEntry format
-                const entries: ShaderEntry[] = shaders.map(shader => ({
-                    id: shader.id,
-                    name: shader.name,
-                    url: `/shaders/${shader.id}.wgsl`,
-                    category: (shader.id.includes('gen') ? 'generative' : 'image') as ShaderCategory,
-                    description: shader.description,
-                    tags: shader.tags,
-                }));
-                setAvailableModes(entries);
-                console.log(`✅ Loaded ${entries.length} shaders`);
-            } catch (error) {
-                console.warn('Failed to load shaders from API:', error);
-                // Silently fail - shader list will be empty but app won't crash
-            }
-        };
-        loadAvailableShaders();
+        try {
+            // Build shader list from shader_coordinates.json
+            const coordMap = shaderCoordinates as Record<string, any>;
+            const entries: ShaderEntry[] = Object.entries(coordMap).map(([id, data]) => ({
+                id,
+                name: data.name || id,
+                url: `/shaders/${id}.wgsl`,
+                category: (data.category?.includes('gen') || id.includes('gen') ? 'generative' : 'image') as ShaderCategory,
+                description: data.reason || '',
+                tags: data.tags || [],
+            }));
+            setAvailableModes(entries);
+            console.log(`✅ Loaded ${entries.length} shaders from shader_coordinates.json`);
+        } catch (error) {
+            console.warn('Failed to load shaders:', error);
+            // Silently fail - shader list will be empty but app won't crash
+        }
     }, []);
 
     // --- Image Loading ---


### PR DESCRIPTION
## Summary
Replaced the dynamic shader API call with a static JSON configuration file (`shader_coordinates.json`) for loading available shaders. This simplifies the shader loading mechanism by removing the dependency on an external API endpoint.

## Key Changes
- Removed import of `listShaders` from `./services/shaderApi`
- Added import of `shader_coordinates.json` static file
- Converted shader loading from async API call to synchronous JSON parsing
- Updated shader entry mapping to extract data from the JSON structure:
  - Uses `name` field from JSON (falls back to `id`)
  - Determines category from `category` field or `id` pattern
  - Maps `reason` field to shader description
  - Maps `tags` field directly

## Implementation Details
- The `useEffect` hook no longer uses an async function wrapper since the operation is now synchronous
- Error handling is preserved to gracefully handle JSON parsing failures
- The shader URL construction remains unchanged (`/shaders/{id}.wgsl`)
- Console logging updated to reference the new data source

https://claude.ai/code/session_01Hth71oXWrFukvrwPWtqXdY