### PR TITLE
Add loadImage method to RendererManager and update WASM module export

### DIFF
--- a/public/wasm/pixelocity_wasm.js
+++ b/public/wasm/pixelocity_wasm.js
@@ -1,1 +1,1 @@
-var Module = function() { return Promise.resolve({}); }; Module.default = Module; export default Module;
+window.PixelocityWASM = function() { return Promise.resolve({}); };

--- a/src/renderer/RendererManager.ts
+++ b/src/renderer/RendererManager.ts
@@ -150,6 +150,18 @@ export class RendererManager {
     }
   }
 
+  /** Load an image by URL, delegating to whichever renderer is active. */
+  async loadImage(url: string): Promise<string> {
+    if (this.currentRenderer instanceof WASMRenderer) {
+      await this.currentRenderer.loadImageFromURL(url);
+      return url;
+    }
+    if (this.currentRenderer && 'loadImage' in this.currentRenderer) {
+      return (this.currentRenderer as any).loadImage(url);
+    }
+    return url;
+  }
+
 
   getAvailableModes(): any[] {
     if (this.currentRenderer && 'getAvailableModes' in this.currentRenderer) {

--- a/wasm_renderer/build.sh
+++ b/wasm_renderer/build.sh
@@ -27,7 +27,7 @@ if ! command -v emcc &> /dev/null; then
     echo "⚠️ Warning: emcc not found. Skipping WASM build."
     # Create dummy files so the TypeScript build doesn't fail looking for them
     mkdir -p "$SCRIPT_DIR/../public/wasm"
-    echo "var Module = function() { return Promise.resolve({}); }; Module.default = Module; export default Module;" > "$SCRIPT_DIR/../public/wasm/pixelocity_wasm.js"
+    echo "window.PixelocityWASM = function() { return Promise.resolve({}); };" > "$SCRIPT_DIR/../public/wasm/pixelocity_wasm.js"
     touch "$SCRIPT_DIR/../public/wasm/pixelocity_wasm.wasm"
     exit 0
 fi


### PR DESCRIPTION
## Summary
This PR adds image loading functionality to the RendererManager and updates the WASM module export pattern to use a global window object instead of ES6 module exports.

## Key Changes
- **Added `loadImage()` method to RendererManager**: New async method that delegates image loading to the active renderer, with specific handling for WASMRenderer (calls `loadImageFromURL`) and fallback support for other renderers with a `loadImage` method
- **Updated WASM module export pattern**: Changed from ES6 module export (`Module.default = Module; export default Module;`) to a global window object assignment (`window.PixelocityWASM`), making the WASM module accessible as a global variable
- **Updated build script**: Modified the dummy WASM file generation in `build.sh` to match the new export pattern when emcc is not available

## Implementation Details
- The `loadImage()` method provides a unified interface for image loading across different renderer implementations
- For WASMRenderer, it calls the renderer's `loadImageFromURL()` method and returns the URL
- For other renderers, it uses duck typing to check for a `loadImage` method before delegating
- The WASM module change simplifies the module loading pattern by using a global namespace instead of ES6 module syntax

https://claude.ai/code/session_018MYo8sFK6vcXESCDzncZ5x