### PR TITLE
Fix Shader Parameter Sliders and Expand Support to 6 Params

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -364,12 +364,12 @@ function MainApp() {
                     rating: shader.rating,
                     hasErrors: shader.has_errors,
                     params: (shader.params || []).map((p: any, idx: number) => ({
-                        id: p.id || p.name || `param${idx + 1}`,
+                        id: p.name || `param${idx + 1}`,
                         name: p.label || p.name || `Parameter ${idx + 1}`,
                         default: p.default ?? 0.5,
                         min: p.min ?? 0,
                         max: p.max ?? 1,
-                        step: p.step ?? 0.01,
+                        step: 0.01,
                         labels: p.labels,
                     })),
                 }));

--- a/src/renderer/WebGPURenderer.ts
+++ b/src/renderer/WebGPURenderer.ts
@@ -389,9 +389,7 @@ export class WebGPURenderer implements Renderer {
   private mouseX      = 0.5;
   private mouseY      = 0.5;
   private mouseDown   = false;
-  private zoomParams  = [0.5, 0.5, 0.5, 0.5];
-  private zoomParam5  = 0.5;  // UI-only (not in GPU vec4 yet)
-  private zoomParam6  = 0.5;  // UI-only (not in GPU vec4 yet)
+  private zoomParams  = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5];
   private ripples: Ripple[] = [];
   private audioBass   = 0;
   private audioMid    = 0;
@@ -1352,8 +1350,8 @@ export class WebGPURenderer implements Renderer {
       case 'zoomParam2': this.zoomParams[1]  = value;     break;
       case 'zoomParam3': this.zoomParams[2]  = value;     break;
       case 'zoomParam4': this.zoomParams[3]  = value;     break;
-      case 'zoomParam5': this.zoomParam5     = value;     break;
-      case 'zoomParam6': this.zoomParam6     = value;     break;
+      case 'zoomParam5': this.zoomParams[4]  = value;     break;
+      case 'zoomParam6': this.zoomParams[5]  = value;     break;
     }
   }
 
@@ -1363,8 +1361,8 @@ export class WebGPURenderer implements Renderer {
     if (params.zoomParam2 !== undefined) this.zoomParams[1] = params.zoomParam2;
     if (params.zoomParam3 !== undefined) this.zoomParams[2] = params.zoomParam3;
     if (params.zoomParam4 !== undefined) this.zoomParams[3] = params.zoomParam4;
-    if (params.zoomParam5 !== undefined) this.zoomParam5 = params.zoomParam5;
-    if (params.zoomParam6 !== undefined) this.zoomParam6 = params.zoomParam6;
+    if (params.zoomParam5 !== undefined) this.zoomParams[4] = params.zoomParam5;
+    if (params.zoomParam6 !== undefined) this.zoomParams[5] = params.zoomParam6;
   }
 
   /** render() is a no-op; actual rendering is driven by the internal RAF loop. */
@@ -1605,9 +1603,10 @@ export class WebGPURenderer implements Renderer {
     this.device.queue.writeBuffer(this.uniformBuf, 0, u.data);
 
     // First 3 floats of extraBuf carry audio (bass, mid, treble)
+    // We add zoomParam5 and zoomParam6 at indices 3 and 4
     this.device.queue.writeBuffer(
       this.extraBuf, 0,
-      new Float32Array([this.audioBass, this.audioMid, this.audioTreble]),
+      new Float32Array([this.audioBass, this.audioMid, this.audioTreble, this.zoomParams[4], this.zoomParams[5]]),
     );
   }
 }

--- a/src/services/shaderApi.ts
+++ b/src/services/shaderApi.ts
@@ -394,12 +394,12 @@ class ShaderApiService {
             const definition = await response.json();
             if (definition.params) {
               shader.params = definition.params.map((p: any, idx: number) => ({
-                id: p.id || p.name || `param${idx + 1}`,
+                id: p.name || `param${idx + 1}`,
                 name: p.label || p.name || `Parameter ${idx + 1}`,
                 default: p.default ?? 0.5,
                 min: p.min ?? 0,
                 max: p.max ?? 1,
-                step: p.step ?? 0.01,
+                step: 0.01,
                 labels: p.labels,
               }));
             }
@@ -439,7 +439,15 @@ class ShaderApiService {
             const defResponse = await fetch(`./shader_definitions/${data.category || 'image'}/${id}.json`);
             if (defResponse.ok) {
               const definition = await defResponse.json();
-              entry.params = definition.params;
+              entry.params = (definition.params || []).map((p: any, idx: number) => ({
+                id: p.name || `param${idx + 1}`,
+                name: p.label || p.name || `Parameter ${idx + 1}`,
+                default: p.default ?? 0.5,
+                min: p.min ?? 0,
+                max: p.max ?? 1,
+                step: 0.01,
+                labels: p.labels,
+              }));
               entry.description = definition.description || entry.description;
             }
           } catch (e) {


### PR DESCRIPTION
This PR fixes the issue where shader parameter sliders were not showing in the UI due to a field name mismatch between the API response and the frontend expectations. It also expands the system to support 6 parameters (up from 4), utilizing the WebGPU extraBuffer for the additional values. Parameters now correctly initialize to their default values when a shader is selected.

Fixes #456

---
*PR created automatically by Jules for task [4427795262243240805](https://jules.google.com/task/4427795262243240805) started by @ford442*