### PR TITLE
Fix shader slot stacking and uniform slider sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,6 +296,10 @@ function MainApp() {
 
         if (mode === 'none') {
             setSlotShaderStatus(prev => { const n = [...prev]; n[index] = 'idle'; return n; });
+            // Tell the renderer to disable this slot so other slots keep running
+            if (rendererRef.current && typeof (rendererRef.current as any).setSlotShader === 'function') {
+                (rendererRef.current as any).setSlotShader(index, '');
+            }
             return;
         }
 
@@ -1321,6 +1325,7 @@ function MainApp() {
                         isMouseDown={isMouseDown} setIsMouseDown={setIsMouseDown} onInit={onInitCanvas}
                         inputSource={inputSource} videoSourceUrl={videoSourceUrl}
                         isMuted={isMuted} setInputSource={setInputSource}
+                        activeSlot={activeSlot}
                         activeGenerativeShader={activeGenerativeShader}
                         selectedVideo={selectedVideo}
                         apiBaseUrl={STORAGE_API_URL}

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -22,6 +22,7 @@ interface WebGPUCanvasProps {
     videoSourceUrl?: string; // NEW: Used for "Uploaded" videos (Blob URL)
     isMuted: boolean;
     setInputSource?: (source: InputSource) => void; // Added for error handling
+    activeSlot: number;
     activeGenerativeShader?: string;
     apiBaseUrl: string;
     // Webcam Props
@@ -36,7 +37,7 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
     farthestPoint, mousePosition, setMousePosition,
     isMouseDown, setIsMouseDown, onInit,
     inputSource, selectedVideo, videoSourceUrl, isMuted,
-    setInputSource, activeGenerativeShader, apiBaseUrl,
+    setInputSource, activeSlot, activeGenerativeShader, apiBaseUrl,
     isWebcamActive = false,
     webcamVideoElement,
     liveStreamUrl
@@ -319,10 +320,10 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
         }
     }, [isMouseDown, rendererRef]);
 
-    // Sync slotParams to renderer (zoomParam1-6) - use first slot's params
+    // Sync slotParams to renderer (zoomParam1-6) - use active slot's params
     useEffect(() => {
         if (rendererRef.current?.updateSlotParams && slotParams.length > 0) {
-            const params = slotParams[0]; // Use first slot's params
+            const params = slotParams[activeSlot] ?? slotParams[0];
             rendererRef.current.updateSlotParams({
                 zoomParam1: params.zoomParam1,
                 zoomParam2: params.zoomParam2,
@@ -332,7 +333,7 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
                 zoomParam6: params.zoomParam6,
             });
         }
-    }, [slotParams, rendererRef]);
+    }, [slotParams, activeSlot, rendererRef]);
 
     // Animation Loop
     useEffect(() => {


### PR DESCRIPTION
Two bugs fixed:
1. Setting a slot to 'none' now tells the renderer to disable that slot, so the remaining slots continue to compose/chain correctly.
2. Uniform parameter sliders now sync the active slot's params to the GPU instead of always using slot 0's values.

https://claude.ai/code/session_01DAXBQoDN5jj8KRY4xEyFm8