### PR TITLE
chore(weekly_plan): reshape to template + 2026-04-18 routine output

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,8 +1,48 @@
-# Weekly Plan & Notes
+# image_video_effects — Weekly Plan
 
-## Storage Manager Updates
-- Fixed CORS error causing `xFailed` when selecting shaders by adding `https://test1.1ink.us` to `ALLOWED_ORIGINS` in `storage_manager/app.py`.
-- Added new entries for `image` and `video` to the `STORAGE_MAP`, mapping to the `images/` and `videos/` Google Cloud Storage directories respectively.
-- Developed new endpoints to allow fetching and managing image (`/api/images`) and video (`/api/videos`) files via streaming directly from GCS to the client, utilizing `run_io` thread pooling, making them non-blocking.
-- Implemented corresponding metadata PUT update endpoints for images and videos (`/api/images/{id}` and `/api/videos/{id}`) with caching behavior to clear cache correctly upon update.
-- Implemented `sync-images` and `sync-videos` admin endpoints (`/api/admin/sync-...`) to maintain synchronization between GCS contents and the respective index files without manually modifying JSON arrays.
+## Today's focus
+**2026-04-18 — Multi-slot shader stacking stability audit + regression harness.**
+Foundation work: stabilize N-slot composition (bind groups, format negotiation, layer chain ordering) before layering AI VJ Mode or further shader authoring on top. Ties together recent `LAYER_CHAIN_FIX_SUMMARY.md`, `fix_multipass_chain.json`, `SHADER_PIPELINE_ENHANCEMENT.md` threads.
+
+## Ideas
+<!--
+Write ideas here during the week as they come to you.
+Routine prioritizes these over generated ideas.
+Format: - [ ] Short description (optional: more context on next line indented)
+Routine will mark picked items as "[in progress — YYYY-MM-DD]".
+-->
+- [ ] AI VJ Mode — prompt-to-shader-stack generation via in-browser Gemma-2-2b
+  Feed user vibe prompt → LLM picks N shaders + params from the 700+ library → renders a live VJ stack. Half-day prototype, multi-day polish.
+- [ ] Shader metadata normalization + full-text search over 700+ library
+  Reconcile `params_missing.md`, `SHADER_PARAMETER_AUDIT.md`, and `shader_params_extracted.json` into a single canonical metadata schema so the scanner/rating/AI-VJ paths share one source of truth. Full-day.
+
+## Backlog
+<!--
+Unfinished items, known bugs, deferred ideas.
+Routine maintains this automatically — you can add items too.
+-->
+- [ ] Storage Manager: verify `/api/images` and `/api/videos` streaming endpoints under load (thread-pool saturation, GCS token refresh edge cases)
+- [ ] Confirm CORS allowlist (`https://test1.1ink.us`) shipped to the VPS
+- [ ] `sync-images` / `sync-videos` admin endpoints need a dry-run mode before first prod run
+- [ ] Follow-up on immutable-let auto-fix scan — `IMMUTABLE_LET_FIX_REPORT.md` still has outstanding entries per scan logs
+- [ ] Bind-group compatibility report (`bindgroup_compatibility_report.json`) lists shaders flagged for mismatched layouts — unresolved
+- [ ] Runtime-error report (`runtime_errors_report.json`) needs triage pass
+
+## Done
+<!--
+Completed items, routine archives here with date.
+Prune occasionally when this gets long.
+-->
+- 2026-04-18: Storage Manager CORS fix for `test1.1ink.us`; image/video streaming endpoints; sync-images/sync-videos admin endpoints (archived from prior notes)
+- 2026-04-18: Obsidian Echo-Chamber generative shader merged (#536)
+- 2026-04-18: Hyper-Refractive Rain-Matrix generative shader merged (#534)
+- 2026-04-18: Bioluminescent Aether Pulsar generative shader merged
+- 2026-04-18: WebGPU renderer polish — 405 play-count POST fix, bitonic-sort built-ins, sine-wave UnfilterableFloat (#532)
+- 2026-04-18: Startup race, event leaks, rating cache stability fixes (#530)
+
+## Last run
+<!-- Routine writes summary here each run. Overwrites previous. -->
+Date: 2026-04-18
+Mode: New Idea
+Focus: Multi-slot shader stacking stability audit + regression harness
+Outcome: pending


### PR DESCRIPTION
## Summary
- Reshape `weekly_plan.md` to the standard Ideas / Backlog / Done / Last run template
- Seed `Ideas` with two unpicked New-Idea-mode directions (AI VJ Mode prompt-to-stack; shader metadata normalization + search)
- Set today's focus: multi-slot shader stacking stability audit + regression harness
- Archive recent shader + stability PRs into `Done` (Obsidian Echo-Chamber, Hyper-Refractive Rain-Matrix, Bioluminescent Aether Pulsar, WebGPU polish #532, stability fixes #530) and prior Storage Manager notes

## Test plan
- [ ] Confirm `weekly_plan.md` renders cleanly on GitHub
- [ ] Verify Ideas entries survive the next weekly-routine run as inherited context

https://claude.ai/code/session_01Szr1JQddSvX3e5YaQxRf1z