### PR TITLE
Fix startup failures: boot gate, webcam dedup, StrictMode guard, and …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,6 +160,11 @@ function MainApp() {
     const [mousePosition, setMousePosition] = useState<{ x: number; y: number }>({ x: -1, y: -1 });
     const [isMouseDown, setIsMouseDown] = useState(false);
 
+    // --- State: Boot Gate ---
+    const [rendererReady, setRendererReady] = useState(false);
+    const [shadersReady, setShadersReady] = useState(false);
+    const initialBootAppliedRef = useRef(false);
+
     // --- Refs ---
     const rendererRef = useRef<Renderer | null>(null);
     const fileInputImageRef = useRef<HTMLInputElement>(null);
@@ -380,6 +385,7 @@ function MainApp() {
                 }));
                 
                 setAvailableModes(entries);
+                setShadersReady(true);
                 // Debug: Check params
                 const withParams = entries.filter(e => e.params && e.params.length > 0);
                 console.log(`✅ Loaded ${entries.length} shaders (API-first with fallback)`);
@@ -389,7 +395,7 @@ function MainApp() {
                 }
             } catch (error) {
                 console.warn('Failed to load shaders:', error);
-                // Silently fail - shader list will be empty but app won't crash
+                setShadersReady(true); // Mark ready even on failure so boot gate doesn't block forever
             }
         };
         
@@ -465,14 +471,27 @@ function MainApp() {
         }
     }, [imageManifest, handleLoadImage]);
 
-    // Auto-load first image when manifest becomes available
-    // This handles the race condition where canvas initializes before manifest
+    // --- Coordinated Boot Gate ---
+    // Wait for both renderer and shader list to be ready before loading initial shader + image.
+    // This fixes the race where onInitCanvas fired before availableModes was populated.
     useEffect(() => {
+        if (!rendererReady || !shadersReady) return;
+        if (initialBootAppliedRef.current) return;
+        initialBootAppliedRef.current = true;
+
+        // Load initial shader
+        const initialMode = modes[0];
+        if (initialMode && initialMode !== 'none') {
+            console.log(`[boot] Loading initial shader: ${initialMode}`);
+            setMode(0, initialMode);
+        }
+
+        // Auto-load first image if manifest is ready
         if (imageManifest.length > 0 && !currentImageUrl && inputSource === 'image') {
-            console.log('Manifest loaded, auto-loading first image...');
+            console.log('[boot] Auto-loading first image...');
             handleNewRandomImage();
         }
-    }, [imageManifest, currentImageUrl, inputSource, handleNewRandomImage]);
+    }, [rendererReady, shadersReady, modes, setMode, imageManifest, currentImageUrl, inputSource, handleNewRandomImage]);
 
     const loadDepthModel = useCallback(async () => {
         if (depthEstimator) { setStatus('Depth model already loaded.'); return; }
@@ -551,14 +570,9 @@ function MainApp() {
             if (rendererRef.current.getAvailableModes) {
                 setAvailableModes(rendererRef.current.getAvailableModes());
             }
-            // Load initial shader for slot 0 if not already loaded
-            const initialMode = modes[0];
-            if (initialMode && initialMode !== 'none') {
-                console.log(`[onInitCanvas] Loading initial shader: ${initialMode}`);
-                setMode(0, initialMode);
-            }
+            setRendererReady(true);
         }
-    }, [modes, setMode]);
+    }, []);
 
     // --- Webcam Handlers ---
     const startWebcam = useCallback(async () => {

--- a/src/RemoteApp.tsx
+++ b/src/RemoteApp.tsx
@@ -34,6 +34,8 @@ const RemoteApp: React.FC = () => {
 
     const channelRef = useRef<BroadcastChannel | null>(null);
     const heartbeatTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const helloRetryRef = useRef<NodeJS.Timeout | null>(null);
+    const gotStateRef = useRef(false);
     const fileInputImageRef = useRef<HTMLInputElement>(null);
     const fileInputVideoRef = useRef<HTMLInputElement>(null);
 
@@ -62,6 +64,11 @@ const RemoteApp: React.FC = () => {
             if (msg.type === 'HEARTBEAT') {
                 resetHeartbeat();
             } else if (msg.type === 'STATE_FULL') {
+                gotStateRef.current = true;
+                if (helloRetryRef.current) {
+                    clearInterval(helloRetryRef.current);
+                    helloRetryRef.current = null;
+                }
                 const state = msg.payload as FullState;
                 setModes(state.modes);
                 setActiveSlot(state.activeSlot);
@@ -84,12 +91,26 @@ const RemoteApp: React.FC = () => {
             }
         };
 
-        // Send Hello
+        // Send Hello with retry (up to 3 retries at 1s intervals)
+        gotStateRef.current = false;
         sendMessage('HELLO');
+        let retryCount = 0;
+        helloRetryRef.current = setInterval(() => {
+            if (gotStateRef.current || retryCount >= 3) {
+                if (helloRetryRef.current) {
+                    clearInterval(helloRetryRef.current);
+                    helloRetryRef.current = null;
+                }
+                return;
+            }
+            retryCount++;
+            sendMessage('HELLO');
+        }, 1000);
 
         return () => {
             channel.close();
             if (heartbeatTimeoutRef.current) clearTimeout(heartbeatTimeoutRef.current);
+            if (helloRetryRef.current) clearInterval(helloRetryRef.current);
         };
     }, [resetHeartbeat, sendMessage]);
 

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -81,7 +81,7 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
         return true;
     };
 
-    // Initialize Renderer
+    // Initialize Renderer (with StrictMode guard)
     useEffect(() => {
         if (!canvasRef.current || !canvasReady) return;
         const canvas = canvasRef.current;
@@ -102,6 +102,7 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
         }
 
         const renderer = new RendererManager({ width: 1920, height: 1080, agentCount: 50000 });
+        let mounted = true;
 
         // Hook up dimensions listener - kept for potential future use or informational purposes,
         // but we are locking buffer size now.
@@ -114,6 +115,11 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
 
         (async () => {
             const success = await renderer.init(canvasRef.current!);
+            // StrictMode guard: if unmounted during async init, discard the result
+            if (!mounted) {
+                renderer.destroy();
+                return;
+            }
             if (success) {
                 if (rendererRef && 'current' in rendererRef) {
                     (rendererRef as React.MutableRefObject<any>).current = renderer;
@@ -126,6 +132,7 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
             }
         })();
         return () => {
+            mounted = false;
             cancelAnimationFrame(animationFrameId.current);
             renderer.destroy();
             // Stop webcam stream if active
@@ -250,18 +257,11 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
             }
 
             if (inputSource === 'webcam') {
-                try {
-                    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
-                    streamRef.current = stream;
-                    videoRef.current!.srcObject = stream;
+                // Use the webcam stream already acquired by App.tsx (via startWebcam)
+                // to avoid duplicate getUserMedia calls and leaked MediaStreams.
+                if (webcamVideoElement && webcamVideoElement.srcObject) {
+                    videoRef.current!.srcObject = webcamVideoElement.srcObject;
                     videoRef.current!.play().catch(console.error);
-                } catch (e) {
-                    console.error("Error accessing webcam:", e);
-                    alert("Could not access webcam.");
-                    // Revert to image if webcam fails
-                    if (setInputSource) {
-                        setInputSource('image');
-                    }
                 }
             } else if (inputSource === 'live') {
                 // Live stream mode - use the HLS video element

--- a/src/renderer/WebGPURenderer.ts
+++ b/src/renderer/WebGPURenderer.ts
@@ -441,6 +441,9 @@ export class WebGPURenderer implements Renderer {
   // ── Initialisation ─────────────────────────────────────────────────────────
 
   async init(canvas: HTMLCanvasElement): Promise<boolean> {
+    // Idempotency guard: prevent double-init (e.g. React StrictMode)
+    if (this.initialized) return true;
+
     // Check WebGPU availability with user-friendly warnings
     if (!navigator.gpu) {
       const warning = getBrowserWarning();
@@ -1391,7 +1394,7 @@ export class WebGPURenderer implements Renderer {
     this.pipelines.clear();
     this.workgroupSizes.clear();
 
-    for (const t of [this.readTex, this.writeTex, this.dataTexA, this.dataTexB,
+    for (const t of [this.sourceTex, this.readTex, this.writeTex, this.dataTexA, this.dataTexB,
                      this.dataTexC, this.depthRead, this.depthWrite, this.emptyTex]) {
       t?.destroy();
     }

--- a/src/services/shaderApi.ts
+++ b/src/services/shaderApi.ts
@@ -3,9 +3,9 @@
  * Handles shader CRUD operations and Shadertoy imports
  */
 
-import { STORAGE_API_URL } from '../config/appConfig';
+import { STORAGE_API_URL, API_BASE_URL } from '../config/appConfig';
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:7860';
+const API_BASE = process.env.REACT_APP_API_BASE_URL || API_BASE_URL;
 
 // --- Types ---
 


### PR DESCRIPTION
…more

- Add coordinated boot gate so initial shader loads only after both renderer and shader list are ready (fixes blank canvas on startup)
- Remove duplicate getUserMedia in WebGPUCanvas (use App.tsx stream)
- Guard async renderer init against React StrictMode double-mount
- Add idempotency guard to WebGPURenderer.init()
- Include sourceTex in destroy() cleanup to prevent GPU memory leak
- Unify API base URL in shaderApi.ts (was defaulting to localhost:7860)
- Add HELLO retry with 3 attempts in RemoteApp for robust handshake

https://claude.ai/code/session_01QbGgaBkAwCuRW1quD3zFFA