### PR TITLE
Fix shader rendering: content-aware caching, correct API endpoints, H…

### DIFF
--- a/src/renderer/WebGPURenderer.ts
+++ b/src/renderer/WebGPURenderer.ts
@@ -391,6 +391,7 @@ export class WebGPURenderer implements Renderer {
 
   // Shader pipeline cache: shader-id → GPUComputePipeline
   private pipelines = new Map<string, GPUComputePipeline>();
+  private pipelineHashes = new Map<string, string>(); // shader-id → content hash
 
   // Multi-slot state with parallelization support
   // Slot 0: Usually chained (background/base effect)
@@ -853,11 +854,20 @@ export class WebGPURenderer implements Renderer {
     }
   }
 
+  private hashWgsl(code: string): string {
+    let hash = 5381;
+    for (let i = 0; i < code.length; i++) {
+      hash = ((hash << 5) + hash + code.charCodeAt(i)) | 0;
+    }
+    return hash.toString(36) + ':' + code.length;
+  }
+
   private compileShader(id: string, wgsl: string): boolean {
     if (!this.device) return false;
-    
-    // Fast path: shader already cached (hot-swap optimization)
-    if (this.pipelines.has(id)) {
+
+    // Fast path: shader already cached AND content unchanged
+    const contentHash = this.hashWgsl(wgsl);
+    if (this.pipelines.has(id) && this.pipelineHashes.get(id) === contentHash) {
       return true;
     }
     
@@ -880,6 +890,7 @@ export class WebGPURenderer implements Renderer {
       });
       
       this.pipelines.set(id, pipeline);
+      this.pipelineHashes.set(id, contentHash);
       return true;
     } catch (e) {
       console.warn(`[WebGPU] Shader compile failed (${id}):`, e);
@@ -997,7 +1008,6 @@ export class WebGPURenderer implements Renderer {
 
   /** Pre-compile a shader for faster hot-swapping later */
   async preloadShader(id: string, url: string): Promise<boolean> {
-    if (this.pipelines.has(id)) return true; // Already cached
     return this.loadShader(id, url);
   }
 

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -433,7 +433,17 @@ export class StorageService {
       if (!response.ok) {
         // Fallback to static URL
         const data = await this.loadJson(`image-effects/shaders/${filename}`);
-        
+
+        // Fetch actual WGSL content instead of returning stringified metadata
+        let content = '';
+        if (data.filename) {
+          try {
+            const wgslFilename = data.filename.replace(/\.json$/, '.wgsl');
+            const wgslRes = await fetch(`${this.apiUrl}/files/image-effects/shaders/${wgslFilename}`);
+            if (wgslRes.ok) content = await wgslRes.text();
+          } catch { /* content stays empty, handled by caller */ }
+        }
+
         this.updateOperation(opId, {
           status: 'completed',
           message: `Loaded shader ${filename}`,
@@ -441,7 +451,7 @@ export class StorageService {
 
         return {
           id: filename.replace('.json', ''),
-          content: JSON.stringify(data),
+          content,
           type: data.format || 'wgsl',
           data,
         };

--- a/src/services/shaderApi.ts
+++ b/src/services/shaderApi.ts
@@ -449,10 +449,9 @@ class ShaderApiService {
     if (cached) return cached;
 
     try {
-      const response = await fetch(`${this.baseUrl}/api/shaders/${shaderId}`);
+      const response = await fetch(`${this.baseUrl}/api/shaders/${shaderId}/wgsl`);
       if (!response.ok) throw new Error('API error');
-      const data = await response.json();
-      const code = data.data?.wgsl_code || data.content || '';
+      const code = await response.text();
       this.cache.set(`code:${shaderId}`, code);
       return code;
     } catch (error) {

--- a/storage_manager/app.py
+++ b/storage_manager/app.py
@@ -1981,6 +1981,7 @@ async def upload_shader(
    
 # ========================= FTP BRIDGE ENDPOINTS =========================
 
+@app.head("/api/shaders/{shader_id}/wgsl")
 @app.get("/api/shaders/{shader_id}/wgsl", response_class=PlainTextResponse)
 async def get_shader_wgsl(shader_id: str):
     """Returns raw WGSL text for direct consumption by WebGPU renderer.


### PR DESCRIPTION
…EAD support

- Add content hash to pipeline cache so updated shaders from VPS trigger recompilation instead of serving stale cached pipelines
- Fix getShaderCode() to use /api/shaders/{id}/wgsl endpoint with response.text() instead of fetching metadata JSON
- Fix StorageService.loadShader fallback to fetch actual WGSL content instead of returning stringified JSON metadata
- Add HEAD method support on shader WGSL endpoint for cache validation

Closes #454

https://claude.ai/code/session_01CEsu5Hs7FieXoJT8vFMHCF