### PR TITLE
Pipeline health check report 2026-04-18

### DIFF
--- a/.pipeline-check-2026-04-18.md
+++ b/.pipeline-check-2026-04-18.md
@@ -1,0 +1,124 @@
+# Pixelocity Pipeline Health Check — 2026-04-18
+
+**Purpose:** Dry-run/verify pass of the full deployment pipeline. No production writes.
+**Branch:** `claude/test-pixelocity-pipeline-KwwnD`
+**Run by:** Claude Code (automated hygiene check)
+
+---
+
+## Step-by-Step Results
+
+### Step 1 — deploy.py dry-run support
+**FAIL (gap)**
+`scripts/deploy.py` accepts only `--force` and `--fresh`. No `--dry-run` or `--check` flag exists. Deployment cannot be simulated; every verification requires a live SFTP connection to DreamHost. Adding dry-run support is a separate task — not added today per scope.
+
+---
+
+### Step 2 — React build (`npm run build`)
+**PASS (with flag)**
+
+Build output:
+- Exit code: 0 — `Compiled successfully`
+- Main JS bundle (uncompressed): **7.5 MB** ← exceeds 5 MB threshold; gzipped size is 2.61 MB which is fine for serving but worth monitoring
+- Source map: 14 MB — not served in production, ignore
+- CSS bundle: 54 KB ✓
+- WGSL shaders in `build/shaders/`: **715 .wgsl files** ✓ (724 total entries including JSON manifests)
+- Shader lists regenerated (12 categories, total 711 shaders indexed across categories) ✓
+
+Note: `node_modules` was not pre-installed in the environment; `npm install` was required as a prerequisite (1395 packages). Any CI pipeline must include an install step.
+
+**Audit warnings:** 38 vulnerabilities (9 low, 6 moderate, 19 high, 4 critical) in npm dependency tree. Not blocking, but warrants a `npm audit fix` pass.
+
+---
+
+### Step 3 — WASM build (`wasm_renderer/build.sh`)
+**SKIP — emcc not available in this environment**
+
+`build.sh` exists and runs correctly. Emscripten (`emcc`) was not found at any of its expected paths:
+- `/content/build_space/emsdk/`
+- `$HOME/emsdk/`
+- `/usr/local/emsdk/`
+
+**Fallback behavior triggered:** `build.sh` created dummy stubs in `public/wasm/`:
+- `pixelocity_wasm.js` — **68 bytes** (non-functional stub)
+- `pixelocity_wasm.wasm` — 78 KB (pre-existing; not regenerated)
+- `wasm_bridge.js` — 11 KB (untouched, pre-existing) ✓
+- `wasm_renderer/wasm_bridge.d.ts` — present ✓
+
+**Critical hygiene issue:** Both the `prebuild` and `build` scripts swallow the emcc failure silently (`2>/dev/null || echo`), so the pipeline reports green even though WASM is broken. A 68-byte stub JS ships to production and would silently break the WASM renderer.
+
+---
+
+### Step 4 — deploy.py SFTP dry-run
+**SKIP — no dry-run mode**
+
+Per Step 1 findings: no dry-run flag exists. Running `deploy.py` would perform a live SFTP deploy to `test.1ink.us`. Skipped per task constraints.
+
+Additional finding: `deploy.py` contains a **hardcoded SSH password** (line ~298). This is a security violation — password is in plaintext in source control.
+
+---
+
+### Step 5 — VPS FastAPI health check
+**PASS**
+
+Endpoint: `https://storage.noahcohn.com/api/health`
+Response (HTTP 200):
+```json
+{
+    "status": "healthy",
+    "service": "storage-manager-api",
+    "timestamp": "2026-04-18T18:53:27.784813+00:00"
+}
+```
+VPS is reachable and reporting healthy. Response time: <10s.
+
+Note: The live endpoint returns `"status": "healthy"` while `storage_manager/app.py` source defines `"status": "online"`. The deployed version may differ from the current source — worth verifying the deployed `app.py` is in sync.
+
+---
+
+### Step 6 — GCS credential verification
+**SKIP — `google-cloud-storage` not installed locally**
+
+Expected environment variables:
+- `GCP_CREDENTIALS` — service account JSON (full key as string)
+- `GCP_BUCKET_NAME` — GCS bucket name
+
+`google.cloud.storage` Python package is not present in this environment (`ModuleNotFoundError`). GCS credential resolution cannot be verified locally without installing the package. The credential pattern in `storage_manager/app.py` is correct (uses `service_account.Credentials.from_service_account_info()`), but runtime verification was not possible.
+
+---
+
+## Top 3 Hygiene Gaps
+
+### 1. Hardcoded SSH password in `deploy.py` (CRITICAL)
+**File:** `scripts/deploy.py` ~line 298
+Password `'GoogleBez12!'` is stored in plaintext in source code. Anyone with read access to the repo has the DreamHost SSH credential. This should be moved to an environment variable (`DREAMHOST_SSH_PASS` or via SSH key auth).
+**Effort:** Half a day — swap to `os.environ.get('DEPLOY_PASSWORD')` + rotate the credential.
+
+### 2. WASM build failure is invisible (HIGH)
+**File:** `package.json` prebuild script + `wasm_renderer/build.sh`
+When `emcc` is missing, the build silently swallows the error and ships a 68-byte stub JS as `pixelocity_wasm.js`. The React build reports success, the deploy proceeds, and the WASM renderer silently breaks in production. The pipeline needs a hard failure when emcc is absent (or an explicit gate that only allows stubs in dev/CI, never in prod).
+**Effort:** Half a day — add an `ALLOW_WASM_STUB=true` guard in `build.sh`; fail hard by default; add `CI=true` check.
+
+### 3. No deploy.py dry-run mode (MEDIUM)
+**File:** `scripts/deploy.py`
+Every deploy verification requires a live SFTP connection. There's no way to preview which files would change without actually pushing them. This makes pre-deploy review manual and error-prone.
+**Effort:** Half a day — add `--dry-run` flag that runs the full diff logic (hash comparison, remote size check) but skips the actual `sftp.put()` calls; prints a summary of would-upload / would-skip / would-remove.
+
+---
+
+## Summary Table
+
+| Step | Status | Notes |
+|------|--------|-------|
+| 1. deploy.py dry-run flag | FAIL (gap) | No `--dry-run`/`--check` flag exists |
+| 2. npm run build | PASS | 7.5 MB uncompressed JS (flag); 715 WGSL shaders present |
+| 3. WASM build | SKIP | emcc not found; dummy stubs ship silently |
+| 4. deploy.py SFTP dry-run | SKIP | No dry-run mode; live deploy skipped per constraints |
+| 5. VPS FastAPI health | PASS | `{"status":"healthy"}` — reachable and online |
+| 6. GCS credentials | SKIP | `google-cloud-storage` not installed locally |
+
+**Pipeline status: AMBER** — Build and VPS are green; WASM and deploy tooling have active hygiene issues that need addressing before the next production push.
+
+---
+
+*Local report — do not commit to git.*


### PR DESCRIPTION
## Summary

- Adds `.pipeline-check-2026-04-18.md` — local pipeline hygiene report (dry-run/verify pass, no production changes)
- React build: PASS (715 WGSL shaders shipped, 7.5 MB uncompressed JS bundle)
- VPS FastAPI health: PASS (`storage.noahcohn.com/api/health` → healthy)
- WASM build: SKIP (emcc not available in environment; dummy stubs correctly not committed)
- deploy.py dry-run: FAIL/gap (no `--dry-run` flag exists)
- GCS credentials: SKIP (`google-cloud-storage` not installed locally)

## Top 3 Hygiene Gaps Found

1. **Hardcoded SSH password in `deploy.py` ~line 298** — plaintext credential in source; move to env var + rotate
2. **WASM stub ships silently** — `prebuild` swallows emcc failure; broken 68-byte stub deploys with a green build signal
3. **No deploy.py dry-run mode** — can't preview file diffs without a live SFTP push

## Test plan

- [ ] Review `.pipeline-check-2026-04-18.md` for accuracy
- [ ] Confirm report is not committed to main (local hygiene artifact only, or delete after review)
- [ ] File follow-up tasks for the 3 hygiene gaps before next production deploy

https://claude.ai/code/session_01RCHmV1TomfikSVqaiy8SoL