### PR TITLE
fix: ccall guard, CSS flex chain, manifest race condition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -467,13 +467,14 @@ function MainApp() {
     }, [aiVj, isAiVjMode, availableModes, modes, handleLoadImage, imageManifest, currentImageUrl]);
     
     const onInitCanvas = useCallback(() => {
-        if(rendererRef.current) {
+        if (rendererRef.current) {
             if (rendererRef.current.getAvailableModes) {
                 setAvailableModes(rendererRef.current.getAvailableModes());
             }
-            handleNewRandomImage();
+            // Image auto-load is handled by the useEffect below (line ~390)
+            // which fires once imageManifest is populated, avoiding the race condition
         }
-    }, [handleNewRandomImage]);
+    }, []);
 
     // --- Webcam Handlers ---
     const startWebcam = useCallback(async () => {

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,21 @@ body {
     flex-direction: column;
 }
 
+#root {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.App {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
 /* Header */
 .header {
     height: 60px;
@@ -104,6 +119,7 @@ body {
 /* Canvas Area */
 .canvas-container {
     flex: 1;
+    min-width: 0;
     height: 100%;
     background-color: #000;
     display: flex;

--- a/src/wasm/wasm_bridge.js
+++ b/src/wasm/wasm_bridge.js
@@ -99,7 +99,13 @@ async function initializeModule(factory, wasmBinaryPath, resolve) {
         return path;
       }
     });
-    
+
+    if (typeof wasmModule.ccall !== 'function') {
+      console.warn('[WASM] Module loaded but ccall unavailable (stub build — upload real emcc binary to public/wasm/)');
+      resolve(false);
+      return;
+    }
+
     console.log('[WASM] Module initialized, calling C++ init...');
 
     // Initialize the C++ renderer


### PR DESCRIPTION
- wasm_bridge.js: check typeof ccall before calling to avoid noisy TypeError when stub module is loaded (no real emcc binary)
- style.css: add flex rules to #root and .App so they participate in the body flex chain; add min-width:0 to .canvas-container to fix the 0px width on first ResizeObserver fire
- App.tsx: remove handleNewRandomImage() from onInitCanvas — the auto-load useEffect already handles it once imageManifest is ready, eliminating the "Manifest empty" race condition

https://claude.ai/code/session_018MYo8sFK6vcXESCDzncZ5x