### PR TITLE
fix: startup race, event leaks, rating cache, and other stability fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -291,9 +291,16 @@ function MainApp() {
     const channelRef = useRef<BroadcastChannel | null>(null);
     const heartbeatIntervalRef = useRef<NodeJS.Timeout | null>(null);
     const rouletteFlashRef = useRef<HTMLDivElement | null>(null);
+    // Mirrors slotShaderStatus state so setMode can read it without being in its dep array
+    const slotShaderStatusRef = useRef<Array<'idle' | 'loading' | 'error'>>(['idle', 'idle', 'idle']);
+    // Direct ref to the WebGPU canvas — set via onCanvasRef callback (avoids fragile querySelector)
+    const webgpuCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
     // --- Helpers ---
     const setMode = useCallback(async (index: number, mode: RenderMode) => {
+        // Guard: if a shader is already compiling on this slot, skip to prevent chaos-mode pile-up
+        if (slotShaderStatusRef.current[index] === 'loading') return;
+
         setModes(prev => {
             const next = [...prev];
             next[index] = mode;
@@ -301,6 +308,7 @@ function MainApp() {
         });
 
         if (mode === 'none') {
+            slotShaderStatusRef.current[index] = 'idle';
             setSlotShaderStatus(prev => { const n = [...prev]; n[index] = 'idle'; return n; });
             // Tell the renderer to disable this slot so other slots keep running
             if (rendererRef.current && typeof (rendererRef.current as any).setSlotShader === 'function') {
@@ -312,8 +320,9 @@ function MainApp() {
         // Attempt to load & compile the shader, tracking status
         const shaderEntry = availableModes.find(s => s.id === mode);
         if (shaderEntry && rendererRef.current && 'loadShader' in rendererRef.current) {
+            slotShaderStatusRef.current[index] = 'loading';
             setSlotShaderStatus(prev => { const n = [...prev]; n[index] = 'loading'; return n; });
-            
+
             try {
                 // Determine shader URL — API shaders now point directly to the .wgsl static file
                 // served by nginx with CORS headers, so pass the URL straight to loadShader.
@@ -331,6 +340,7 @@ function MainApp() {
                     }
                 }
                 
+                slotShaderStatusRef.current[index] = ok ? 'idle' : 'error';
                 setSlotShaderStatus(prev => { const n = [...prev]; n[index] = ok ? 'idle' : 'error'; return n; });
                 
                 // Initialize slider values to shader's declared param defaults
@@ -375,6 +385,7 @@ function MainApp() {
                 }
             } catch (error) {
                 console.error(`❌ Failed to load shader ${shaderEntry.id}:`, error);
+                slotShaderStatusRef.current[index] = 'error';
                 setSlotShaderStatus(prev => { const n = [...prev]; n[index] = 'error'; return n; });
             }
         }
@@ -402,6 +413,9 @@ function MainApp() {
     // --- Effects & Initializers ---
     
     useEffect(() => {
+        const controller = new AbortController();
+        const signal = controller.signal;
+
         // Fetch the dynamic image manifest from the backend on startup
         const fetchImageManifest = async () => {
             let manifest: ImageRecord[] = [];
@@ -409,7 +423,7 @@ function MainApp() {
 
             // 1. Try API
             try {
-                const response = await fetch(IMAGE_MANIFEST_URL);
+                const response = await fetch(IMAGE_MANIFEST_URL, { signal });
                 if (response.ok) {
                     const data = await response.json();
                     if (!Array.isArray(data)) {
@@ -422,13 +436,14 @@ function MainApp() {
                     }));
                 }
             } catch (error) {
+                if ((error as Error).name === 'AbortError') return;
                 console.warn("Backend API failed, trying local manifest...", error);
             }
 
             // 2. Try Local Manifest (Bucket Images & Videos) if API Empty OR Videos Missing
             if (manifest.length === 0 || videos.length === 0) {
                 try {
-                    const response = await fetch(LOCAL_MANIFEST_URL);
+                    const response = await fetch(LOCAL_MANIFEST_URL, { signal });
                     if (response.ok) {
                         const data = await response.json();
 
@@ -456,6 +471,7 @@ function MainApp() {
                         console.log("Loaded local manifest. Total:", manifest.length, "images,", videos.length, "videos");
                     }
                 } catch (e) {
+                    if ((e as Error).name === 'AbortError') return;
                     console.warn("Failed to load local manifest:", e);
                 }
             }
@@ -472,7 +488,7 @@ function MainApp() {
             } else {
                 setStatus(`Loaded ${manifest.length} images, ${videos.length} videos`);
             }
-            
+
             // Video fallback
             if (videos.length === 0) {
                 console.warn("No videos found. Using sample videos.");
@@ -492,15 +508,19 @@ function MainApp() {
             }
         };
         fetchImageManifest();
+        return () => controller.abort();
     }, []);
 
     // --- Load Available Shaders (API-First with Local Fallback) ---
     useEffect(() => {
+        let isMounted = true;
+
         const loadShaders = async () => {
             try {
                 // Try API first, fallback to local shader_coordinates.json
                 const apiShaders = await ShaderApi.getShaderList();
-                
+                if (!isMounted) return;
+
                 // Transform API shaders to match expected format
                 const entries: ShaderEntry[] = apiShaders.map(shader => ({
                     id: shader.id,
@@ -522,7 +542,7 @@ function MainApp() {
                         labels: p.labels,
                     })),
                 }));
-                
+
                 setAvailableModes(entries);
                 setShadersReady(true);
                 // Debug: Check params
@@ -533,11 +553,12 @@ function MainApp() {
                     console.log(`   Example: ${withParams[0].id} has params:`, withParams[0].params);
                 }
             } catch (error) {
+                if (!isMounted) return;
                 console.warn('Failed to load shaders:', error);
                 setShadersReady(true); // Mark ready even on failure so boot gate doesn't block forever
             }
         };
-        
+
         // Helper to determine category — use API category field first, then infer from tags/id
         function determineCategory(shader: ApiShaderEntry): ShaderCategory {
             // Prefer the category field from the API/definition if available
@@ -565,8 +586,9 @@ function MainApp() {
             if (shader.tags?.includes('geometric') || shader.tags?.includes('tessellation')) return 'geometric';
             return 'image';
         }
-        
+
         loadShaders();
+        return () => { isMounted = false; };
     }, []);
 
     // --- Image Loading ---
@@ -628,8 +650,9 @@ function MainApp() {
     }, [imageManifest, handleLoadImage]);
 
     // --- Coordinated Boot Gate ---
-    // Wait for both renderer and shader list to be ready before loading initial shader + image.
-    // This fixes the race where onInitCanvas fired before availableModes was populated.
+    // Wait for both renderer and shader list to be ready before loading initial shader.
+    // Image auto-load is handled by a separate effect below so it works even if the
+    // manifest arrives after the renderer/shader gate fires.
     useEffect(() => {
         if (!rendererReady || !shadersReady) return;
         if (initialBootAppliedRef.current) return;
@@ -641,13 +664,17 @@ function MainApp() {
             console.log(`[boot] Loading initial shader: ${initialMode}`);
             setMode(0, initialMode);
         }
+    }, [rendererReady, shadersReady, modes, setMode]);
 
-        // Auto-load first image if manifest is ready
-        if (imageManifest.length > 0 && !currentImageUrl && inputSource === 'image') {
-            console.log('[boot] Auto-loading first image...');
-            handleNewRandomImage();
-        }
-    }, [rendererReady, shadersReady, modes, setMode, imageManifest, currentImageUrl, inputSource, handleNewRandomImage]);
+    // --- Initial Image Auto-Load ---
+    // Separate from the boot gate so it fires whenever the manifest becomes available,
+    // even if that happens after the renderer is already ready.
+    useEffect(() => {
+        if (!rendererReady || imageManifest.length === 0 || currentImageUrl) return;
+        if (inputSource !== 'image') return;
+        console.log('[boot] Auto-loading first image (manifest ready)...');
+        handleNewRandomImage();
+    }, [rendererReady, imageManifest, currentImageUrl, inputSource, handleNewRandomImage]);
 
     const loadDepthModel = useCallback(async () => {
         if (depthEstimator) { setStatus('Depth model already loaded.'); return; }
@@ -1074,8 +1101,8 @@ function MainApp() {
     }, []);
 
     const startRecording = useCallback(async () => {
-        // Find the canvas element
-        const canvas = document.querySelector('canvas[data-testid="webgpu-canvas"]') as HTMLCanvasElement;
+        // Use the canvas ref exposed by WebGPUCanvas (avoids fragile DOM querySelector)
+        const canvas = webgpuCanvasRef.current;
         if (!canvas) {
             setStatus('❌ Canvas not found for recording');
             return;
@@ -1202,10 +1229,15 @@ function MainApp() {
 
         channel.onmessage = (event) => {
             const msg = event.data as SyncMessage;
-            
+
             if (msg.type === 'HELLO') {
-                // Remote app connected, send full state
+                // Remote app connected — send full state and start heartbeat if not already running
                 sendMessage('STATE_FULL', buildFullState());
+                if (!heartbeatIntervalRef.current) {
+                    heartbeatIntervalRef.current = setInterval(() => {
+                        sendMessage('HEARTBEAT');
+                    }, 5000); // 5s is plenty for a keep-alive
+                }
             } else if (msg.type === 'CMD_SET_MODE') {
                 const { index, mode } = msg.payload;
                 setMode(index, mode);
@@ -1242,15 +1274,11 @@ function MainApp() {
             }
         };
 
-        // Start heartbeat to keep remote connected
-        heartbeatIntervalRef.current = setInterval(() => {
-            sendMessage('HEARTBEAT');
-        }, 1000); // Send heartbeat every second
-
         return () => {
             channel.close();
             if (heartbeatIntervalRef.current) {
                 clearInterval(heartbeatIntervalRef.current);
+                heartbeatIntervalRef.current = null;
             }
         };
     }, [buildFullState, sendMessage, handleNewRandomImage, loadDepthModel, updateSlotParam, setMode]);
@@ -1357,6 +1385,7 @@ function MainApp() {
                         apiBaseUrl={STORAGE_API_URL}
                         isWebcamActive={isWebcamActive}
                         webcamVideoElement={videoElementRef.current}
+                        onCanvasRef={(el) => { webgpuCanvasRef.current = el; }}
                     />
                     <div className="status-bar">
                         {isAiVjMode ? `[AI VJ]: ${aiVjMessage}` : status}

--- a/src/components/LiveStreamBridge.tsx
+++ b/src/components/LiveStreamBridge.tsx
@@ -100,12 +100,11 @@ export const LiveStreamBridge: React.FC<LiveStreamBridgeProps> = ({
           video.removeEventListener('loadedmetadata', handleCanPlay);
         };
       } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
-        // Native HLS support (Safari)
+        // Native HLS support (Safari) — keep a reference so the listener can be removed
         video.src = streamUrl;
-        video.addEventListener('loadedmetadata', () => {
-          setIsReady(true);
-          onVideoReady(video);
-        });
+        const handleNativeReady = () => { setIsReady(true); onVideoReady(video); };
+        video.addEventListener('loadedmetadata', handleNativeReady);
+        return () => video.removeEventListener('loadedmetadata', handleNativeReady);
       } else {
         onError?.('HLS not supported in this browser');
       }

--- a/src/components/WebGPUCanvas.tsx
+++ b/src/components/WebGPUCanvas.tsx
@@ -31,6 +31,8 @@ interface WebGPUCanvasProps {
     webcamVideoElement?: HTMLVideoElement | null;
     // Live Stream Props
     liveStreamUrl?: string; // NEW: HLS live stream URL
+    // Expose the canvas element to the parent (e.g. for recording)
+    onCanvasRef?: (canvas: HTMLCanvasElement | null) => void;
 }
 
 const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
@@ -41,7 +43,8 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
     setInputSource, activeSlot, activeGenerativeShader, apiBaseUrl,
     isWebcamActive = false,
     webcamVideoElement,
-    liveStreamUrl
+    liveStreamUrl,
+    onCanvasRef
 }) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -61,6 +64,15 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
 
     // Track if there are active interactive/mouse-driven effects
     const [hasInteractiveEffects, setHasInteractiveEffects] = useState(false);
+
+    // Expose canvas element to parent (e.g. for recording) via onCanvasRef callback
+    useEffect(() => {
+        if (!canvasRef.current) return;
+        onCanvasRef?.(canvasRef.current);
+        return () => onCanvasRef?.(null);
+    // canvasRef.current is stable; we only need to re-run if the callback identity changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [onCanvasRef]);
 
     // Ensure canvas has valid dimensions before WebGPU initialization
     const ensureCanvasSize = (canvas: HTMLCanvasElement) => {
@@ -527,10 +539,6 @@ const WebGPUCanvas: React.FC<WebGPUCanvasProps> = ({
                 data-testid="webgpu-canvas"
                 width={INTERNAL_RENDER_RESOLUTION}
                 height={INTERNAL_RENDER_RESOLUTION}
-                onMouseMove={handleCanvasMouseMove}
-                onMouseDown={handleMouseDown}
-                onMouseUp={handleMouseUp}
-                onMouseLeave={handleMouseLeave}
                 onPointerMove={handleCanvasMouseMove}
                 onPointerDown={handleMouseDown}
                 onPointerUp={handleMouseUp}

--- a/src/services/ShaderRatingIntegration.ts
+++ b/src/services/ShaderRatingIntegration.ts
@@ -99,10 +99,12 @@ export class ShaderRatingService {
       
       if (!response.ok) throw new Error('Failed to submit rating');
       const updated = await response.json();
-      
-      // Update cache
+
+      // Update the individual cache entry and invalidate the list timestamp so
+      // the next enrichWithRatings() / getRating() call fetches fresh data.
       this.cache.set(shaderId, updated);
-      
+      this.lastFetch = 0;
+
       return updated;
     } catch (error) {
       console.error('ShaderRatingService.rateShader:', error);


### PR DESCRIPTION
## Summary

Architecture and stability fixes identified during a deep code review. All changes are targeted and non-breaking.

### Critical
- **Boot gate race (App.tsx):** The initial image auto-load was inside a one-shot boot gate guarded by `initialBootAppliedRef`. If the image manifest arrived *after* renderer+shaders were ready, the guard had already fired and the auto-load silently never happened. Separated into its own idempotent `useEffect` that fires whenever the manifest becomes available.

### High
- **LiveStreamBridge Safari leak:** The native-HLS path (Safari fallback) registered an anonymous arrow function as the `loadedmetadata` listener — impossible to remove. Stored it in a named variable and returned a proper cleanup function.
- **Star rating cache:** `ShaderRatingIntegration.rateShader()` updated the individual cache entry but left `lastFetch` unchanged, so `enrichWithRatings()` continued serving stale list data for up to 5 minutes. Now resets `lastFetch = 0` on successful submission.
- **Startup fetch cleanup:** Added `AbortController` to the image manifest fetch and an `isMounted` guard to the shader loader so in-flight requests don't call state setters on an unmounted component.

### Medium
- **Chaos mode debounce:** `setMode` had no guard against concurrent compilations. Added a `slotShaderStatusRef` (mirrors state without being in the dep array) and skip early if a slot is already `'loading'`, preventing chaos-mode pile-up.
- **Recording canvas selector:** Replaced `document.querySelector('canvas[data-testid="webgpu-canvas"]')` with a direct `webgpuCanvasRef` wired through a new `onCanvasRef` callback prop on `WebGPUCanvas`.

### Low
- **Mouse/Pointer double-fire (WebGPUCanvas):** Both `onMouse*` and `onPointer*` handlers were attached. Pointer events are a superset of mouse events; removed the `onMouse*` set to prevent each interaction firing the handler twice.
- **BroadcastChannel heartbeat:** Was unconditionally pulsing at 1 Hz even with no remote connected. Now starts only after receiving a `HELLO` message and uses a 5 s interval.

## Test plan

- [ ] Simulate slow manifest (DevTools throttle) — confirm image auto-loads once manifest arrives even when renderer was ready first
- [ ] Mount/unmount `LiveStreamBridge` in Safari — confirm no stale `loadedmetadata` listeners after cleanup
- [ ] Submit a star rating → immediately open the shader browser → confirm fresh rating appears (no 5-min wait)
- [ ] Hot-reload mid-startup — confirm no React "state update on unmounted component" warnings
- [ ] Enable chaos mode for 60 s — confirm no GPU crash or shader state desync
- [ ] Click on canvas while moving mouse — confirm no doubled mousemove events in console

https://claude.ai/code/session_011xBdbqLzTcezF2nxMLTQeT