### PR TITLE
chore(plan): weekly routine 2026-05-02 — shader metadata normalization

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,8 +1,8 @@
 # image_video_effects — Weekly Plan
 
 ## Today's focus
-**2026-04-25 — AI VJ Mode: expand Alucinate to the full 961-shader library + add param suggestion.**
-Extend `src/AutoDJ.ts` (`Alucinate` class) to (1) build a unified cross-category shader manifest from all 15 category JSON files at runtime instead of a filtered generative-only subset, (2) add LLM-driven param suggestion alongside shader ID selection so each slot gets tuned params, and (3) wire a vibe-prompt text input in the Controls UI that fires a one-shot generation without waiting for the 25-second auto-loop cycle.
+**2026-05-02 — Shader metadata normalization + full-text search over the 918-shader library.**
+Create `src/services/shaderCatalog.ts` as the single canonical metadata service that merges the 15 `public/shader-lists/*.json` category files (918 shaders, tags/description) with `reports/shader_params_extracted.json` (693 shaders, rich per-param schemas with `mapping` and `description`). Build a lightweight in-memory full-text index (id + name + tags + description) on top of the merged catalog. Wire the search into `ShaderBrowserWithRatings` and update `Alucinate.buildShaderManifest()` to delegate to the new service so the AI VJ path shares one source of truth.
 
 ## Ideas
 <!--
@@ -11,9 +11,10 @@ Routine prioritizes these over generated ideas.
 Format: - [ ] Short description (optional: more context on next line indented)
 Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 -->
-- [in progress — 2026-04-25] AI VJ Mode — prompt-to-shader-stack generation via in-browser Gemma-2-2b
+- [x] AI VJ Mode — prompt-to-shader-stack generation via in-browser Gemma-2-2b
   Feed user vibe prompt → LLM picks N shaders + params from the 700+ library → renders a live VJ stack. Half-day prototype, multi-day polish.
-- [ ] Shader metadata normalization + full-text search over 700+ library
+  → Completed 2026-04-25 (buildShaderManifest all 15 categories, selectShadersFromLLM with params, vibe-prompt UI wired in Controls.tsx)
+- [in progress — 2026-05-02] Shader metadata normalization + full-text search over 700+ library
   Reconcile `params_missing.md`, `SHADER_PARAMETER_AUDIT.md`, and `shader_params_extracted.json` into a single canonical metadata schema so the scanner/rating/AI-VJ paths share one source of truth. Full-day.
 
 ## Backlog
@@ -24,16 +25,17 @@ Routine maintains this automatically — you can add items too.
 - [ ] Storage Manager: verify `/api/images` and `/api/videos` streaming endpoints under load (thread-pool saturation, GCS token refresh edge cases)
 - [ ] Confirm CORS allowlist (`https://test1.1ink.us`) shipped to the VPS
 - [ ] `sync-images` / `sync-videos` admin endpoints need a dry-run mode before first prod run
-- [ ] Follow-up on immutable-let auto-fix scan — `IMMUTABLE_LET_FIX_REPORT.md` still has outstanding entries per scan logs
-- [ ] Bind-group compatibility report (`bindgroup_compatibility_report.json`) lists shaders flagged for mismatched layouts — unresolved
-- [ ] Runtime-error report (`runtime_errors_report.json`) needs triage pass
-- [ ] Multi-slot regression harness still unbuilt — `slotOrchestrator.ts`, `multipassRegistry.ts`, `bindGroupValidator.ts` exist but no Jest test suite covers them; last week's focus did not land
+- [ ] Bind-group compatibility report (`reports/bindgroup_compatibility_report.json`, 22k-line JSON) needs triage pass — many shaders flagged for mismatched layouts
+- [ ] Runtime-error report (`reports/runtime_errors_report.json`): 49 shaders with errors out of 699 scanned (April 2026 scan — needs refresh + systematic fix pass)
+- [ ] Test runner broken: `typescript` missing from `node_modules`; run `npm install` in project root before `npm test` / Jest will fail with MODULE_NOT_FOUND. `npm run build` is unaffected.
+- [ ] `layerChain.spec.ts` (292-line multi-slot regression harness) passes structurally but cannot run until the `typescript` dep is restored — add a CI step to enforce `npm ci` before test.
 
 ## Done
 <!--
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- 2026-05-02: AI VJ Mode — Alucinate full-library manifest (all 15 categories, 918 shaders), LLM param suggestion (`selectShadersFromLLM` returns `{id, params}[]`), `onUpdateParams` callback, `generateFromVibe()` one-shot method, vibe-prompt text input + Generate button in Controls.tsx (kimi-cli swarm, confirmed via `.swarm-state.md` + code audit)
 - 2026-04-18: Storage Manager CORS fix for `test1.1ink.us`; image/video streaming endpoints; sync-images/sync-videos admin endpoints (archived from prior notes)
 - 2026-04-18: Obsidian Echo-Chamber generative shader merged (#536)
 - 2026-04-18: Hyper-Refractive Rain-Matrix generative shader merged (#534)
@@ -43,7 +45,7 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-04-25
+Date: 2026-05-02
 Mode: User Idea
-Focus: AI VJ Mode — Alucinate full-library + param suggestion + vibe-prompt UI
+Focus: Shader metadata normalization + full-text search (shaderCatalog.ts service)
 Outcome: pending


### PR DESCRIPTION
## Summary

- Marks AI VJ Mode complete (confirmed via `.swarm-state.md` + code audit of `AutoDJ.ts`, `App.tsx`, `Controls.tsx`)
- Sets today's focus to `shaderCatalog.ts` canonical metadata service + full-text search over 918-shader library
- Updates backlog: broken test runner (`typescript` missing from node_modules), clarified report file locations in `reports/`, removed phantom `IMMUTABLE_LET_FIX_REPORT.md` entry
- Marks "Shader metadata normalization" idea `[in progress — 2026-05-02]`

## Changes

`weekly_plan.md` only — no source code modified.

https://claude.ai/code/session_01X64jfLyXm45ftvYgSPNJbw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X64jfLyXm45ftvYgSPNJbw)_