### PR TITLE
Fix 405 play-count POST, bitonic-sort built-ins, sine-wave UnfilterableFloat

### DIFF
--- a/public/shaders/bitonic-sort.wgsl
+++ b/public/shaders/bitonic-sort.wgsl
@@ -22,9 +22,13 @@ struct Uniforms {
 
 // bitonic sort per workgroup skeleton: use dataTextureA as pixel buffer
 @compute @workgroup_size(16, 16, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-  let idx = local_invocation_id.x;
-  let pixel_idx = group_id.x * 256u + idx;
+fn main(
+    @builtin(global_invocation_id) global_id:    vec3<u32>,
+    @builtin(local_invocation_id)  local_id:     vec3<u32>,
+    @builtin(workgroup_id)         workgroup_id:  vec3<u32>,
+) {
+  let idx = local_id.x;
+  let pixel_idx = workgroup_id.x * 256u + idx;
   // Load: for simplicity, read from readTexture
   let width = u32(u.config.z);
   let x = pixel_idx % width;

--- a/public/shaders/sine-wave.wgsl
+++ b/public/shaders/sine-wave.wgsl
@@ -36,10 +36,11 @@ fn multi_octave_wave(pos: f32, time: f32, freq: f32, speed: f32, octaves: u32) -
     return value;
 }
 
-// Safe texture sampling with edge clamping
-fn sample_clamped(tex: texture_2d<f32>, samp: sampler, uv: vec2<f32>) -> vec4<f32> {
-    let clampedUV = clamp(uv, vec2<f32>(0.001), vec2<f32>(0.999));
-    return textureSampleLevel(tex, samp, clampedUV, 0.0);
+// Safe texture fetch with edge clamping (textureLoad avoids filtering-sampler restrictions)
+fn sample_load(tex: texture_2d<f32>, uv: vec2<f32>) -> vec4<f32> {
+    let dims = vec2<f32>(textureDimensions(tex));
+    let coords = clamp(vec2<i32>(uv * dims), vec2<i32>(0), vec2<i32>(dims) - vec2<i32>(1));
+    return textureLoad(tex, coords, 0);
 }
 
 @compute @workgroup_size(16, 16, 1)
@@ -79,17 +80,17 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (chromatic > 0.01) {
         // Red channel (least refraction)
         let redUV = finalUV - totalDisplacement * chromatic * 0.3;
-        finalColor.r = sample_clamped(readTexture, u_sampler, redUV).r;
-        
+        finalColor.r = sample_load(readTexture, redUV).r;
+
         // Green channel (medium refraction)
-        finalColor.g = sample_clamped(readTexture, u_sampler, finalUV).g;
-        
+        finalColor.g = sample_load(readTexture, finalUV).g;
+
         // Blue channel (most refraction)
         let blueUV = finalUV + totalDisplacement * chromatic * 0.3;
-        finalColor.b = sample_clamped(readTexture, u_sampler, blueUV).b;
+        finalColor.b = sample_load(readTexture, blueUV).b;
     } else {
         // Standard sampling without chromatic aberration
-        finalColor = sample_clamped(readTexture, u_sampler, finalUV).rgb;
+        finalColor = sample_load(readTexture, finalUV).rgb;
     }
 
     // --- Edge Darkening (vignette effect to hide clamping) ---
@@ -103,6 +104,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (chromatic > 0.01) {
         depthUV = finalUV + totalDisplacement * chromatic * 0.2;
     }
-    let depth = sample_clamped(readDepthTexture, non_filtering_sampler, depthUV).r;
+    let depth = sample_load(readDepthTexture, depthUV).r;
     textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -381,7 +381,10 @@ function MainApp() {
 
                 // Record play event (fire-and-forget)
                 if (ok) {
-                    fetch(`${SHADER_WGSL_URL}/${shaderEntry.id}/play`, { method: 'GET' }).catch(() => {});
+                    fetch(`${SHADER_WGSL_URL}/${shaderEntry.id}/play`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                    }).catch(() => {});
                 }
             } catch (error) {
                 console.error(`❌ Failed to load shader ${shaderEntry.id}:`, error);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **App.tsx**: Change `/play` fetch from `GET` to `POST` to match the backend `@app.post` route — eliminates the 405 flood and correctly records shader play counts
- **bitonic-sort.wgsl**: Declare missing `@builtin(local_invocation_id)` and `@builtin(workgroup_id)` parameters in `fn main()`; replace bare `local_invocation_id`/`group_id` references with the properly scoped `local_id`/`workgroup_id` variables
- **sine-wave.wgsl**: Replace `textureSampleLevel`-based `sample_clamped(tex, samp, uv)` helper with a sampler-free `sample_load(tex, uv)` using `textureLoad` — fixes the `UnfilterableFloat` pipeline creation crash on hardware without the `float32-filterable` feature

## Test plan

- [ ] Open DevTools console — zero 405 errors when switching shaders
- [ ] Network tab: switching any shader shows a POST request to `.../play` returning 200
- [ ] Load `bitonic-sort` shader — no "unresolved value 'local_invocation_id'" WGSL parse error
- [ ] Load `sine-wave` shader — no "UnfilterableFloat used with filtering sampler" pipeline error
- [ ] Visually verify sine-wave distortion still renders correctly

https://claude.ai/code/session_0141CAnNzUv37Bh14yhLcX6f
EOF
)