### PR TITLE
chore: weekly plan update 2026-05-09 — WGSL error-fix pass focus

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,8 +1,8 @@
 # image_video_effects — Weekly Plan
 
 ## Today's focus
-**2026-05-02 — Shader metadata normalization + full-text search over the 918-shader library.**
-Create `src/services/shaderCatalog.ts` as the single canonical metadata service that merges the 15 `public/shader-lists/*.json` category files (918 shaders, tags/description) with `reports/shader_params_extracted.json` (693 shaders, rich per-param schemas with `mapping` and `description`). Build a lightweight in-memory full-text index (id + name + tags + description) on top of the merged catalog. Wire the search into `ShaderBrowserWithRatings` and update `Alucinate.buildShaderManifest()` to delegate to the new service so the AI VJ path shares one source of truth.
+**2026-05-09 — Systematic WGSL runtime-error fix pass over the 49 critical shaders in `reports/runtime_errors_report.json`.**
+kimi-cli iterates over every shader with `status: "critical"` (invalid_binding × 8, sampler_mismatch × 15, division_by_zero guards, array_bounds clamps, missing_write stubs). For each shader: read the error payload from the report, open the WGSL source in `public/shaders/`, apply the minimal targeted fix, re-validate with `naga` (or `wgsl-analyzer` if available), update `reports/runtime_errors_report.json` in-place to mark the shader clean. Save progress to `.swarm-state.md` at each iteration boundary. Do not touch `reports/bindgroup_compatibility_report.json` or any TypeScript/React files.
 
 ## Ideas
 <!--
@@ -14,8 +14,13 @@ Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 - [x] AI VJ Mode — prompt-to-shader-stack generation via in-browser Gemma-2-2b
   Feed user vibe prompt → LLM picks N shaders + params from the 700+ library → renders a live VJ stack. Half-day prototype, multi-day polish.
   → Completed 2026-04-25 (buildShaderManifest all 15 categories, selectShadersFromLLM with params, vibe-prompt UI wired in Controls.tsx)
-- [in progress — 2026-05-02] Shader metadata normalization + full-text search over 700+ library
+- [x] Shader metadata normalization + full-text search over 700+ library
   Reconcile `params_missing.md`, `SHADER_PARAMETER_AUDIT.md`, and `shader_params_extracted.json` into a single canonical metadata schema so the scanner/rating/AI-VJ paths share one source of truth. Full-day.
+  → Completed 2026-05-02 (shaderCatalog.ts built, wired into ShaderBrowserWithRatings + AutoDJ.buildShaderManifest)
+- [ ] AI VJ stack persistence + history panel
+  Add localStorage save/load of generated stacks, a "VJ history" panel showing last N stacks with their vibe prompts, and a one-click "regenerate variation" button. Surface live shader IDs in the UI. Half-day.
+- [ ] Per-shader param presets + AI VJ randomizer
+  Build a preset system for param combos (keyed off shaderCatalog), add a "randomize params" operator that samples within min/max/step ranges for each shader in the active AI VJ stack. Enables live-performance use. Full-day.
 
 ## Backlog
 <!--
@@ -26,7 +31,6 @@ Routine maintains this automatically — you can add items too.
 - [ ] Confirm CORS allowlist (`https://test1.1ink.us`) shipped to the VPS
 - [ ] `sync-images` / `sync-videos` admin endpoints need a dry-run mode before first prod run
 - [ ] Bind-group compatibility report (`reports/bindgroup_compatibility_report.json`, 22k-line JSON) needs triage pass — many shaders flagged for mismatched layouts
-- [ ] Runtime-error report (`reports/runtime_errors_report.json`): 49 shaders with errors out of 699 scanned (April 2026 scan — needs refresh + systematic fix pass)
 - [ ] Test runner broken: `typescript` missing from `node_modules`; run `npm install` in project root before `npm test` / Jest will fail with MODULE_NOT_FOUND. `npm run build` is unaffected.
 - [ ] `layerChain.spec.ts` (292-line multi-slot regression harness) passes structurally but cannot run until the `typescript` dep is restored — add a CI step to enforce `npm ci` before test.
 
@@ -35,6 +39,7 @@ Routine maintains this automatically — you can add items too.
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- 2026-05-09: Shader metadata normalization — `shaderCatalog.ts` service built (merges 15 category JSONs + shader_params_extracted.json, in-memory full-text index, module-level cache), wired into `ShaderBrowserWithRatings` (search) and `AutoDJ.buildShaderManifest()` (AI VJ path). Single source of truth confirmed in code audit.
 - 2026-05-02: AI VJ Mode — Alucinate full-library manifest (all 15 categories, 918 shaders), LLM param suggestion (`selectShadersFromLLM` returns `{id, params}[]`), `onUpdateParams` callback, `generateFromVibe()` one-shot method, vibe-prompt text input + Generate button in Controls.tsx (kimi-cli swarm, confirmed via `.swarm-state.md` + code audit)
 - 2026-04-18: Storage Manager CORS fix for `test1.1ink.us`; image/video streaming endpoints; sync-images/sync-videos admin endpoints (archived from prior notes)
 - 2026-04-18: Obsidian Echo-Chamber generative shader merged (#536)
@@ -45,7 +50,7 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-05-02
-Mode: User Idea
-Focus: Shader metadata normalization + full-text search (shaderCatalog.ts service)
+Date: 2026-05-09
+Mode: New Idea
+Focus: Systematic WGSL runtime-error fix pass (49 critical shaders from runtime_errors_report.json)
 Outcome: pending


### PR DESCRIPTION
## Summary

- Marks `shaderCatalog.ts` work as Done (confirmed wired into `ShaderBrowserWithRatings` + `AutoDJ.buildShaderManifest`)
- Sets today's focus to systematic WGSL runtime-error fix pass (49 critical shaders in `reports/runtime_errors_report.json`)
- Appends two new Ideas to the backlog: AI VJ stack persistence + history panel; per-shader param presets + AI VJ randomizer
- Updates Last run metadata (mode: New Idea, 2026-05-09)

## Test plan

- [ ] `weekly_plan.md` renders correctly in GitHub markdown preview
- [ ] Done section reflects accurate completion dates
- [ ] Ideas section has two new unchecked items appended

https://claude.ai/code/session_015QzboAiUKLAS1pB1vcG7UE

---
_Generated by [Claude Code](https://claude.ai/code/session_015QzboAiUKLAS1pB1vcG7UE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development planning and progress tracking documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/image_video_effects/pull/609)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->