### PR TITLE
Implement Eldritch Tesseract-Hive Mind generative shader

### DIFF
--- a/public/shader-lists/advanced-hybrid.json
+++ b/public/shader-lists/advanced-hybrid.json
@@ -1,219 +1,117 @@
 [
   {
-    "id": "block-distort-em",
-    "name": "Block Distort EM",
-    "url": "shaders/block-distort-em.wgsl",
+    "id": "aero-chromatics-prismatic",
+    "name": "Aero Chromatics Prismatic",
+    "url": "shaders/aero-chromatics-prismatic.wgsl",
     "category": "advanced-hybrid",
-    "description": "Grid blocks pushed by mouse proximity, distorted by electromagnetic field lines. Electric field displaces UVs, magnetic field rotates hue. Click ripples spawn orbiting secondary charges.",
-    "features": [
-      "mouse-driven",
-      "field-simulation",
+    "description": "Wind-driven chromatic smoke trails enhanced with physical prismatic dispersion via Cauchy's equation. Each wavelength refracts at a different angle through a virtual lens, creating rainbow edge effects on advected smoke.",
+    "tags": [
+      "prismatic",
+      "dispersion",
       "chromatic",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Block Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Push Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "RGB Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Field Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "electromagnetic",
-      "distortion",
-      "chromatic"
-    ]
-  },
-  {
-    "id": "aurora-rift-iridescence",
-    "name": "Aurora Rift Iridescence",
-    "url": "shaders/aurora-rift-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Atmospheric curl-flow aurora blended with thin-film interference. Pattern density drives soap-bubble and oil-slick film thickness, producing flowing iridescence that rides the aurora's organic motion.",
-    "tags": [
-      "iridescence",
-      "thin-film",
-      "aurora",
-      "volumetric",
-      "atmospheric",
-      "spectral",
-      "interference"
+      "cauchy",
+      "smoke",
+      "simulation"
     ],
     "features": [
-      "thin-film-interference",
-      "volumetric",
-      "curl-noise",
+      "prismatic-dispersion",
+      "chromatic-advection",
+      "cauchy-equation",
       "mouse-driven",
-      "depth-aware",
-      "HDR"
+      "spectral"
     ],
     "params": [
       {
-        "id": "scale",
-        "name": "Pattern Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "flow_speed",
-        "name": "Flow Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "film_ior",
-        "name": "Film IOR",
+        "id": "wind",
+        "name": "Wind Force",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "intensity",
-        "name": "Iridescence Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "decay",
+        "name": "Smoke Decay",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chroma",
+        "name": "Chromatic Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "source",
+        "name": "Source Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ],
     "target_rating": 4.8
   },
   {
-    "id": "predator-prey-rgba",
-    "name": "Predator-Prey RGBA",
-    "url": "shaders/predator-prey-rgba.wgsl",
+    "id": "aerogel-smoke-hdr",
+    "name": "Aerogel Smoke HDR",
+    "url": "shaders/aerogel-smoke-hdr.wgsl",
     "category": "advanced-hybrid",
-    "description": "Continuous-density predator-prey ecosystem simulation packed into RGBA32FLOAT. Plants photosynthesize using source image luminance, herbivores graze, carnivores hunt, and toxins accumulate from overpopulation. Species diffuse across the grid creating emergent spatial waves.",
+    "description": "Ethereal aerogel volumetric smoke with HDR bloom enhancement. Silica nanoparticle scattering combines with an HDR bloom kernel that amplifies overbright regions, creating luminous glow around dense scattering zones.",
     "tags": [
-      "predator-prey",
-      "ecosystem",
-      "simulation",
-      "food-chain",
-      "rgba-state-machine",
-      "emergent",
-      "interactive",
-      "mouse-driven",
-      "temporal"
+      "volumetric",
+      "HDR",
+      "bloom",
+      "scattering",
+      "aerogel",
+      "atmospheric"
     ],
     "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
+      "volumetric-scattering",
+      "HDR-bloom",
+      "rayleigh-mie",
+      "rgba-data-channel",
+      "mouse-driven"
     ],
     "params": [
       {
-        "id": "eatProbability",
-        "name": "Eat Probability",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "deathRate",
-        "name": "Death Rate",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "plantGrowth",
-        "name": "Plant Growth",
+        "id": "density",
+        "name": "Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "toxinStrength",
-        "name": "Toxin Strength",
+        "id": "scattering",
+        "name": "Blue Scatter",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Light Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "bloom",
+        "name": "HDR Bloom",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
-    ]
-  },
-  {
-    "id": "bubble-lens-coupled",
-    "name": "Bubble Lens Coupled",
-    "url": "shaders/bubble-lens-coupled.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Magnifying bubble lens warped by fluid dynamics. Mouse movement drags viscous fluid that distorts the lens boundary and creates vortices inside. Click ripples create fluid bursts.",
-    "features": [
-      "mouse-driven",
-      "fluid-simulation",
-      "lens-distortion",
-      "temporal"
     ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Bubble Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Magnification",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "Film Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "fluid",
-      "lens",
-      "distortion",
-      "interactive"
-    ]
+    "target_rating": 4.8
   },
   {
     "id": "anisotropic-kuwahara-nlm",
@@ -274,3356 +172,6 @@
     "target_rating": 4.5
   },
   {
-    "id": "bio-lenia-rgba",
-    "name": "Bio Lenia RGBA",
-    "url": "shaders/bio-lenia-rgba.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Four-species continuous cellular automata with Lenia-style smooth growth functions applied to each RGBA channel. Combines reaction-diffusion chemistry with biological emergence patterns. Cross-inhibition between species pairs creates complex multi-color morphologies.",
-    "tags": [
-      "lenia",
-      "cellular-automata",
-      "reaction-diffusion",
-      "biological",
-      "emergence",
-      "simulation",
-      "rgba-state-machine",
-      "continuous-ca",
-      "colorful"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "radius",
-        "name": "Kernel Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "growthCenter",
-        "name": "Growth Center",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "crossInhibit",
-        "name": "Cross Inhibition",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "timeStep",
-        "name": "Time Step",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "stellar-plasma-blackbody",
-    "name": "Stellar Plasma Blackbody",
-    "url": "shaders/stellar-plasma-blackbody.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Cosmic nebula domain-warped FBM blended with Planck's law blackbody thermal coloring. Energy intensity drives temperature mapping \u2014 cool voids glow ember-red, hot plasma cores burn blue-white with physically-correct radiance scaling.",
-    "tags": [
-      "blackbody",
-      "thermal",
-      "plasma",
-      "nebula",
-      "procedural",
-      "cosmic",
-      "HDR",
-      "physics"
-    ],
-    "features": [
-      "generative",
-      "blackbody-radiation",
-      "procedural",
-      "audio-reactive",
-      "mouse-driven",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "temp_shift",
-        "name": "Temperature Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Evolution Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "zoom_scale",
-        "name": "Zoom Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "thermal_intensity",
-        "name": "Thermal Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "spec-importance-sampled-bokeh",
-    "name": "Importance Sampled Bokeh",
-    "url": "shaders/spec-importance-sampled-bokeh.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Bokeh blur guided by image brightness using importance sampling. Bright pixels act as point light sources creating crisp bokeh highlights with smooth backgrounds via golden angle spiral distribution.",
-    "tags": [
-      "bokeh",
-      "importance-sampling",
-      "blur",
-      "depth-of-field",
-      "golden-angle",
-      "HDR"
-    ],
-    "features": [
-      "importance-sampling",
-      "bokeh",
-      "mouse-driven",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "radius",
-        "name": "Bokeh Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "shape",
-        "name": "Highlight Shape",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "brightness",
-        "name": "Brightness Boost",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chroma",
-        "name": "Chromatic Aberration",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "wave-equation-rgba-fluid",
-    "name": "Wave Equation RGBA Fluid",
-    "url": "shaders/wave-equation-rgba-fluid.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Coupled wave equation and incompressible fluid simulation packed into RGBA32FLOAT. Wave height and velocity drive fluid motion while fluid pressure dampens waves. Dye advection visualizes the combined flow field with rainbow phase coloring.",
-    "tags": [
-      "wave",
-      "fluid",
-      "simulation",
-      "physics",
-      "navier-stokes",
-      "rgba-state-machine",
-      "interactive",
-      "mouse-driven",
-      "temporal",
-      "colorful"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "depth-aware"
-    ],
-    "params": [
-      {
-        "id": "waveSpeed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "damping",
-        "name": "Wave Damping",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "viscosity",
-        "name": "Fluid Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "sourceStrength",
-        "name": "Source Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "thermal-touch-blackbody",
-    "name": "Thermal Touch Blackbody",
-    "url": "shaders/thermal-touch-blackbody.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Mouse-driven thermal camera with blackbody radiation coloring. The cursor acts as a localized heat source and image brightness maps to physically-correct temperature via Planck's law.",
-    "tags": [
-      "thermal",
-      "blackbody",
-      "mouse-driven",
-      "physics",
-      "spectral",
-      "HDR"
-    ],
-    "features": [
-      "blackbody-radiation",
-      "mouse-heat-source",
-      "physical-color",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "heat_intensity",
-        "name": "Heat Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "radius",
-        "name": "Heat Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "ambient",
-        "name": "Ambient Temperature",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "blend",
-        "name": "Original Blend",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "bio-touch-em",
-    "name": "Bio Touch EM",
-    "url": "shaders/bio-touch-em.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Bio-luminescent cellular structures distorted by electromagnetic field lines. Magnetic field rotates cell glow colors. Click ripples spawn orbiting secondary charges.",
-    "features": [
-      "mouse-driven",
-      "field-simulation",
-      "organic",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Glow Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Cell Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Field Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "organic",
-      "electromagnetic",
-      "glow",
-      "interactive"
-    ]
-  },
-  {
-    "id": "glass-refraction-prismatic",
-    "name": "Glass Refraction Prismatic",
-    "url": "shaders/glass-refraction-prismatic.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Raymarched glass blobs with 4-band spectral dispersion using Cauchy's equation and CIE color matching. Each wavelength refracts at a different angle through animated SDF glass surfaces.",
-    "features": [
-      "advanced-hybrid",
-      "raymarched",
-      "spectral-dispersion",
-      "physical-refraction",
-      "mouse-driven",
-      "depth-aware",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "transparency",
-        "name": "Transparency",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Glass transparency / thickness"
-      },
-      {
-        "id": "dispersion",
-        "name": "Cauchy B Coefficient",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Spectral dispersion strength via Cauchy's B parameter"
-      },
-      {
-        "id": "thickness",
-        "name": "Thickness Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Absorption thickness scale"
-      },
-      {
-        "id": "roughness",
-        "name": "Surface Roughness",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Surface roughness affecting specular highlights"
-      }
-    ],
-    "chunks_used": [
-      "sdSphere, smoothUnion, map, calcNormal (glass_refraction_alpha.wgsl)",
-      "fresnel, refractRay (glass_refraction_alpha.wgsl)",
-      "cauchyIOR, wavelengthToRGB (spec-prismatic-dispersion.wgsl)"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "glass",
-      "refraction",
-      "spectral",
-      "prismatic",
-      "physical",
-      "chromatic"
-    ]
-  },
-  {
-    "id": "particle-dreams-hdr",
-    "name": "Particle Dreams HDR",
-    "url": "shaders/particle-dreams-hdr.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Multi-layer depth particle accumulation with HDR bloom chain. 5 depth layers with flow noise and vortex distortion, combined with exposure-based radial bloom and ACES tone mapping.",
-    "features": [
-      "advanced-hybrid",
-      "multi-pass-accumulation",
-      "hdr-bloom",
-      "depth-aware",
-      "mouse-driven",
-      "temporal",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "bloom_radius",
-        "name": "Bloom Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Radius of HDR bloom kernel"
-      },
-      {
-        "id": "bloom_intensity",
-        "name": "Bloom Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Intensity of bloom accumulation"
-      },
-      {
-        "id": "exposure",
-        "name": "Tone Map Exposure",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "ACES tone mapping exposure bias"
-      },
-      {
-        "id": "fog_density",
-        "name": "Fog Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Volumetric fog density"
-      }
-    ],
-    "chunks_used": [
-      "Layer accumulation, flow noise (particle_dreams_alpha.wgsl)",
-      "HDR bloom kernel, ACES tone map (alpha-hdr-bloom-chain.wgsl)",
-      "Depth chromatic aberration (particle_dreams_alpha.wgsl)"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "particles",
-      "hdr",
-      "bloom",
-      "depth",
-      "dreamy",
-      "volumetric"
-    ]
-  },
-  {
-    "id": "gen-astro-orrery-blackbody",
-    "name": "Astro Orrery Blackbody",
-    "url": "shaders/gen-astro-orrery-blackbody.wgsl",
-    "category": "advanced-hybrid",
-    "description": "A kinetic astronomical orrery where each ring's thermal energy determines its blackbody color. Rotating rings glow with physically accurate star temperatures from cool red dwarfs to blazing blue giants.",
-    "tags": [
-      "astronomical",
-      "blackbody",
-      "thermal",
-      "orrery",
-      "space",
-      "physical",
-      "HDR"
-    ],
-    "features": [
-      "audio-reactive",
-      "mouse-driven",
-      "raymarched",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "complexity",
-        "name": "Ring Complexity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Orbital Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "audio",
-        "name": "Audio Reactivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "bioluminescent-blackbody",
-    "name": "Bioluminescent Blackbody",
-    "url": "shaders/bioluminescent-blackbody.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Living organic growth patterns with physically-correct thermal coloring. Growth energy maps to blackbody temperature \u2014 cooler regions glow deep red, active growth burns orange-yellow, and intense hotspots reach white-hot temperatures.",
-    "tags": [
-      "bioluminescent",
-      "blackbody",
-      "organic",
-      "growth",
-      "thermal",
-      "physics"
-    ],
-    "features": [
-      "organic-growth",
-      "blackbody-thermal",
-      "bioluminescence",
-      "interactive",
-      "temporal-persistence",
-      "depth-aware"
-    ],
-    "params": [
-      {
-        "id": "spread",
-        "name": "Spread Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "density",
-        "name": "Branch Density",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "spores",
-        "name": "Spore Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "holographic-interferometry-bilateral",
-    "name": "Holographic Interferometry Bilateral",
-    "url": "shaders/holographic-interferometry-bilateral.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Simulated hologram with interference fringes and edge-preserving bilateral smoothing. Speckle noise is softly reduced while sharp interference fringe edges remain crisp.",
-    "features": [
-      "advanced-hybrid",
-      "holography",
-      "bilateral-filter",
-      "interference-patterns",
-      "speckle-reduction",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "fringe_density",
-        "name": "Fringe Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of interference fringes"
-      },
-      {
-        "id": "coherence",
-        "name": "Coherence Length",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Laser coherence (affects speckle size)"
-      },
-      {
-        "id": "reconstruction_angle",
-        "name": "Reconstruction Angle",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Hologram reconstruction angle"
-      },
-      {
-        "id": "saturation",
-        "name": "Color Saturation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Saturation of holographic colors"
-      }
-    ],
-    "advanced_params": [
-      {
-        "id": "bilateral_spatial",
-        "name": "Bilateral Spatial",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.x",
-        "description": "Spatial sigma of bilateral filter"
-      },
-      {
-        "id": "bilateral_color",
-        "name": "Bilateral Color",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.y",
-        "description": "Color sigma of bilateral filter"
-      },
-      {
-        "id": "bilateral_blend",
-        "name": "Bilateral Blend",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.z",
-        "description": "Blend between original hologram and smoothed result"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (holographic-interferometry.wgsl)",
-      "speckleNoise (holographic-interferometry.wgsl)",
-      "interferencePattern (holographic-interferometry.wgsl)",
-      "reconstructHologram (holographic-interferometry.wgsl)",
-      "bilateral filter (conv-bilateral-dream.wgsl)"
-    ],
-    "performance_target": "30-40 FPS (GTX 1060)",
-    "created_by": "Agent CB-3 \u2014 Convolution Post-Processor",
-    "created_date": "2026-04-18",
-    "tags": [
-      "hologram",
-      "interference",
-      "bilateral",
-      "speckle",
-      "rainbow"
-    ]
-  },
-  {
-    "id": "gen-raptor-mini-flow",
-    "name": "Raptor Mini Flow",
-    "url": "shaders/gen-raptor-mini-flow.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Predatory raptor agents navigate structure-tensor flow fields, hunting along image edges and orientations. Their trails follow dominant eigenvectors while audio rage pulses through the swarm.",
-    "tags": [
-      "predator",
-      "flow-field",
-      "cellular",
-      "audio-reactive",
-      "mouse-driven",
-      "organic",
-      "generative"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware"
-    ],
-    "params": [
-      {
-        "id": "turn",
-        "name": "Turn Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Max Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "rage",
-        "name": "Rage Duration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "flow",
-        "name": "Flow Influence",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "circuit-breaker-explosion",
-    "name": "Circuit Breaker Explosion",
-    "url": "shaders/circuit-breaker-explosion.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Circuit board edges chromatically separated near the mouse prism. Overload flashes become spectral rainbows. Click ripples launch chromatic shockwaves through the circuit pattern.",
-    "features": [
-      "mouse-driven",
-      "chromatic",
-      "circuit-simulation",
-      "glitch"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Grid Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Overload",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "Jitter",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Prism Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "chromatic",
-      "circuit",
-      "glitch",
-      "interactive"
-    ]
-  },
-  {
-    "id": "liquid-metal-prismatic",
-    "name": "Liquid Metal Prismatic",
-    "url": "shaders/liquid-metal-prismatic.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Liquid metal ripple distortion combined with 4-band spectral prismatic dispersion. Curved metal surface acts as a dynamic liquid prism \u2014 ripples create varying curvature that refracts light into separated wavelength bands via Cauchy's equation.",
-    "tags": [
-      "prismatic",
-      "dispersion",
-      "liquid",
-      "metal",
-      "spectral",
-      "chromatic",
-      "physical"
-    ],
-    "features": [
-      "spectral-rendering",
-      "liquid",
-      "metallic",
-      "physical-dispersion",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "ripple_speed",
-        "name": "Ripple Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "ripple_intensity",
-        "name": "Ripple Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "curvature",
-        "name": "Prism Curvature",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "spectral_sat",
-        "name": "Spectral Saturation",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "photonic-caustics-iridescence",
-    "name": "Photonic Caustics Iridescence",
-    "url": "shaders/photonic-caustics-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Backward photon-traced caustics combined with thin-film interference iridescence. Caustic intensity modulates film thickness, creating soap-bubble colors on light concentrations. Features chromatic dispersion, Fresnel reflections, and temporal accumulation.",
-    "tags": [
-      "caustics",
-      "iridescence",
-      "thin-film",
-      "interference",
-      "spectral",
-      "refraction",
-      "dispersion",
-      "photon-tracing",
-      "temporal"
-    ],
-    "features": [
-      "depth-aware",
-      "temporal",
-      "spectral-render",
-      "mouse-driven",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "ior",
-        "name": "Index of Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "lightSize",
-        "name": "Light Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "dispersion",
-        "name": "Chromatic Dispersion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "charcoal-rub-diffusion",
-    "name": "Charcoal Rub + Anisotropic Diffusion",
-    "url": "shaders/charcoal-rub-diffusion.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Physical charcoal media simulation with Perona-Malik anisotropic diffusion preprocessing. Diffusion creates smooth tonal regions before charcoal conversion, with diffusion coefficient modulating charcoal density.",
-    "tags": [
-      "charcoal",
-      "anisotropic-diffusion",
-      "physical-media",
-      "drawing",
-      "edge-preserving",
-      "convolution"
-    ],
-    "features": [
-      "advanced-convolution",
-      "upgraded-rgba",
-      "mouse-driven",
-      "temporal",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Hardness",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Texture Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Reveal Rate",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Diffusion Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.5
-  },
-  {
-    "id": "aurora-rift-2-iridescence",
-    "name": "Aurora Rift 2 Iridescence",
-    "url": "shaders/aurora-rift-2-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Iridescent aurora curtains combining volumetric aurora simulation with thin-film interference. Each aurora layer gets soap-bubble/oil-slick coloring from optical path difference. Optical depth modulates film thickness; viewing angle drives color shift. Beer's Law transmittance composites physically.",
-    "features": [
-      "thin-film-interference",
-      "aurora",
-      "volumetric",
-      "depth-aware",
-      "spectral-render",
-      "mouse-driven",
-      "HDR",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Overall aurora and iridescence intensity"
-      },
-      {
-        "id": "speed",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Aurora curtain drift speed"
-      },
-      {
-        "id": "depth_weight",
-        "name": "Depth Weight",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Depth influence on alpha layering"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Noise turbulence for film thickness variation"
-      }
-    ],
-    "chunks_used": [
-      "fbm (aurora-rift-2)",
-      "physicalTransmittance / Beer's Law (aurora-rift-2)",
-      "thinFilmColor (spec-iridescence-engine)",
-      "wavelengthToRGB (spec-iridescence-engine)"
-    ],
-    "tags": [
-      "aurora",
-      "iridescence",
-      "thin-film",
-      "interference",
-      "volumetric",
-      "spectral",
-      "atmospheric"
-    ],
-    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
-    "created_date": "2026-04-18"
-  },
-  {
-    "id": "retro-phosphor-stipple",
-    "name": "Retro Phosphor Stipple",
-    "url": "shaders/retro-phosphor-stipple.wgsl",
-    "category": "advanced-hybrid",
-    "description": "CRT phosphor simulation with blue-noise stippled dot triads. Authentic barrel distortion, scanlines, and temporal persistence combined with perceptually optimal blue-noise dot placement for each RGB channel.",
-    "features": [
-      "advanced-hybrid",
-      "crt-simulation",
-      "blue-noise",
-      "stippling",
-      "temporal-persistence",
-      "audio-reactive",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "curvature",
-        "name": "Screen Curvature",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Barrel distortion strength"
-      },
-      {
-        "id": "phosphor_scale",
-        "name": "Phosphor Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Size of blue-noise phosphor dots"
-      },
-      {
-        "id": "scanlines",
-        "name": "Scanline Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "CRT scanline darkness"
-      },
-      {
-        "id": "flicker",
-        "name": "Flicker Intensity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Interlaced field flicker"
-      }
-    ],
-    "chunks_used": [
-      "Barrel distortion, scanlines, persistence (retro_phosphor_dream.wgsl)",
-      "Blue-noise offset, golden angle disk (spec-blue-noise-stipple.wgsl)"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "crt",
-      "retro",
-      "phosphor",
-      "blue-noise",
-      "stipple",
-      "vintage"
-    ]
-  },
-  {
-    "id": "glass-wipes-coupled",
-    "name": "Glass Wipes Coupled",
-    "url": "shaders/glass-wipes-coupled.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Rain on glass combined with viscous fluid coupling physics. Rain drops feed a fluid simulation that creates realistic water streaks, while the mouse wiper clears fluid with vortex dynamics.",
-    "tags": [
-      "glass",
-      "rain",
-      "fluid",
-      "simulation",
-      "water",
-      "temporal",
-      "mouse-driven"
-    ],
-    "features": [
-      "mouse-driven",
-      "fluid-simulation",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "rain_intensity",
-        "name": "Rain Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "viscosity",
-        "name": "Fluid Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "wiper_size",
-        "name": "Wiper Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "vortex_strength",
-        "name": "Vortex Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "thermal-vision-blackbody",
-    "name": "Thermal Vision Blackbody",
-    "url": "shaders/thermal-vision-blackbody.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Physically-correct thermal vision camera using blackbody radiation via Planck's law. Image luminance maps to real temperature colors, with mouse acting as a localized heat source and configurable sensor contrast.",
-    "tags": [
-      "thermal",
-      "blackbody",
-      "physics",
-      "spectral",
-      "HDR",
-      "mouse-driven"
-    ],
-    "features": [
-      "blackbody-radiation",
-      "thermal-vision",
-      "mouse-driven",
-      "HDR",
-      "physical-color"
-    ],
-    "params": [
-      {
-        "id": "temp_low",
-        "name": "Temperature Low",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "temp_high",
-        "name": "Temperature High",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "contrast",
-        "name": "Sensor Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "atmos-fog-volumetric",
-    "name": "Atmospheric Fog Volumetric",
-    "url": "shaders/atmos-fog-volumetric.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Enhanced volumetric fog combining physical transmittance with interactive depth-layered alpha. Mouse clears fog locally, ripples create swirling disturbances, and height-based density mixes with Beer's Law for atmospheric realism.",
-    "tags": [
-      "volumetric",
-      "fog",
-      "atmosphere",
-      "depth-aware",
-      "mouse-driven",
-      "physics"
-    ],
-    "features": [
-      "volumetric-fog",
-      "depth-aware",
-      "mouse-clear",
-      "ripple-swirl",
-      "beers-law",
-      "rgba-data-channel"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Fog Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "height",
-        "name": "Fog Height",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "depth_weight",
-        "name": "Depth Weight",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "liquid-magnetic-ferro-em",
-    "name": "Liquid Magnetic Ferro EM",
-    "url": "shaders/liquid-magnetic-ferro-em.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Ferrofluid simulation coupled with electromagnetic wave propagation. Rosensweig instability spikes are driven by both static magnetic dipoles and time-varying EM waves, with metallic iridescence colored by field direction.",
-    "features": [
-      "advanced-hybrid",
-      "ferrofluid",
-      "em-simulation",
-      "wave-propagation",
-      "mouse-driven",
-      "temporal",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "field_strength",
-        "name": "Field Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Base magnetic field strength"
-      },
-      {
-        "id": "spike_sharpness",
-        "name": "Spike Sharpness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Ferrofluid peak sharpness"
-      },
-      {
-        "id": "em_coupling",
-        "name": "EM Coupling",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "How much EM wave affects the fluid"
-      },
-      {
-        "id": "dipoles",
-        "name": "Dipole Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Number of orbiting magnetic dipoles"
-      }
-    ],
-    "chunks_used": [
-      "Magnetic dipole field, Rosensweig spikes (liquid_magnetic_ferro.wgsl)",
-      "EM wave propagation, charge injection (alpha-em-field-simulation.wgsl)",
-      "Value noise, fbm2 (alpha-em-field-simulation.wgsl)"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "ferrofluid",
-      "magnetic",
-      "em-field",
-      "waves",
-      "metallic",
-      "simulation"
-    ]
-  },
-  {
-    "id": "aero-chromatics-prismatic",
-    "name": "Aero Chromatics Prismatic",
-    "url": "shaders/aero-chromatics-prismatic.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Wind-driven chromatic smoke trails enhanced with physical prismatic dispersion via Cauchy's equation. Each wavelength refracts at a different angle through a virtual lens, creating rainbow edge effects on advected smoke.",
-    "tags": [
-      "prismatic",
-      "dispersion",
-      "chromatic",
-      "cauchy",
-      "smoke",
-      "simulation"
-    ],
-    "features": [
-      "prismatic-dispersion",
-      "chromatic-advection",
-      "cauchy-equation",
-      "mouse-driven",
-      "spectral"
-    ],
-    "params": [
-      {
-        "id": "wind",
-        "name": "Wind Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "decay",
-        "name": "Smoke Decay",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chroma",
-        "name": "Chromatic Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "source",
-        "name": "Source Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "sim-heat-haze-blackbody",
-    "name": "Heat Haze Blackbody",
-    "url": "shaders/sim-heat-haze-blackbody.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Temperature field convection simulation with physically-correct blackbody thermal glow. Hot ground and rising convection plumes radiate with Planck's law colors \u2014 cool air stays neutral while intense heat sources glow from red ember to blue-white.",
-    "tags": [
-      "blackbody",
-      "thermal",
-      "heat",
-      "haze",
-      "simulation",
-      "convection",
-      "physics"
-    ],
-    "features": [
-      "simulation",
-      "blackbody-radiation",
-      "temperature-field",
-      "convection",
-      "mouse-driven",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "temperature",
-        "name": "Temperature Intensity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "convection_speed",
-        "name": "Convection Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion Strength",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "heat_sources",
-        "name": "Heat Source Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "aurora-borealis-iridescence",
-    "name": "Aurora Borealis Iridescence",
-    "url": "shaders/aurora-borealis-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Northern lights with flowing ribbon curves enhanced by thin-film iridescence. Each aurora ribbon shimmers with soap-bubble and oil-slick interference colors driven by ribbon intensity and animated turbulence.",
-    "tags": [
-      "aurora",
-      "iridescence",
-      "thin-film",
-      "interference",
-      "atmospheric",
-      "spectral"
-    ],
-    "features": [
-      "aurora-ribbons",
-      "thin-film-interference",
-      "curl-noise",
-      "mouse-driven",
-      "audio-reactive",
-      "atmospheric"
-    ],
-    "params": [
-      {
-        "id": "ribbons",
-        "name": "Ribbon Count",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "flow",
-        "name": "Flow Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "width",
-        "name": "Ribbon Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Iridescence",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.9
-  },
-  {
-    "id": "aerogel-smoke-hdr",
-    "name": "Aerogel Smoke HDR",
-    "url": "shaders/aerogel-smoke-hdr.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Ethereal aerogel volumetric smoke with HDR bloom enhancement. Silica nanoparticle scattering combines with an HDR bloom kernel that amplifies overbright regions, creating luminous glow around dense scattering zones.",
-    "tags": [
-      "volumetric",
-      "HDR",
-      "bloom",
-      "scattering",
-      "aerogel",
-      "atmospheric"
-    ],
-    "features": [
-      "volumetric-scattering",
-      "HDR-bloom",
-      "rayleigh-mie",
-      "rgba-data-channel",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "scattering",
-        "name": "Blue Scatter",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Light Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      },
-      {
-        "id": "bloom",
-        "name": "HDR Bloom",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "sim-smoke-trails-thermal",
-    "name": "Smoke Trails Thermal",
-    "url": "shaders/sim-smoke-trails-thermal.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Volumetric smoke fluid simulation with physically-correct blackbody thermal coloring. Smoke temperature maps to Kelvin via Planck's law \u2014 cool wisps glow ember-red, hot cores burn blue-white with Stefan-Boltzmann radiance scaling.",
-    "tags": [
-      "blackbody",
-      "thermal",
-      "smoke",
-      "simulation",
-      "fluid",
-      "volumetric",
-      "physics"
-    ],
-    "features": [
-      "simulation",
-      "blackbody-radiation",
-      "volumetric-smoke",
-      "vorticity",
-      "mouse-driven",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "density_scale",
-        "name": "Smoke Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "rise_speed",
-        "name": "Rise Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "thermal_intensity",
-        "name": "Thermal Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "spec-spherical-harmonics-light",
-    "name": "Spherical Harmonics Light",
-    "url": "shaders/spec-spherical-harmonics-light.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Spherical harmonics lighting derived from image content. Computes SH coefficients from local image samples and applies them to depth-derived normals for realistic ambient lighting.",
-    "tags": [
-      "spherical-harmonics",
-      "SH-lighting",
-      "normal-mapping",
-      "depth-aware",
-      "ambient-lighting"
-    ],
-    "features": [
-      "spherical-harmonics",
-      "SH-lighting",
-      "depth-aware",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "sh_strength",
-        "name": "SH Strength",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "normal_scale",
-        "name": "Normal Scale",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "specular",
-        "name": "Specular Power",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "ambient",
-        "name": "Ambient Boost",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "chromatic-focus-coupled",
-    "name": "Chromatic Focus Coupled",
-    "url": "shaders/chromatic-focus-coupled.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Chromatic aberration DOF with fluid-coupled distortion. Mouse movement stirs a viscous fluid that twists and blurs chromatic channels. Click ripples inject fluid bursts.",
-    "features": [
-      "mouse-driven",
-      "fluid-simulation",
-      "chromatic",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Blur",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "Focus Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.8
-      },
-      {
-        "id": "w",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "fluid",
-      "chromatic",
-      "depth-of-field",
-      "interactive"
-    ]
-  },
-  {
-    "id": "audio-voronoi-gabor",
-    "name": "Audio Voronoi Gabor",
-    "url": "shaders/audio-voronoi-gabor.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Audio-reactive Voronoi displacement modulated by Gabor texture analysis. Gabor filter banks detect local texture orientation and strength, rotating and scaling cell displacement. Edges and textured regions displace differently than smooth areas.",
-    "features": [
-      "audio-reactive",
-      "voronoi",
-      "gabor-texture",
-      "displacement-mapping",
-      "mouse-driven",
-      "depth-aware",
-      "randomization-safe",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "cell_count",
-        "name": "Cell Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Number of Voronoi cells"
-      },
-      {
-        "id": "audio_reactivity",
-        "name": "Audio Reactivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "How much audio affects the cells"
-      },
-      {
-        "id": "displacement",
-        "name": "Displacement Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Strength of displacement effect"
-      },
-      {
-        "id": "gabor_influence",
-        "name": "Texture Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "How much Gabor texture affects displacement"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "hash22 (gen_grid.wgsl)",
-      "gaborResponse (conv-gabor-texture-analyzer)",
-      "Voronoi pattern (audio-voronoi-displacement)",
-      "Audio band simulation (audio-voronoi-displacement)"
-    ],
-    "tags": [
-      "audio",
-      "music",
-      "reactive",
-      "texture",
-      "gabor",
-      "voronoi",
-      "displacement"
-    ],
-    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
-    "created_date": "2026-04-18"
-  },
-  {
-    "id": "glass-bead-curtain-iridescence",
-    "name": "Glass Bead Curtain Iridescence",
-    "url": "shaders/glass-bead-curtain-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "A curtain of refractive glass beads where each bead surface exhibits thin-film iridescence (soap-bubble colors). Combines physical Beer-Lambert transmission with spectral interference.",
-    "tags": [
-      "glass",
-      "iridescence",
-      "thin-film",
-      "interference",
-      "spectral",
-      "refraction",
-      "mouse-driven"
-    ],
-    "features": [
-      "mouse-driven",
-      "thin-film-interference",
-      "spectral-render",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "bead_size",
-        "name": "Bead Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "iridescence",
-        "name": "Iridescence",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "film_thickness",
-        "name": "Film Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "tensor-flow-morphological",
-    "name": "Tensor Flow Morphological",
-    "url": "shaders/tensor-flow-morphological.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Depth-aware tensor eigenwarp with morphological post-processing. Erosion darkens compressed tensor regions, dilation brightens tensile regions. Gradient highlights edges created by tensor warping.",
-    "features": [
-      "advanced-hybrid",
-      "tensor-warp",
-      "morphological",
-      "depth-aware",
-      "mouse-driven",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "strain_scale",
-        "name": "Strain Scale",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Amplitude of tensor-field deformation"
-      },
-      {
-        "id": "detail_preserve",
-        "name": "Detail Preserve",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "How much high-frequency detail is preserved"
-      },
-      {
-        "id": "depth_weight",
-        "name": "Depth Weight",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Influence of depth on deformation"
-      },
-      {
-        "id": "tensor_mode",
-        "name": "Tensor Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Blend from stretch-dominant to shear-dominant"
-      }
-    ],
-    "advanced_params": [
-      {
-        "id": "kernel_radius",
-        "name": "Kernel Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.x",
-        "description": "Morphological structuring element radius"
-      },
-      {
-        "id": "erosion_dilation_blend",
-        "name": "Erosion/Dilation Blend",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.y",
-        "description": "0=erosion, 1=dilation"
-      },
-      {
-        "id": "gradient_boost",
-        "name": "Gradient Boost",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.z",
-        "description": "Morphological gradient amplification"
-      },
-      {
-        "id": "morph_blend",
-        "name": "Morphology Blend",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.w",
-        "description": "Blend between sculpted and morphological result"
-      }
-    ],
-    "chunks_used": [
-      "sampleDepth (tensor-flow-sculpting.wgsl)",
-      "tensorEigen (tensor-flow-sculpting.wgsl)",
-      "vnoise (tensor-flow-sculpting.wgsl)",
-      "rippleDisp (tensor-flow-sculpting.wgsl)",
-      "fbm_tfs (tensor-flow-sculpting.wgsl)",
-      "stressColor (tensor-flow-sculpting.wgsl)",
-      "morphological operators (conv-morphological-erosion-dilation.wgsl)"
-    ],
-    "performance_target": "25-35 FPS (GTX 1060)",
-    "created_by": "Agent CB-3 \u2014 Convolution Post-Processor",
-    "created_date": "2026-04-18",
-    "tags": [
-      "tensor",
-      "warp",
-      "morphological",
-      "depth-aware",
-      "sculpt"
-    ]
-  },
-  {
-    "id": "spec-blackbody-thermal",
-    "name": "Blackbody Thermal",
-    "url": "shaders/spec-blackbody-thermal.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Maps image luminance to physically-correct blackbody radiation colors using Planck's law. Dark regions glow like embers, medium = white heat, bright = blue plasma.",
-    "tags": [
-      "blackbody",
-      "thermal",
-      "radiation",
-      "physics",
-      "HDR",
-      "temperature"
-    ],
-    "features": [
-      "blackbody-radiation",
-      "HDR",
-      "physical-color",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "temp_low",
-        "name": "Low Temperature",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "temp_high",
-        "name": "High Temperature",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Thermal Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Ember Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "painterly-oil-bilateral",
-    "name": "Painterly Oil + Bilateral Dream",
-    "url": "shaders/painterly-oil-bilateral.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Oil painting simulation with anisotropic Kuwahara, color quantization, and impasto texture, post-processed with edge-preserving bilateral filter for a dreamy smoothness. Mouse focus aperture controls sharpness.",
-    "tags": [
-      "oil",
-      "painting",
-      "bilateral",
-      "impasto",
-      "artistic",
-      "dreamy",
-      "convolution"
-    ],
-    "features": [
-      "advanced-convolution",
-      "upgraded-rgba",
-      "depth-aware",
-      "mouse-driven",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Brush Size",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Wetness",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Bilateral Dream",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Mouse Focus",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.5
-  },
-  {
-    "id": "glass-wall-prismatic",
-    "name": "Glass Wall Prismatic",
-    "url": "shaders/glass-wall-prismatic.wgsl",
-    "category": "advanced-hybrid",
-    "description": "A grid of glass tiles where each tile acts as a prismatic lens with 4-band spectral dispersion via Cauchy's equation. Mouse interaction tilts tiles, refracting light into rainbow spectra.",
-    "tags": [
-      "glass",
-      "prismatic",
-      "spectral",
-      "dispersion",
-      "refraction",
-      "chromatic",
-      "mouse-driven"
-    ],
-    "features": [
-      "mouse-driven",
-      "spectral-rendering",
-      "physical-dispersion",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "grid_size",
-        "name": "Grid Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "curvature",
-        "name": "Curvature",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "dispersion",
-        "name": "Dispersion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "thickness",
-        "name": "Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "hybrid-spectral-decomposed",
-    "name": "Hybrid Spectral Decomposed",
-    "url": "shaders/hybrid-spectral-decomposed.wgsl",
-    "category": "advanced-hybrid",
-    "description": "4-band spectral decomposition combined with audio-reactive pixel sorting. Image decomposed into low/mid-low/mid-high/high frequencies. Each band sorted independently with unique spectral color tints, then recomposed with per-band gains.",
-    "features": [
-      "advanced-hybrid",
-      "pixel-sorting",
-      "spectral-decomposition",
-      "audio-reactive",
-      "mouse-driven",
-      "randomization-safe",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "sort_threshold",
-        "name": "Sort Sensitivity",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Base luminance threshold for pixel sorting"
-      },
-      {
-        "id": "spectral_bands",
-        "name": "Spectral Bands",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Number of frequency bands for coloring"
-      },
-      {
-        "id": "displacement",
-        "name": "Spectral Displacement",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Displacement based on spectral energy"
-      },
-      {
-        "id": "hue_shift",
-        "name": "Hue Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color shift based on frequency band"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)",
-      "hueShift (stellar-plasma.wgsl)",
-      "4-band decomposition (alpha-spectral-decompose)",
-      "pixel sorting (hybrid-spectral-sorting)"
-    ],
-    "tags": [
-      "spectral",
-      "decomposition",
-      "pixel-sorting",
-      "audio",
-      "frequency",
-      "equalizer"
-    ],
-    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
-    "created_date": "2026-04-18"
-  },
-  {
-    "id": "spectral-flow-structure",
-    "name": "Spectral Flow Structure",
-    "url": "shaders/spectral-flow-structure.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Structure-tensor-guided pixel sorting with Line Integral Convolution. Eigenvectors from the structure tensor drive sort direction; coherency modulates blend strength. LIC adds flow-line texture. Audio-reactive with mouse vortices.",
-    "features": [
-      "advanced-hybrid",
-      "pixel-sorting",
-      "structure-tensor",
-      "LIC",
-      "audio-reactive",
-      "mouse-driven",
-      "randomization-safe",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "lic_steps",
-        "name": "LIC Steps",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Line Integral Convolution step count"
-      },
-      {
-        "id": "coherency_boost",
-        "name": "Coherency Boost",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Structure tensor coherency influence"
-      },
-      {
-        "id": "sort_threshold",
-        "name": "Sort Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Pixel sorting luminance threshold"
-      },
-      {
-        "id": "smoothing",
-        "name": "Temporal Smoothing",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Sort blend smoothing amount"
-      }
-    ],
-    "chunks_used": [
-      "structureTensor (conv-structure-tensor-flow)",
-      "LIC (conv-structure-tensor-flow)",
-      "pixel sorting (spectral-flow-sorting)",
-      "frequency analysis (spectral-flow-sorting)"
-    ],
-    "tags": [
-      "structure-tensor",
-      "LIC",
-      "pixel-sorting",
-      "flow",
-      "texture-analysis",
-      "audio"
-    ],
-    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
-    "created_date": "2026-04-18"
-  },
-  {
-    "id": "spec-iridescence-engine",
-    "name": "Iridescence Engine",
-    "url": "shaders/spec-iridescence-engine.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Thin-film interference simulation creating soap-bubble and oil-slick iridescence. Uses depth texture for film thickness and physically-correct optical path difference.",
-    "tags": [
-      "iridescence",
-      "thin-film",
-      "interference",
-      "spectral",
-      "oil-slick",
-      "soap-bubble"
-    ],
-    "features": [
-      "thin-film-interference",
-      "depth-aware",
-      "spectral-render",
-      "mouse-driven",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "film_thickness",
-        "name": "Film Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "film_ior",
-        "name": "Film IOR",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "gen-audio-spirograph-julia",
-    "name": "Audio Spirograph Julia",
-    "url": "shaders/gen-audio-spirograph-julia.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Audio-reactive spirograph curves that unfold into mouse-driven Julia set fractals. Each harmonic ring breathes with audio while the Julia constant morphs via mouse position.",
-    "tags": [
-      "audio-reactive",
-      "fractal",
-      "spirograph",
-      "julia",
-      "geometric",
-      "colorful",
-      "procedural"
-    ],
-    "features": [
-      "audio-reactive",
-      "mouse-driven",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "freq",
-        "name": "Base Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "julia",
-        "name": "Julia Mix",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "trail",
-        "name": "Trail Length",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "thickness",
-        "name": "Line Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "spec-temporal-path-tracer",
-    "name": "Temporal Path Tracer",
-    "url": "shaders/spec-temporal-path-tracer.wgsl",
-    "category": "advanced-hybrid",
-    "description": "2D path tracer with temporal accumulation. Casts light rays that bounce off image edges, accumulating Monte Carlo samples over time for soft global illumination and color bleeding.",
-    "tags": [
-      "path-tracing",
-      "temporal",
-      "monte-carlo",
-      "global-illumination",
-      "ray-marching"
-    ],
-    "features": [
-      "temporal-accumulation",
-      "path-tracing",
-      "Monte-Carlo",
-      "mouse-driven",
-      "HDR",
-      "multi-pass-1"
-    ],
-    "params": [
-      {
-        "id": "bounces",
-        "name": "Max Bounces",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "edge_threshold",
-        "name": "Edge Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "radiance",
-        "name": "Radiance Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "roughness",
-        "name": "Surface Roughness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.9
-  },
-  {
-    "id": "neural-raymarcher-gabor",
-    "name": "Neural Raymarcher Gabor",
-    "url": "shaders/neural-raymarcher-gabor.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Raymarched neural network visualization with Gabor oriented texture detection. Gabor responses highlight connection directions and layer boundaries with psychedelic color mapping.",
-    "features": [
-      "advanced-hybrid",
-      "neural-raymarching",
-      "gabor-texture",
-      "volumetric",
-      "randomization-safe",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "network_depth",
-        "name": "Network Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Depth of neural network layers"
-      },
-      {
-        "id": "activation_vis",
-        "name": "Activation Visualization",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Visibility of Gabor activation patterns"
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Volumetric glow intensity"
-      },
-      {
-        "id": "camera_rotation",
-        "name": "Camera Rotation",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Camera orbit position"
-      }
-    ],
-    "advanced_params": [
-      {
-        "id": "gabor_freq",
-        "name": "Gabor Frequency",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.x",
-        "description": "Gabor filter frequency"
-      },
-      {
-        "id": "gabor_sigma",
-        "name": "Gabor Sigma",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.y",
-        "description": "Gabor Gaussian envelope width"
-      },
-      {
-        "id": "gabor_scale",
-        "name": "Gabor Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.z",
-        "description": "Response scaling factor"
-      }
-    ],
-    "chunks_used": [
-      "ping_pong (neural-raymarcher.wgsl)",
-      "hash21 (neural-raymarcher.wgsl)",
-      "noise (neural-raymarcher.wgsl)",
-      "reconstruct_normal (neural-raymarcher.wgsl)",
-      "gaborResponse (conv-gabor-texture-analyzer.wgsl)",
-      "palette (conv-gabor-texture-analyzer.wgsl)"
-    ],
-    "performance_target": "20-30 FPS (GTX 1060)",
-    "created_by": "Agent CB-3 \u2014 Convolution Post-Processor",
-    "created_date": "2026-04-18",
-    "tags": [
-      "neural",
-      "raymarcher",
-      "gabor",
-      "texture",
-      "volumetric",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "gen-biomechanical-hive-julia",
-    "name": "Biomechanical Hive Julia",
-    "url": "shaders/gen-biomechanical-hive-julia.wgsl",
-    "category": "advanced-hybrid",
-    "description": "A biomechanical hive where each cell contains a living quaternion Julia fractal core. The chitinous exoskeleton surrounds morphing 4D fractal organisms that pulse with bioluminescence.",
-    "tags": [
-      "biomechanical",
-      "fractal",
-      "julia",
-      "raymarched",
-      "hive",
-      "organic",
-      "futuristic"
-    ],
-    "features": [
-      "mouse-driven",
-      "raymarched",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Hive Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "pulse",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "biomass",
-        "name": "Biomass",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "morph",
-        "name": "Julia Morph Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "glass-shatter-morph",
-    "name": "Glass Shatter Morph",
-    "url": "shaders/glass-shatter-morph.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Interactive shattered glass where Voronoi shards are sculpted by morphological erosion/dilation on edges. Combines physical glass transmission with mathematical morphology for cracked-edge detail.",
-    "tags": [
-      "glass",
-      "shatter",
-      "morphological",
-      "voronoi",
-      "erosion",
-      "dilation",
-      "mouse-driven"
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration",
-      "advanced-convolution"
-    ],
-    "params": [
-      {
-        "id": "shard_scale",
-        "name": "Shard Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "displacement",
-        "name": "Displacement",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "morph_blend",
-        "name": "Morph Blend",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "edge_width",
-        "name": "Edge Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "engraving-stipple-blue-noise",
-    "name": "Engraving Stipple Blue Noise",
-    "url": "shaders/engraving-stipple-blue-noise.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Traditional copper-plate engraving stipple fused with blue-noise dithered pointillism. Golden-ratio low-discrepancy sequences create perceptually optimal dot distributions. Mouse acts as raking light revealing engraved depth.",
-    "features": [
-      "mouse-driven",
-      "blue-noise",
-      "pointillism",
-      "stipple"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Stipple Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dot_size",
-        "name": "Dot Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "light",
-        "name": "Mouse Light",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "burr_texture",
-        "name": "Burr Texture",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "engraving",
-      "stipple",
-      "blue-noise",
-      "pointillism",
-      "artistic",
-      "dithering"
-    ],
-    "target_rating": 4.6
-  },
-  {
-    "id": "nano-assembler-crystal",
-    "name": "Nano Assembler Crystal",
-    "url": "shaders/nano-assembler-crystal.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Grid-based nanobots assemble into crystalline structures using phase-field dynamics. RGBA stores assembly phase, temperature, crystal orientation, and impurity. Mouse disrupts assembly causing scatter; ripples trigger nucleation. Displays nanobot glow when disassembled and orientation-dependent crystal color when assembled.",
-    "tags": [
-      "nano-assembler",
-      "crystal",
-      "growth",
-      "phase-field",
-      "grid",
-      "simulation",
-      "rgba-state-machine",
-      "interactive",
-      "mouse-driven",
-      "temporal"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "assemblyProgress",
-        "name": "Assembly Progress",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "particleDensity",
-        "name": "Grid Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "scatterForce",
-        "name": "Disruption",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "rebuildSpeed",
-        "name": "Rebuild Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "byte-mosh-explosion",
-    "name": "Byte Mosh Explosion",
-    "url": "shaders/byte-mosh-explosion.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Bitwise pixel corruption meets chromatic prism explosion. XOR, AND, shift and rotate operations are applied to spectrally displaced channels radiating from mouse and ripple shockwaves.",
-    "features": [
-      "advanced-hybrid",
-      "bitwise-glitch",
-      "chromatic-explosion",
-      "mouse-driven",
-      "ripple",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "operation_mix",
-        "name": "Operation Mix",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Bitwise operation variety"
-      },
-      {
-        "id": "bit_shift",
-        "name": "Bit Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Bit shift amount"
-      },
-      {
-        "id": "error_rate",
-        "name": "Error Rate",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Glitch probability"
-      },
-      {
-        "id": "prism_strength",
-        "name": "Prism Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Chromatic dispersion strength"
-      }
-    ],
-    "chunks_used": [
-      "Bitwise pack/unpack, XOR/AND/shift/rotate (byte-mosh.wgsl)",
-      "Prism displacement, ripple shockwaves (mouse-chromatic-explosion.wgsl)"
-    ],
-    "performance_target": "45 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "glitch",
-      "bitwise",
-      "chromatic",
-      "prism",
-      "explosion",
-      "corruption"
-    ]
-  },
-  {
-    "id": "gravitational-lensing-nlm",
-    "name": "Gravitational Lensing NLM",
-    "url": "shaders/gravitational-lensing-nlm.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Black hole gravitational lensing with non-local means artistic overdrive. Patch-similarity filtering smooths background starfields while preserving unique features like the event horizon and Einstein ring.",
-    "features": [
-      "advanced-hybrid",
-      "schwarzschild-metric",
-      "non-local-means",
-      "artistic-overdrive",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "black_hole_mass",
-        "name": "Black Hole Mass",
-        "default": 0.25,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Mass of the black hole"
-      },
-      {
-        "id": "disk_brightness",
-        "name": "Accretion Disk Brightness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Brightness of accretion disk"
-      },
-      {
-        "id": "camera_orbit",
-        "name": "Camera Orbit",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Camera orbit position"
-      },
-      {
-        "id": "redshift",
-        "name": "Gravitational Redshift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Intensity of gravitational redshift"
-      }
-    ],
-    "advanced_params": [
-      {
-        "id": "patch_radius",
-        "name": "Patch Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.x",
-        "description": "NLM patch comparison radius"
-      },
-      {
-        "id": "search_radius",
-        "name": "Search Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.y",
-        "description": "NLM search window radius"
-      },
-      {
-        "id": "filter_strength",
-        "name": "Filter Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.z",
-        "description": "NLM filter strength (h parameter)"
-      },
-      {
-        "id": "overdrive",
-        "name": "Artistic Overdrive",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_config.w",
-        "description": "Artistic overdrive blend amount"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gravitational-lensing.wgsl)",
-      "schwarzschildFactor (gravitational-lensing.wgsl)",
-      "renderAccretionDisk (gravitational-lensing.wgsl)",
-      "gravitationalRedshift (gravitational-lensing.wgsl)",
-      "patchDistance (conv-non-local-means.wgsl)"
-    ],
-    "performance_target": "20-30 FPS (GTX 1060)",
-    "created_by": "Agent CB-3 \u2014 Convolution Post-Processor",
-    "created_date": "2026-04-18",
-    "tags": [
-      "black-hole",
-      "gravitational-lensing",
-      "nlm",
-      "artistic",
-      "space"
-    ]
-  },
-  {
-    "id": "boids-rgba-ecosystem",
-    "name": "Boids RGBA Ecosystem",
-    "url": "shaders/boids-rgba-ecosystem.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Boids-inspired flow-field flocking combined with continuous multi-species ecosystem simulation. RGBA channels store species densities that advect, flock, and compete. Species 1 (flockers) and Species 2 (predators) consume resources, produce toxins, and exhibit emergent flocking behavior through neighborhood vector fields.",
-    "tags": [
-      "boids",
-      "flocking",
-      "ecosystem",
-      "simulation",
-      "rgba-state-machine",
-      "predator-prey",
-      "emergent",
-      "interactive",
-      "mouse-driven",
-      "temporal"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "flockCohesion",
-        "name": "Flock Cohesion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "predationRate",
-        "name": "Predation Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "diffusion",
-        "name": "Diffusion Rate",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "toxinStrength",
-        "name": "Toxin Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "ink-dispersion-guided",
-    "name": "Ink Dispersion Guided",
-    "url": "shaders/ink-dispersion-guided.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Depth-guided edge-preserving filter combined with ink-style halftone rendering. The guided filter smooths based on depth boundaries, then the result is rendered as ink dots with paper texture.",
-    "features": [
-      "advanced-hybrid",
-      "depth-guided-filter",
-      "ink-halftone",
-      "edge-detection",
-      "mouse-driven",
-      "depth-aware",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "dot_size",
-        "name": "Dot Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Halftone dot grid size"
-      },
-      {
-        "id": "edge_sensitivity",
-        "name": "Edge Sensitivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Edge detection threshold"
-      },
-      {
-        "id": "depth_influence",
-        "name": "Depth Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "How much depth guides the filter"
-      },
-      {
-        "id": "ink_density",
-        "name": "Ink Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Density of ink lines and dots"
-      }
-    ],
-    "chunks_used": [
-      "Guided filter linear model (conv-guided-filter-depth.wgsl)",
-      "Halftone dot rendering (ink_dispersion_alpha.wgsl)",
-      "Mouse aperture modulation (conv-guided-filter-depth.wgsl)"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "ink",
-      "halftone",
-      "guided-filter",
-      "depth",
-      "artistic",
-      "paper"
-    ]
-  },
-  {
-    "id": "blueprint-reveal-guided",
-    "name": "Blueprint Reveal + Guided Filter",
-    "url": "shaders/blueprint-reveal-guided.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Blueprint effect with depth-guided edge-aware filtering. The guided filter smooths the image using depth as guide before Sobel edge detection, creating blueprint lines that respect true object boundaries.",
-    "tags": [
-      "blueprint",
-      "guided-filter",
-      "depth-aware",
-      "edge-detection",
-      "technical",
-      "convolution"
-    ],
-    "features": [
-      "advanced-convolution",
-      "depth-aware",
-      "mouse-driven",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Edge Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Grid Opacity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Reveal Radius",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Softness",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.5
-  },
-  {
-    "id": "spec-prismatic-dispersion",
-    "name": "Prismatic Dispersion",
-    "url": "shaders/spec-prismatic-dispersion.wgsl",
-    "category": "advanced-hybrid",
-    "description": "4-band spectral dispersion through glass using Cauchy's equation. Treats RGBA as physical wavelengths with refractive index variation, reconstructing color via CIE color matching.",
-    "tags": [
-      "spectral",
-      "prismatic",
-      "dispersion",
-      "physical",
-      "chromatic",
-      "glass"
-    ],
-    "features": [
-      "spectral-rendering",
-      "mouse-driven",
-      "physical-dispersion",
-      "HDR"
-    ],
-    "params": [
-      {
-        "id": "glass_curvature",
-        "name": "Glass Curvature",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "cauchy_b",
-        "name": "Cauchy B (Dispersion)",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glass_thickness",
-        "name": "Glass Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "spectral_saturation",
-        "name": "Spectral Saturation",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "holographic-failure-iridescence",
-    "name": "Holographic Failure Iridescence",
-    "url": "shaders/holographic-failure-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Simulated hologram projection failure merged with thin-film interference iridescence. Flickering artifacts and block noise overlay soap-bubble spectral colors driven by depth, viewing angle, and time.",
-    "features": [
-      "advanced-hybrid",
-      "holographic",
-      "thin-film-interference",
-      "glitch",
-      "depth-aware",
-      "mouse-driven",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "failure",
-        "name": "Failure Amount",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Holographic projection failure intensity"
-      },
-      {
-        "id": "holographic",
-        "name": "Holographic Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Base holographic color strength"
-      },
-      {
-        "id": "film_ior",
-        "name": "Film IOR",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Thin film index of refraction"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Film thickness noise variation"
-      }
-    ],
-    "chunks_used": [
-      "Flicker, block artifacts, holographic color (holographic-projection-failure.wgsl)",
-      "Thin-film interference, spectral sampling (spec-iridescence-engine.wgsl)"
-    ],
-    "performance_target": "40 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "hologram",
-      "iridescence",
-      "glitch",
-      "thin-film",
-      "spectral",
-      "failure"
-    ]
-  },
-  {
     "id": "ascii-flow-structure",
     "name": "ASCII Flow + Structure Tensor",
     "url": "shaders/ascii-flow-structure.wgsl",
@@ -3679,365 +227,6 @@
       }
     ],
     "target_rating": 4.5
-  },
-  {
-    "id": "vhs-tracking-bilateral",
-    "name": "VHS Tracking Bilateral",
-    "url": "shaders/vhs-tracking-bilateral.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Full VHS signal chain physics with edge-preserving bilateral smoothing. Timebase jitter, chroma noise, and control track dropouts are filtered through a bilateral dream, creating a soft analog degradation while preserving edges.",
-    "features": [
-      "advanced-hybrid",
-      "vhs-simulation",
-      "bilateral-filter",
-      "chroma-noise",
-      "temporal",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "tracking",
-        "name": "Tracking Error",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "VHS tracking error intensity"
-      },
-      {
-        "id": "chroma_noise",
-        "name": "Chroma Noise",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chroma channel noise amount"
-      },
-      {
-        "id": "spatial_sigma",
-        "name": "Spatial Sigma",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Bilateral spatial spread"
-      },
-      {
-        "id": "color_sigma",
-        "name": "Color Sigma",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Bilateral color range sensitivity"
-      }
-    ],
-    "chunks_used": [
-      "VHS jitter, chroma noise, dropouts, quantization (vhs-tracking.wgsl)",
-      "Bilateral filter core (conv-bilateral-dream.wgsl)"
-    ],
-    "performance_target": "45 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "vhs",
-      "retro",
-      "bilateral",
-      "analog",
-      "noise",
-      "smoothing"
-    ]
-  },
-  {
-    "id": "crt-tv-stipple",
-    "name": "CRT TV Stipple",
-    "url": "shaders/crt-tv-stipple.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Authentic CRT TV simulation with blue-noise stippled phosphor dots. Combines barrel distortion, chromatic aberration, scanlines, and phosphor decay with perceptually optimal blue-noise dot placement for each RGB subpixel triad.",
-    "features": [
-      "advanced-hybrid",
-      "crt-simulation",
-      "blue-noise",
-      "stippling",
-      "barrel-distortion",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "scanlines",
-        "name": "Scanline Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "CRT scanline darkness"
-      },
-      {
-        "id": "phosphor_glow",
-        "name": "Phosphor Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Phosphor bloom around bright areas"
-      },
-      {
-        "id": "stipple_density",
-        "name": "Stipple Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Density of blue-noise stipple dots"
-      },
-      {
-        "id": "barrel",
-        "name": "Barrel Distortion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "CRT screen curvature amount"
-      }
-    ],
-    "chunks_used": [
-      "Barrel distortion, scanlines, phosphor decay (crt-tv.wgsl)",
-      "Blue-noise offset, stipple placement (spec-blue-noise-stipple.wgsl)"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
-    "created_date": "2026-04-18",
-    "tags": [
-      "crt",
-      "retro",
-      "stipple",
-      "blue-noise",
-      "phosphor",
-      "vintage"
-    ]
-  },
-  {
-    "id": "black-hole-iridescence",
-    "name": "Black Hole Iridescence",
-    "url": "shaders/black-hole-iridescence.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Gravitational lensing black hole with iridescent accretion disk. The warped background and glowing disk receive thin-film interference coloring based on viewing angle, producing soap-bubble chromatic effects around the event horizon.",
-    "tags": [
-      "black-hole",
-      "iridescence",
-      "gravitational-lensing",
-      "thin-film",
-      "interference",
-      "space"
-    ],
-    "features": [
-      "gravitational-lensing",
-      "thin-film-interference",
-      "accretion-disk",
-      "mouse-driven",
-      "depth-aware"
-    ],
-    "params": [
-      {
-        "id": "gravity",
-        "name": "Lens Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "radius",
-        "name": "Event Horizon",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Disk Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "iridescence",
-        "name": "Iridescence",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.9
-  },
-  {
-    "id": "cmyk-halftone-explosion",
-    "name": "CMYK Halftone Explosion",
-    "url": "shaders/cmyk-halftone-explosion.wgsl",
-    "category": "advanced-hybrid",
-    "description": "CMYK halftone dots spectrally separated near the mouse via prism displacement. Click ripples launch chromatic shockwaves through the halftone pattern.",
-    "features": [
-      "mouse-driven",
-      "chromatic",
-      "prism",
-      "print-simulation"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Dot Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Angle Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "Channel Spread",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Prism Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "chromatic",
-      "halftone",
-      "prism",
-      "interactive"
-    ]
-  },
-  {
-    "id": "double-exposure-hdr",
-    "name": "Double Exposure HDR",
-    "url": "shaders/double-exposure-hdr.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Ghostly double exposure blending combined with HDR bloom chain. The image overlays a zoomed/rotated version of itself, then luminous halos form around bright overlap regions with ACES tone mapping. Mouse sets the pivot point.",
-    "features": [
-      "mouse-driven",
-      "HDR",
-      "bloom",
-      "tone-mapping"
-    ],
-    "params": [
-      {
-        "id": "zoom",
-        "name": "Zoom Level",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "opacity",
-        "name": "Opacity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "saturation",
-        "name": "Saturation",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "double-exposure",
-      "HDR",
-      "bloom",
-      "photography",
-      "artistic",
-      "ghostly"
-    ],
-    "target_rating": 4.5
-  },
-  {
-    "id": "gen-xeno-botanical-ecosystem",
-    "name": "Xeno Botanical Ecosystem",
-    "url": "shaders/gen-xeno-botanical-ecosystem.wgsl",
-    "category": "advanced-hybrid",
-    "description": "Botanical flora patterns host a living RGBA ecosystem simulation. Species colonize branch structures, competing for photosynthetic resources while toxins accumulate in dense growth regions.",
-    "tags": [
-      "botanical",
-      "ecosystem",
-      "generative",
-      "simulation",
-      "organic",
-      "temporal",
-      "colorful"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "audio-reactive",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "growth",
-        "name": "Growth Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "complexity",
-        "name": "Branch Complexity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "ecosystem",
-        "name": "Ecosystem Strength",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Glow Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
   },
   {
     "id": "astral-kaleidoscope-morph",
@@ -4099,6 +288,1194 @@
     "target_rating": 4.5
   },
   {
+    "id": "atmos-fog-volumetric",
+    "name": "Atmospheric Fog Volumetric",
+    "url": "shaders/atmos-fog-volumetric.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Enhanced volumetric fog combining physical transmittance with interactive depth-layered alpha. Mouse clears fog locally, ripples create swirling disturbances, and height-based density mixes with Beer's Law for atmospheric realism.",
+    "tags": [
+      "volumetric",
+      "fog",
+      "atmosphere",
+      "depth-aware",
+      "mouse-driven",
+      "physics"
+    ],
+    "features": [
+      "volumetric-fog",
+      "depth-aware",
+      "mouse-clear",
+      "ripple-swirl",
+      "beers-law",
+      "rgba-data-channel"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Fog Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "height",
+        "name": "Fog Height",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "depth_weight",
+        "name": "Depth Weight",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "audio-voronoi-gabor",
+    "name": "Audio Voronoi Gabor",
+    "url": "shaders/audio-voronoi-gabor.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Audio-reactive Voronoi displacement modulated by Gabor texture analysis. Gabor filter banks detect local texture orientation and strength, rotating and scaling cell displacement. Edges and textured regions displace differently than smooth areas.",
+    "features": [
+      "audio-reactive",
+      "voronoi",
+      "gabor-texture",
+      "displacement-mapping",
+      "mouse-driven",
+      "depth-aware",
+      "randomization-safe",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "cell_count",
+        "name": "Cell Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Number of Voronoi cells"
+      },
+      {
+        "id": "audio_reactivity",
+        "name": "Audio Reactivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "How much audio affects the cells"
+      },
+      {
+        "id": "displacement",
+        "name": "Displacement Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Strength of displacement effect"
+      },
+      {
+        "id": "gabor_influence",
+        "name": "Texture Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "How much Gabor texture affects displacement"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "hash22 (gen_grid.wgsl)",
+      "gaborResponse (conv-gabor-texture-analyzer)",
+      "Voronoi pattern (audio-voronoi-displacement)",
+      "Audio band simulation (audio-voronoi-displacement)"
+    ],
+    "tags": [
+      "audio",
+      "music",
+      "reactive",
+      "texture",
+      "gabor",
+      "voronoi",
+      "displacement"
+    ],
+    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
+    "created_date": "2026-04-18"
+  },
+  {
+    "id": "aurora-borealis-iridescence",
+    "name": "Aurora Borealis Iridescence",
+    "url": "shaders/aurora-borealis-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Northern lights with flowing ribbon curves enhanced by thin-film iridescence. Each aurora ribbon shimmers with soap-bubble and oil-slick interference colors driven by ribbon intensity and animated turbulence.",
+    "tags": [
+      "aurora",
+      "iridescence",
+      "thin-film",
+      "interference",
+      "atmospheric",
+      "spectral"
+    ],
+    "features": [
+      "aurora-ribbons",
+      "thin-film-interference",
+      "curl-noise",
+      "mouse-driven",
+      "audio-reactive",
+      "atmospheric"
+    ],
+    "params": [
+      {
+        "id": "ribbons",
+        "name": "Ribbon Count",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "flow",
+        "name": "Flow Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "width",
+        "name": "Ribbon Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Iridescence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.9
+  },
+  {
+    "id": "aurora-rift-2-iridescence",
+    "name": "Aurora Rift 2 Iridescence",
+    "url": "shaders/aurora-rift-2-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Iridescent aurora curtains combining volumetric aurora simulation with thin-film interference. Each aurora layer gets soap-bubble/oil-slick coloring from optical path difference. Optical depth modulates film thickness; viewing angle drives color shift. Beer's Law transmittance composites physically.",
+    "features": [
+      "thin-film-interference",
+      "aurora",
+      "volumetric",
+      "depth-aware",
+      "spectral-render",
+      "mouse-driven",
+      "HDR",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Overall aurora and iridescence intensity"
+      },
+      {
+        "id": "speed",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Aurora curtain drift speed"
+      },
+      {
+        "id": "depth_weight",
+        "name": "Depth Weight",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Depth influence on alpha layering"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Noise turbulence for film thickness variation"
+      }
+    ],
+    "chunks_used": [
+      "fbm (aurora-rift-2)",
+      "physicalTransmittance / Beer's Law (aurora-rift-2)",
+      "thinFilmColor (spec-iridescence-engine)",
+      "wavelengthToRGB (spec-iridescence-engine)"
+    ],
+    "tags": [
+      "aurora",
+      "iridescence",
+      "thin-film",
+      "interference",
+      "volumetric",
+      "spectral",
+      "atmospheric"
+    ],
+    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
+    "created_date": "2026-04-18"
+  },
+  {
+    "id": "aurora-rift-iridescence",
+    "name": "Aurora Rift Iridescence",
+    "url": "shaders/aurora-rift-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Atmospheric curl-flow aurora blended with thin-film interference. Pattern density drives soap-bubble and oil-slick film thickness, producing flowing iridescence that rides the aurora's organic motion.",
+    "tags": [
+      "iridescence",
+      "thin-film",
+      "aurora",
+      "volumetric",
+      "atmospheric",
+      "spectral",
+      "interference"
+    ],
+    "features": [
+      "thin-film-interference",
+      "volumetric",
+      "curl-noise",
+      "mouse-driven",
+      "depth-aware",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "scale",
+        "name": "Pattern Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "flow_speed",
+        "name": "Flow Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "film_ior",
+        "name": "Film IOR",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Iridescence Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "bio-lenia-rgba",
+    "name": "Bio Lenia RGBA",
+    "url": "shaders/bio-lenia-rgba.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Four-species continuous cellular automata with Lenia-style smooth growth functions applied to each RGBA channel. Combines reaction-diffusion chemistry with biological emergence patterns. Cross-inhibition between species pairs creates complex multi-color morphologies.",
+    "tags": [
+      "lenia",
+      "cellular-automata",
+      "reaction-diffusion",
+      "biological",
+      "emergence",
+      "simulation",
+      "rgba-state-machine",
+      "continuous-ca",
+      "colorful"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "radius",
+        "name": "Kernel Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "growthCenter",
+        "name": "Growth Center",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "crossInhibit",
+        "name": "Cross Inhibition",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "timeStep",
+        "name": "Time Step",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "bio-touch-em",
+    "name": "Bio Touch EM",
+    "url": "shaders/bio-touch-em.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Bio-luminescent cellular structures distorted by electromagnetic field lines. Magnetic field rotates cell glow colors. Click ripples spawn orbiting secondary charges.",
+    "features": [
+      "mouse-driven",
+      "field-simulation",
+      "organic",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Glow Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Cell Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
+        "name": "Field Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "organic",
+      "electromagnetic",
+      "glow",
+      "interactive"
+    ]
+  },
+  {
+    "id": "bioluminescent-blackbody",
+    "name": "Bioluminescent Blackbody",
+    "url": "shaders/bioluminescent-blackbody.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Living organic growth patterns with physically-correct thermal coloring. Growth energy maps to blackbody temperature — cooler regions glow deep red, active growth burns orange-yellow, and intense hotspots reach white-hot temperatures.",
+    "tags": [
+      "bioluminescent",
+      "blackbody",
+      "organic",
+      "growth",
+      "thermal",
+      "physics"
+    ],
+    "features": [
+      "organic-growth",
+      "blackbody-thermal",
+      "bioluminescence",
+      "interactive",
+      "temporal-persistence",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "spread",
+        "name": "Spread Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "density",
+        "name": "Branch Density",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "spores",
+        "name": "Spore Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "black-hole-iridescence",
+    "name": "Black Hole Iridescence",
+    "url": "shaders/black-hole-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Gravitational lensing black hole with iridescent accretion disk. The warped background and glowing disk receive thin-film interference coloring based on viewing angle, producing soap-bubble chromatic effects around the event horizon.",
+    "tags": [
+      "black-hole",
+      "iridescence",
+      "gravitational-lensing",
+      "thin-film",
+      "interference",
+      "space"
+    ],
+    "features": [
+      "gravitational-lensing",
+      "thin-film-interference",
+      "accretion-disk",
+      "mouse-driven",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "gravity",
+        "name": "Lens Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "radius",
+        "name": "Event Horizon",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Disk Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "iridescence",
+        "name": "Iridescence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.9
+  },
+  {
+    "id": "block-distort-em",
+    "name": "Block Distort EM",
+    "url": "shaders/block-distort-em.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Grid blocks pushed by mouse proximity, distorted by electromagnetic field lines. Electric field displaces UVs, magnetic field rotates hue. Click ripples spawn orbiting secondary charges.",
+    "features": [
+      "mouse-driven",
+      "field-simulation",
+      "chromatic",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Block Size",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Push Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "RGB Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
+        "name": "Field Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive",
+      "electromagnetic",
+      "distortion",
+      "chromatic"
+    ]
+  },
+  {
+    "id": "blueprint-reveal-guided",
+    "name": "Blueprint Reveal + Guided Filter",
+    "url": "shaders/blueprint-reveal-guided.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Blueprint effect with depth-guided edge-aware filtering. The guided filter smooths the image using depth as guide before Sobel edge detection, creating blueprint lines that respect true object boundaries.",
+    "tags": [
+      "blueprint",
+      "guided-filter",
+      "depth-aware",
+      "edge-detection",
+      "technical",
+      "convolution"
+    ],
+    "features": [
+      "advanced-convolution",
+      "depth-aware",
+      "mouse-driven",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Edge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Grid Opacity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Reveal Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.5
+  },
+  {
+    "id": "boids-rgba-ecosystem",
+    "name": "Boids RGBA Ecosystem",
+    "url": "shaders/boids-rgba-ecosystem.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Boids-inspired flow-field flocking combined with continuous multi-species ecosystem simulation. RGBA channels store species densities that advect, flock, and compete. Species 1 (flockers) and Species 2 (predators) consume resources, produce toxins, and exhibit emergent flocking behavior through neighborhood vector fields.",
+    "tags": [
+      "boids",
+      "flocking",
+      "ecosystem",
+      "simulation",
+      "rgba-state-machine",
+      "predator-prey",
+      "emergent",
+      "interactive",
+      "mouse-driven",
+      "temporal"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "flockCohesion",
+        "name": "Flock Cohesion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "predationRate",
+        "name": "Predation Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "diffusion",
+        "name": "Diffusion Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "toxinStrength",
+        "name": "Toxin Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "bubble-lens-coupled",
+    "name": "Bubble Lens Coupled",
+    "url": "shaders/bubble-lens-coupled.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Magnifying bubble lens warped by fluid dynamics. Mouse movement drags viscous fluid that distorts the lens boundary and creates vortices inside. Click ripples create fluid bursts.",
+    "features": [
+      "mouse-driven",
+      "fluid-simulation",
+      "lens-distortion",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Bubble Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Magnification",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "Film Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "fluid",
+      "lens",
+      "distortion",
+      "interactive"
+    ]
+  },
+  {
+    "id": "byte-mosh-explosion",
+    "name": "Byte Mosh Explosion",
+    "url": "shaders/byte-mosh-explosion.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Bitwise pixel corruption meets chromatic prism explosion. XOR, AND, shift and rotate operations are applied to spectrally displaced channels radiating from mouse and ripple shockwaves.",
+    "features": [
+      "advanced-hybrid",
+      "bitwise-glitch",
+      "chromatic-explosion",
+      "mouse-driven",
+      "ripple",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "operation_mix",
+        "name": "Operation Mix",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Bitwise operation variety"
+      },
+      {
+        "id": "bit_shift",
+        "name": "Bit Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Bit shift amount"
+      },
+      {
+        "id": "error_rate",
+        "name": "Error Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Glitch probability"
+      },
+      {
+        "id": "prism_strength",
+        "name": "Prism Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Chromatic dispersion strength"
+      }
+    ],
+    "chunks_used": [
+      "Bitwise pack/unpack, XOR/AND/shift/rotate (byte-mosh.wgsl)",
+      "Prism displacement, ripple shockwaves (mouse-chromatic-explosion.wgsl)"
+    ],
+    "performance_target": "45 FPS (GTX 1060)",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "glitch",
+      "bitwise",
+      "chromatic",
+      "prism",
+      "explosion",
+      "corruption"
+    ]
+  },
+  {
+    "id": "charcoal-rub-diffusion",
+    "name": "Charcoal Rub + Anisotropic Diffusion",
+    "url": "shaders/charcoal-rub-diffusion.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Physical charcoal media simulation with Perona-Malik anisotropic diffusion preprocessing. Diffusion creates smooth tonal regions before charcoal conversion, with diffusion coefficient modulating charcoal density.",
+    "tags": [
+      "charcoal",
+      "anisotropic-diffusion",
+      "physical-media",
+      "drawing",
+      "edge-preserving",
+      "convolution"
+    ],
+    "features": [
+      "advanced-convolution",
+      "upgraded-rgba",
+      "mouse-driven",
+      "temporal",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Texture Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Reveal Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Diffusion Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.5
+  },
+  {
+    "id": "chromatic-focus-coupled",
+    "name": "Chromatic Focus Coupled",
+    "url": "shaders/chromatic-focus-coupled.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Chromatic aberration DOF with fluid-coupled distortion. Mouse movement stirs a viscous fluid that twists and blurs chromatic channels. Click ripples inject fluid bursts.",
+    "features": [
+      "mouse-driven",
+      "fluid-simulation",
+      "chromatic",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Blur",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "Focus Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.8
+      },
+      {
+        "id": "w",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "fluid",
+      "chromatic",
+      "depth-of-field",
+      "interactive"
+    ]
+  },
+  {
+    "id": "circuit-breaker-explosion",
+    "name": "Circuit Breaker Explosion",
+    "url": "shaders/circuit-breaker-explosion.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Circuit board edges chromatically separated near the mouse prism. Overload flashes become spectral rainbows. Click ripples launch chromatic shockwaves through the circuit pattern.",
+    "features": [
+      "mouse-driven",
+      "chromatic",
+      "circuit-simulation",
+      "glitch"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Grid Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Overload",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "Jitter",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
+        "name": "Prism Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "chromatic",
+      "circuit",
+      "glitch",
+      "interactive"
+    ]
+  },
+  {
+    "id": "cmyk-halftone-explosion",
+    "name": "CMYK Halftone Explosion",
+    "url": "shaders/cmyk-halftone-explosion.wgsl",
+    "category": "advanced-hybrid",
+    "description": "CMYK halftone dots spectrally separated near the mouse via prism displacement. Click ripples launch chromatic shockwaves through the halftone pattern.",
+    "features": [
+      "mouse-driven",
+      "chromatic",
+      "prism",
+      "print-simulation"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Dot Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Angle Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "Channel Spread",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
+        "name": "Prism Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "chromatic",
+      "halftone",
+      "prism",
+      "interactive"
+    ]
+  },
+  {
+    "id": "crt-tv-stipple",
+    "name": "CRT TV Stipple",
+    "url": "shaders/crt-tv-stipple.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Authentic CRT TV simulation with blue-noise stippled phosphor dots. Combines barrel distortion, chromatic aberration, scanlines, and phosphor decay with perceptually optimal blue-noise dot placement for each RGB subpixel triad.",
+    "features": [
+      "advanced-hybrid",
+      "crt-simulation",
+      "blue-noise",
+      "stippling",
+      "barrel-distortion",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "scanlines",
+        "name": "Scanline Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "CRT scanline darkness"
+      },
+      {
+        "id": "phosphor_glow",
+        "name": "Phosphor Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Phosphor bloom around bright areas"
+      },
+      {
+        "id": "stipple_density",
+        "name": "Stipple Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Density of blue-noise stipple dots"
+      },
+      {
+        "id": "barrel",
+        "name": "Barrel Distortion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "CRT screen curvature amount"
+      }
+    ],
+    "chunks_used": [
+      "Barrel distortion, scanlines, phosphor decay (crt-tv.wgsl)",
+      "Blue-noise offset, stipple placement (spec-blue-noise-stipple.wgsl)"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "crt",
+      "retro",
+      "stipple",
+      "blue-noise",
+      "phosphor",
+      "vintage"
+    ]
+  },
+  {
+    "id": "datamosh-brush-diffusion",
+    "name": "Datamosh Brush Diffusion",
+    "url": "shaders/datamosh-brush-diffusion.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Interactive datamoshing brush with anisotropic diffusion. Paint to freeze or corrupt pixels while Perona-Malik diffusion smooths along edges, creating oil-painted MPEG artifact trails with temporal persistence.",
+    "features": [
+      "advanced-hybrid",
+      "datamosh",
+      "anisotropic-diffusion",
+      "mouse-driven",
+      "temporal",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "brush_size",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Datamosh brush radius"
+      },
+      {
+        "id": "kappa",
+        "name": "Edge Sensitivity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Perona-Malik edge stopping threshold"
+      },
+      {
+        "id": "diffusion_rate",
+        "name": "Diffusion Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Anisotropic diffusion time step"
+      },
+      {
+        "id": "ghosting",
+        "name": "Ghost Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Alpha ghost trail intensity"
+      }
+    ],
+    "chunks_used": [
+      "Datamosh brush, block corruption, alpha ghosting (datamosh-brush.wgsl)",
+      "Perona-Malik diffusion, edge coefficients (conv-anisotropic-diffusion.wgsl)"
+    ],
+    "performance_target": "40 FPS (GTX 1060)",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "datamosh",
+      "glitch",
+      "diffusion",
+      "mouse-driven",
+      "oil-paint",
+      "temporal"
+    ]
+  },
+  {
     "id": "digital-decay-rgba",
     "name": "Digital Decay RGBA",
     "url": "shaders/digital-decay-rgba.wgsl",
@@ -4117,8 +1494,8 @@
         "id": "intensity",
         "name": "Decay Intensity",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Digital corruption strength"
@@ -4127,8 +1504,8 @@
         "id": "block_size",
         "name": "Block Size",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "MPEG macroblock size"
@@ -4137,8 +1514,8 @@
         "id": "corruption_speed",
         "name": "Corruption Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Speed of digital decay evolution"
@@ -4147,8 +1524,8 @@
         "id": "feed",
         "name": "RD Feed Rate",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Reaction-diffusion feed rate"
@@ -4159,7 +1536,7 @@
       "4-species reaction-diffusion, Laplacian (alpha-reaction-diffusion-rgba.wgsl)"
     ],
     "performance_target": "35 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
     "created_date": "2026-04-18",
     "tags": [
       "glitch",
@@ -4169,6 +1546,58 @@
       "digital",
       "corruption"
     ]
+  },
+  {
+    "id": "double-exposure-hdr",
+    "name": "Double Exposure HDR",
+    "url": "shaders/double-exposure-hdr.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Ghostly double exposure blending combined with HDR bloom chain. The image overlays a zoomed/rotated version of itself, then luminous halos form around bright overlap regions with ACES tone mapping. Mouse sets the pivot point.",
+    "features": [
+      "mouse-driven",
+      "HDR",
+      "bloom",
+      "tone-mapping"
+    ],
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Zoom Level",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "opacity",
+        "name": "Opacity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "saturation",
+        "name": "Saturation",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "double-exposure",
+      "HDR",
+      "bloom",
+      "photography",
+      "artistic",
+      "ghostly"
+    ],
+    "target_rating": 4.5
   },
   {
     "id": "encaustic-wax-blackbody",
@@ -4188,29 +1617,29 @@
         "id": "thickness",
         "name": "Wax Thickness",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "texture",
         "name": "Surface Texture",
         "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "radius",
         "name": "Melt Radius",
         "default": 0.2,
-        "min": 0.0,
+        "min": 0,
         "max": 0.5
       },
       {
         "id": "thermal_intensity",
         "name": "Thermal Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
@@ -4220,6 +1649,58 @@
       "wax",
       "artistic",
       "HDR"
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "engraving-stipple-blue-noise",
+    "name": "Engraving Stipple Blue Noise",
+    "url": "shaders/engraving-stipple-blue-noise.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Traditional copper-plate engraving stipple fused with blue-noise dithered pointillism. Golden-ratio low-discrepancy sequences create perceptually optimal dot distributions. Mouse acts as raking light revealing engraved depth.",
+    "features": [
+      "mouse-driven",
+      "blue-noise",
+      "pointillism",
+      "stipple"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Stipple Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dot_size",
+        "name": "Dot Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "light",
+        "name": "Mouse Light",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "burr_texture",
+        "name": "Burr Texture",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "engraving",
+      "stipple",
+      "blue-noise",
+      "pointillism",
+      "artistic",
+      "dithering"
     ],
     "target_rating": 4.6
   },
@@ -4278,6 +1759,1572 @@
     "target_rating": 4.6
   },
   {
+    "id": "gen-astro-orrery-blackbody",
+    "name": "Astro Orrery Blackbody",
+    "url": "shaders/gen-astro-orrery-blackbody.wgsl",
+    "category": "advanced-hybrid",
+    "description": "A kinetic astronomical orrery where each ring's thermal energy determines its blackbody color. Rotating rings glow with physically accurate star temperatures from cool red dwarfs to blazing blue giants.",
+    "tags": [
+      "astronomical",
+      "blackbody",
+      "thermal",
+      "orrery",
+      "space",
+      "physical",
+      "HDR"
+    ],
+    "features": [
+      "audio-reactive",
+      "mouse-driven",
+      "raymarched",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "complexity",
+        "name": "Ring Complexity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Orbital Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "audio",
+        "name": "Audio Reactivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-audio-spirograph-julia",
+    "name": "Audio Spirograph Julia",
+    "url": "shaders/gen-audio-spirograph-julia.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Audio-reactive spirograph curves that unfold into mouse-driven Julia set fractals. Each harmonic ring breathes with audio while the Julia constant morphs via mouse position.",
+    "tags": [
+      "audio-reactive",
+      "fractal",
+      "spirograph",
+      "julia",
+      "geometric",
+      "colorful",
+      "procedural"
+    ],
+    "features": [
+      "audio-reactive",
+      "mouse-driven",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "freq",
+        "name": "Base Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "julia",
+        "name": "Julia Mix",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "trail",
+        "name": "Trail Length",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "thickness",
+        "name": "Line Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-biomechanical-hive-julia",
+    "name": "Biomechanical Hive Julia",
+    "url": "shaders/gen-biomechanical-hive-julia.wgsl",
+    "category": "advanced-hybrid",
+    "description": "A biomechanical hive where each cell contains a living quaternion Julia fractal core. The chitinous exoskeleton surrounds morphing 4D fractal organisms that pulse with bioluminescence.",
+    "tags": [
+      "biomechanical",
+      "fractal",
+      "julia",
+      "raymarched",
+      "hive",
+      "organic",
+      "futuristic"
+    ],
+    "features": [
+      "mouse-driven",
+      "raymarched",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Hive Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "pulse",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "biomass",
+        "name": "Biomass",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "morph",
+        "name": "Julia Morph Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-raptor-mini-flow",
+    "name": "Raptor Mini Flow",
+    "url": "shaders/gen-raptor-mini-flow.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Predatory raptor agents navigate structure-tensor flow fields, hunting along image edges and orientations. Their trails follow dominant eigenvectors while audio rage pulses through the swarm.",
+    "tags": [
+      "predator",
+      "flow-field",
+      "cellular",
+      "audio-reactive",
+      "mouse-driven",
+      "organic",
+      "generative"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "turn",
+        "name": "Turn Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Max Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "rage",
+        "name": "Rage Duration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "flow",
+        "name": "Flow Influence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-xeno-botanical-ecosystem",
+    "name": "Xeno Botanical Ecosystem",
+    "url": "shaders/gen-xeno-botanical-ecosystem.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Botanical flora patterns host a living RGBA ecosystem simulation. Species colonize branch structures, competing for photosynthetic resources while toxins accumulate in dense growth regions.",
+    "tags": [
+      "botanical",
+      "ecosystem",
+      "generative",
+      "simulation",
+      "organic",
+      "temporal",
+      "colorful"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "audio-reactive",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "growth",
+        "name": "Growth Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "complexity",
+        "name": "Branch Complexity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ecosystem",
+        "name": "Ecosystem Strength",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Glow Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "glass-bead-curtain-iridescence",
+    "name": "Glass Bead Curtain Iridescence",
+    "url": "shaders/glass-bead-curtain-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "A curtain of refractive glass beads where each bead surface exhibits thin-film iridescence (soap-bubble colors). Combines physical Beer-Lambert transmission with spectral interference.",
+    "tags": [
+      "glass",
+      "iridescence",
+      "thin-film",
+      "interference",
+      "spectral",
+      "refraction",
+      "mouse-driven"
+    ],
+    "features": [
+      "mouse-driven",
+      "thin-film-interference",
+      "spectral-render",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "bead_size",
+        "name": "Bead Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "iridescence",
+        "name": "Iridescence",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "film_thickness",
+        "name": "Film Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "glass-refraction-prismatic",
+    "name": "Glass Refraction Prismatic",
+    "url": "shaders/glass-refraction-prismatic.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Raymarched glass blobs with 4-band spectral dispersion using Cauchy's equation and CIE color matching. Each wavelength refracts at a different angle through animated SDF glass surfaces.",
+    "features": [
+      "advanced-hybrid",
+      "raymarched",
+      "spectral-dispersion",
+      "physical-refraction",
+      "mouse-driven",
+      "depth-aware",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "transparency",
+        "name": "Transparency",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Glass transparency / thickness"
+      },
+      {
+        "id": "dispersion",
+        "name": "Cauchy B Coefficient",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Spectral dispersion strength via Cauchy's B parameter"
+      },
+      {
+        "id": "thickness",
+        "name": "Thickness Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Absorption thickness scale"
+      },
+      {
+        "id": "roughness",
+        "name": "Surface Roughness",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Surface roughness affecting specular highlights"
+      }
+    ],
+    "chunks_used": [
+      "sdSphere, smoothUnion, map, calcNormal (glass_refraction_alpha.wgsl)",
+      "fresnel, refractRay (glass_refraction_alpha.wgsl)",
+      "cauchyIOR, wavelengthToRGB (spec-prismatic-dispersion.wgsl)"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "glass",
+      "refraction",
+      "spectral",
+      "prismatic",
+      "physical",
+      "chromatic"
+    ]
+  },
+  {
+    "id": "glass-shatter-morph",
+    "name": "Glass Shatter Morph",
+    "url": "shaders/glass-shatter-morph.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Interactive shattered glass where Voronoi shards are sculpted by morphological erosion/dilation on edges. Combines physical glass transmission with mathematical morphology for cracked-edge detail.",
+    "tags": [
+      "glass",
+      "shatter",
+      "morphological",
+      "voronoi",
+      "erosion",
+      "dilation",
+      "mouse-driven"
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration",
+      "advanced-convolution"
+    ],
+    "params": [
+      {
+        "id": "shard_scale",
+        "name": "Shard Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "displacement",
+        "name": "Displacement",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "morph_blend",
+        "name": "Morph Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "edge_width",
+        "name": "Edge Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "glass-wall-prismatic",
+    "name": "Glass Wall Prismatic",
+    "url": "shaders/glass-wall-prismatic.wgsl",
+    "category": "advanced-hybrid",
+    "description": "A grid of glass tiles where each tile acts as a prismatic lens with 4-band spectral dispersion via Cauchy's equation. Mouse interaction tilts tiles, refracting light into rainbow spectra.",
+    "tags": [
+      "glass",
+      "prismatic",
+      "spectral",
+      "dispersion",
+      "refraction",
+      "chromatic",
+      "mouse-driven"
+    ],
+    "features": [
+      "mouse-driven",
+      "spectral-rendering",
+      "physical-dispersion",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "grid_size",
+        "name": "Grid Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "curvature",
+        "name": "Curvature",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dispersion",
+        "name": "Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "thickness",
+        "name": "Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "glass-wipes-coupled",
+    "name": "Glass Wipes Coupled",
+    "url": "shaders/glass-wipes-coupled.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Rain on glass combined with viscous fluid coupling physics. Rain drops feed a fluid simulation that creates realistic water streaks, while the mouse wiper clears fluid with vortex dynamics.",
+    "tags": [
+      "glass",
+      "rain",
+      "fluid",
+      "simulation",
+      "water",
+      "temporal",
+      "mouse-driven"
+    ],
+    "features": [
+      "mouse-driven",
+      "fluid-simulation",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "rain_intensity",
+        "name": "Rain Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "viscosity",
+        "name": "Fluid Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "wiper_size",
+        "name": "Wiper Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "vortex_strength",
+        "name": "Vortex Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "gravitational-lensing-nlm",
+    "name": "Gravitational Lensing NLM",
+    "url": "shaders/gravitational-lensing-nlm.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Black hole gravitational lensing with non-local means artistic overdrive. Patch-similarity filtering smooths background starfields while preserving unique features like the event horizon and Einstein ring.",
+    "features": [
+      "advanced-hybrid",
+      "schwarzschild-metric",
+      "non-local-means",
+      "artistic-overdrive",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "black_hole_mass",
+        "name": "Black Hole Mass",
+        "default": 0.25,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Mass of the black hole"
+      },
+      {
+        "id": "disk_brightness",
+        "name": "Accretion Disk Brightness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Brightness of accretion disk"
+      },
+      {
+        "id": "camera_orbit",
+        "name": "Camera Orbit",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Camera orbit position"
+      },
+      {
+        "id": "redshift",
+        "name": "Gravitational Redshift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Intensity of gravitational redshift"
+      }
+    ],
+    "advanced_params": [
+      {
+        "id": "patch_radius",
+        "name": "Patch Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.x",
+        "description": "NLM patch comparison radius"
+      },
+      {
+        "id": "search_radius",
+        "name": "Search Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.y",
+        "description": "NLM search window radius"
+      },
+      {
+        "id": "filter_strength",
+        "name": "Filter Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.z",
+        "description": "NLM filter strength (h parameter)"
+      },
+      {
+        "id": "overdrive",
+        "name": "Artistic Overdrive",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.w",
+        "description": "Artistic overdrive blend amount"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gravitational-lensing.wgsl)",
+      "schwarzschildFactor (gravitational-lensing.wgsl)",
+      "renderAccretionDisk (gravitational-lensing.wgsl)",
+      "gravitationalRedshift (gravitational-lensing.wgsl)",
+      "patchDistance (conv-non-local-means.wgsl)"
+    ],
+    "performance_target": "20-30 FPS (GTX 1060)",
+    "created_by": "Agent CB-3 — Convolution Post-Processor",
+    "created_date": "2026-04-18",
+    "tags": [
+      "black-hole",
+      "gravitational-lensing",
+      "nlm",
+      "artistic",
+      "space"
+    ]
+  },
+  {
+    "id": "holographic-failure-iridescence",
+    "name": "Holographic Failure Iridescence",
+    "url": "shaders/holographic-failure-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Simulated hologram projection failure merged with thin-film interference iridescence. Flickering artifacts and block noise overlay soap-bubble spectral colors driven by depth, viewing angle, and time.",
+    "features": [
+      "advanced-hybrid",
+      "holographic",
+      "thin-film-interference",
+      "glitch",
+      "depth-aware",
+      "mouse-driven",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "failure",
+        "name": "Failure Amount",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Holographic projection failure intensity"
+      },
+      {
+        "id": "holographic",
+        "name": "Holographic Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Base holographic color strength"
+      },
+      {
+        "id": "film_ior",
+        "name": "Film IOR",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Thin film index of refraction"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Film thickness noise variation"
+      }
+    ],
+    "chunks_used": [
+      "Flicker, block artifacts, holographic color (holographic-projection-failure.wgsl)",
+      "Thin-film interference, spectral sampling (spec-iridescence-engine.wgsl)"
+    ],
+    "performance_target": "40 FPS (GTX 1060)",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "hologram",
+      "iridescence",
+      "glitch",
+      "thin-film",
+      "spectral",
+      "failure"
+    ]
+  },
+  {
+    "id": "holographic-interferometry-bilateral",
+    "name": "Holographic Interferometry Bilateral",
+    "url": "shaders/holographic-interferometry-bilateral.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Simulated hologram with interference fringes and edge-preserving bilateral smoothing. Speckle noise is softly reduced while sharp interference fringe edges remain crisp.",
+    "features": [
+      "advanced-hybrid",
+      "holography",
+      "bilateral-filter",
+      "interference-patterns",
+      "speckle-reduction",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "fringe_density",
+        "name": "Fringe Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of interference fringes"
+      },
+      {
+        "id": "coherence",
+        "name": "Coherence Length",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Laser coherence (affects speckle size)"
+      },
+      {
+        "id": "reconstruction_angle",
+        "name": "Reconstruction Angle",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Hologram reconstruction angle"
+      },
+      {
+        "id": "saturation",
+        "name": "Color Saturation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Saturation of holographic colors"
+      }
+    ],
+    "advanced_params": [
+      {
+        "id": "bilateral_spatial",
+        "name": "Bilateral Spatial",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.x",
+        "description": "Spatial sigma of bilateral filter"
+      },
+      {
+        "id": "bilateral_color",
+        "name": "Bilateral Color",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.y",
+        "description": "Color sigma of bilateral filter"
+      },
+      {
+        "id": "bilateral_blend",
+        "name": "Bilateral Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.z",
+        "description": "Blend between original hologram and smoothed result"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (holographic-interferometry.wgsl)",
+      "speckleNoise (holographic-interferometry.wgsl)",
+      "interferencePattern (holographic-interferometry.wgsl)",
+      "reconstructHologram (holographic-interferometry.wgsl)",
+      "bilateral filter (conv-bilateral-dream.wgsl)"
+    ],
+    "performance_target": "30-40 FPS (GTX 1060)",
+    "created_by": "Agent CB-3 — Convolution Post-Processor",
+    "created_date": "2026-04-18",
+    "tags": [
+      "hologram",
+      "interference",
+      "bilateral",
+      "speckle",
+      "rainbow"
+    ]
+  },
+  {
+    "id": "hybrid-spectral-decomposed",
+    "name": "Hybrid Spectral Decomposed",
+    "url": "shaders/hybrid-spectral-decomposed.wgsl",
+    "category": "advanced-hybrid",
+    "description": "4-band spectral decomposition combined with audio-reactive pixel sorting. Image decomposed into low/mid-low/mid-high/high frequencies. Each band sorted independently with unique spectral color tints, then recomposed with per-band gains.",
+    "features": [
+      "advanced-hybrid",
+      "pixel-sorting",
+      "spectral-decomposition",
+      "audio-reactive",
+      "mouse-driven",
+      "randomization-safe",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "sort_threshold",
+        "name": "Sort Sensitivity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Base luminance threshold for pixel sorting"
+      },
+      {
+        "id": "spectral_bands",
+        "name": "Spectral Bands",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Number of frequency bands for coloring"
+      },
+      {
+        "id": "displacement",
+        "name": "Spectral Displacement",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Displacement based on spectral energy"
+      },
+      {
+        "id": "hue_shift",
+        "name": "Hue Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color shift based on frequency band"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)",
+      "hueShift (stellar-plasma.wgsl)",
+      "4-band decomposition (alpha-spectral-decompose)",
+      "pixel sorting (hybrid-spectral-sorting)"
+    ],
+    "tags": [
+      "spectral",
+      "decomposition",
+      "pixel-sorting",
+      "audio",
+      "frequency",
+      "equalizer"
+    ],
+    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
+    "created_date": "2026-04-18"
+  },
+  {
+    "id": "ink-dispersion-guided",
+    "name": "Ink Dispersion Guided",
+    "url": "shaders/ink-dispersion-guided.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Depth-guided edge-preserving filter combined with ink-style halftone rendering. The guided filter smooths based on depth boundaries, then the result is rendered as ink dots with paper texture.",
+    "features": [
+      "advanced-hybrid",
+      "depth-guided-filter",
+      "ink-halftone",
+      "edge-detection",
+      "mouse-driven",
+      "depth-aware",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "dot_size",
+        "name": "Dot Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Halftone dot grid size"
+      },
+      {
+        "id": "edge_sensitivity",
+        "name": "Edge Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Edge detection threshold"
+      },
+      {
+        "id": "depth_influence",
+        "name": "Depth Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "How much depth guides the filter"
+      },
+      {
+        "id": "ink_density",
+        "name": "Ink Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Density of ink lines and dots"
+      }
+    ],
+    "chunks_used": [
+      "Guided filter linear model (conv-guided-filter-depth.wgsl)",
+      "Halftone dot rendering (ink_dispersion_alpha.wgsl)",
+      "Mouse aperture modulation (conv-guided-filter-depth.wgsl)"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "ink",
+      "halftone",
+      "guided-filter",
+      "depth",
+      "artistic",
+      "paper"
+    ]
+  },
+  {
+    "id": "liquid-magnetic-ferro-em",
+    "name": "Liquid Magnetic Ferro EM",
+    "url": "shaders/liquid-magnetic-ferro-em.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Ferrofluid simulation coupled with electromagnetic wave propagation. Rosensweig instability spikes are driven by both static magnetic dipoles and time-varying EM waves, with metallic iridescence colored by field direction.",
+    "features": [
+      "advanced-hybrid",
+      "ferrofluid",
+      "em-simulation",
+      "wave-propagation",
+      "mouse-driven",
+      "temporal",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "field_strength",
+        "name": "Field Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Base magnetic field strength"
+      },
+      {
+        "id": "spike_sharpness",
+        "name": "Spike Sharpness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Ferrofluid peak sharpness"
+      },
+      {
+        "id": "em_coupling",
+        "name": "EM Coupling",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "How much EM wave affects the fluid"
+      },
+      {
+        "id": "dipoles",
+        "name": "Dipole Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Number of orbiting magnetic dipoles"
+      }
+    ],
+    "chunks_used": [
+      "Magnetic dipole field, Rosensweig spikes (liquid_magnetic_ferro.wgsl)",
+      "EM wave propagation, charge injection (alpha-em-field-simulation.wgsl)",
+      "Value noise, fbm2 (alpha-em-field-simulation.wgsl)"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "ferrofluid",
+      "magnetic",
+      "em-field",
+      "waves",
+      "metallic",
+      "simulation"
+    ]
+  },
+  {
+    "id": "liquid-metal-prismatic",
+    "name": "Liquid Metal Prismatic",
+    "url": "shaders/liquid-metal-prismatic.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Liquid metal ripple distortion combined with 4-band spectral prismatic dispersion. Curved metal surface acts as a dynamic liquid prism — ripples create varying curvature that refracts light into separated wavelength bands via Cauchy's equation.",
+    "tags": [
+      "prismatic",
+      "dispersion",
+      "liquid",
+      "metal",
+      "spectral",
+      "chromatic",
+      "physical"
+    ],
+    "features": [
+      "spectral-rendering",
+      "liquid",
+      "metallic",
+      "physical-dispersion",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "ripple_speed",
+        "name": "Ripple Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ripple_intensity",
+        "name": "Ripple Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "curvature",
+        "name": "Prism Curvature",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "spectral_sat",
+        "name": "Spectral Saturation",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "nano-assembler-crystal",
+    "name": "Nano Assembler Crystal",
+    "url": "shaders/nano-assembler-crystal.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Grid-based nanobots assemble into crystalline structures using phase-field dynamics. RGBA stores assembly phase, temperature, crystal orientation, and impurity. Mouse disrupts assembly causing scatter; ripples trigger nucleation. Displays nanobot glow when disassembled and orientation-dependent crystal color when assembled.",
+    "tags": [
+      "nano-assembler",
+      "crystal",
+      "growth",
+      "phase-field",
+      "grid",
+      "simulation",
+      "rgba-state-machine",
+      "interactive",
+      "mouse-driven",
+      "temporal"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "assemblyProgress",
+        "name": "Assembly Progress",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "particleDensity",
+        "name": "Grid Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "scatterForce",
+        "name": "Disruption",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "rebuildSpeed",
+        "name": "Rebuild Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "neural-raymarcher-gabor",
+    "name": "Neural Raymarcher Gabor",
+    "url": "shaders/neural-raymarcher-gabor.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Raymarched neural network visualization with Gabor oriented texture detection. Gabor responses highlight connection directions and layer boundaries with psychedelic color mapping.",
+    "features": [
+      "advanced-hybrid",
+      "neural-raymarching",
+      "gabor-texture",
+      "volumetric",
+      "randomization-safe",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "network_depth",
+        "name": "Network Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Depth of neural network layers"
+      },
+      {
+        "id": "activation_vis",
+        "name": "Activation Visualization",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Visibility of Gabor activation patterns"
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Volumetric glow intensity"
+      },
+      {
+        "id": "camera_rotation",
+        "name": "Camera Rotation",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Camera orbit position"
+      }
+    ],
+    "advanced_params": [
+      {
+        "id": "gabor_freq",
+        "name": "Gabor Frequency",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.x",
+        "description": "Gabor filter frequency"
+      },
+      {
+        "id": "gabor_sigma",
+        "name": "Gabor Sigma",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.y",
+        "description": "Gabor Gaussian envelope width"
+      },
+      {
+        "id": "gabor_scale",
+        "name": "Gabor Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.z",
+        "description": "Response scaling factor"
+      }
+    ],
+    "chunks_used": [
+      "ping_pong (neural-raymarcher.wgsl)",
+      "hash21 (neural-raymarcher.wgsl)",
+      "noise (neural-raymarcher.wgsl)",
+      "reconstruct_normal (neural-raymarcher.wgsl)",
+      "gaborResponse (conv-gabor-texture-analyzer.wgsl)",
+      "palette (conv-gabor-texture-analyzer.wgsl)"
+    ],
+    "performance_target": "20-30 FPS (GTX 1060)",
+    "created_by": "Agent CB-3 — Convolution Post-Processor",
+    "created_date": "2026-04-18",
+    "tags": [
+      "neural",
+      "raymarcher",
+      "gabor",
+      "texture",
+      "volumetric",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "painterly-oil-bilateral",
+    "name": "Painterly Oil + Bilateral Dream",
+    "url": "shaders/painterly-oil-bilateral.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Oil painting simulation with anisotropic Kuwahara, color quantization, and impasto texture, post-processed with edge-preserving bilateral filter for a dreamy smoothness. Mouse focus aperture controls sharpness.",
+    "tags": [
+      "oil",
+      "painting",
+      "bilateral",
+      "impasto",
+      "artistic",
+      "dreamy",
+      "convolution"
+    ],
+    "features": [
+      "advanced-convolution",
+      "upgraded-rgba",
+      "depth-aware",
+      "mouse-driven",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Wetness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Bilateral Dream",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Mouse Focus",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.5
+  },
+  {
+    "id": "particle-dreams-hdr",
+    "name": "Particle Dreams HDR",
+    "url": "shaders/particle-dreams-hdr.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Multi-layer depth particle accumulation with HDR bloom chain. 5 depth layers with flow noise and vortex distortion, combined with exposure-based radial bloom and ACES tone mapping.",
+    "features": [
+      "advanced-hybrid",
+      "multi-pass-accumulation",
+      "hdr-bloom",
+      "depth-aware",
+      "mouse-driven",
+      "temporal",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "bloom_radius",
+        "name": "Bloom Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Radius of HDR bloom kernel"
+      },
+      {
+        "id": "bloom_intensity",
+        "name": "Bloom Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Intensity of bloom accumulation"
+      },
+      {
+        "id": "exposure",
+        "name": "Tone Map Exposure",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "ACES tone mapping exposure bias"
+      },
+      {
+        "id": "fog_density",
+        "name": "Fog Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Volumetric fog density"
+      }
+    ],
+    "chunks_used": [
+      "Layer accumulation, flow noise (particle_dreams_alpha.wgsl)",
+      "HDR bloom kernel, ACES tone map (alpha-hdr-bloom-chain.wgsl)",
+      "Depth chromatic aberration (particle_dreams_alpha.wgsl)"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "particles",
+      "hdr",
+      "bloom",
+      "depth",
+      "dreamy",
+      "volumetric"
+    ]
+  },
+  {
+    "id": "photonic-caustics-iridescence",
+    "name": "Photonic Caustics Iridescence",
+    "url": "shaders/photonic-caustics-iridescence.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Backward photon-traced caustics combined with thin-film interference iridescence. Caustic intensity modulates film thickness, creating soap-bubble colors on light concentrations. Features chromatic dispersion, Fresnel reflections, and temporal accumulation.",
+    "tags": [
+      "caustics",
+      "iridescence",
+      "thin-film",
+      "interference",
+      "spectral",
+      "refraction",
+      "dispersion",
+      "photon-tracing",
+      "temporal"
+    ],
+    "features": [
+      "depth-aware",
+      "temporal",
+      "spectral-render",
+      "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "ior",
+        "name": "Index of Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "lightSize",
+        "name": "Light Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dispersion",
+        "name": "Chromatic Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "predator-prey-rgba",
+    "name": "Predator-Prey RGBA",
+    "url": "shaders/predator-prey-rgba.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Continuous-density predator-prey ecosystem simulation packed into RGBA32FLOAT. Plants photosynthesize using source image luminance, herbivores graze, carnivores hunt, and toxins accumulate from overpopulation. Species diffuse across the grid creating emergent spatial waves.",
+    "tags": [
+      "predator-prey",
+      "ecosystem",
+      "simulation",
+      "food-chain",
+      "rgba-state-machine",
+      "emergent",
+      "interactive",
+      "mouse-driven",
+      "temporal"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "eatProbability",
+        "name": "Eat Probability",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "deathRate",
+        "name": "Death Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "plantGrowth",
+        "name": "Plant Growth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "toxinStrength",
+        "name": "Toxin Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
     "id": "quantum-foam-bilateral",
     "name": "Quantum Foam Bilateral",
     "url": "shaders/quantum-foam-bilateral.wgsl",
@@ -4295,8 +3342,8 @@
         "id": "foam_scale",
         "name": "Foam Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Scale of quantum foam cells"
@@ -4305,8 +3352,8 @@
         "id": "flow_speed",
         "name": "Flow Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Speed of curl noise flow"
@@ -4315,8 +3362,8 @@
         "id": "diffusion_rate",
         "name": "Diffusion Rate",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Amount of diffusion blending"
@@ -4325,8 +3372,8 @@
         "id": "detail",
         "name": "Detail",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Octave count and emission detail"
@@ -4337,8 +3384,8 @@
         "id": "bilateral_spatial",
         "name": "Bilateral Spatial",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_config.x",
         "description": "Spatial sigma of bilateral filter"
@@ -4347,8 +3394,8 @@
         "id": "bilateral_color",
         "name": "Bilateral Color",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_config.y",
         "description": "Color sigma of bilateral filter"
@@ -4357,8 +3404,8 @@
         "id": "bilateral_blend",
         "name": "Bilateral Blend",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_config.z",
         "description": "Blend between original foam and smoothed result"
@@ -4372,7 +3419,7 @@
       "bilateral filter (conv-bilateral-dream.wgsl)"
     ],
     "performance_target": "25-35 FPS (GTX 1060)",
-    "created_by": "Agent CB-3 \u2014 Convolution Post-Processor",
+    "created_by": "Agent CB-3 — Convolution Post-Processor",
     "created_date": "2026-04-18",
     "tags": [
       "quantum",
@@ -4402,8 +3449,8 @@
         "id": "curvature",
         "name": "Screen Curvature",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Barrel distortion strength"
@@ -4412,8 +3459,8 @@
         "id": "phosphor_size",
         "name": "Phosphor Size",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "RGB triad dot size"
@@ -4422,8 +3469,8 @@
         "id": "scanlines",
         "name": "Scanline Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "CRT scanline darkness"
@@ -4432,8 +3479,8 @@
         "id": "bloom",
         "name": "HDR Bloom",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "HDR bloom intensity"
@@ -4444,7 +3491,7 @@
       "HDR bloom kernel, ACES tone mapping (alpha-hdr-bloom-chain.wgsl)"
     ],
     "performance_target": "50 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
     "created_date": "2026-04-18",
     "tags": [
       "crt",
@@ -4456,75 +3503,1028 @@
     ]
   },
   {
-    "id": "datamosh-brush-diffusion",
-    "name": "Datamosh Brush Diffusion",
-    "url": "shaders/datamosh-brush-diffusion.wgsl",
+    "id": "retro-phosphor-stipple",
+    "name": "Retro Phosphor Stipple",
+    "url": "shaders/retro-phosphor-stipple.wgsl",
     "category": "advanced-hybrid",
-    "description": "Interactive datamoshing brush with anisotropic diffusion. Paint to freeze or corrupt pixels while Perona-Malik diffusion smooths along edges, creating oil-painted MPEG artifact trails with temporal persistence.",
+    "description": "CRT phosphor simulation with blue-noise stippled dot triads. Authentic barrel distortion, scanlines, and temporal persistence combined with perceptually optimal blue-noise dot placement for each RGB channel.",
     "features": [
       "advanced-hybrid",
-      "datamosh",
-      "anisotropic-diffusion",
+      "crt-simulation",
+      "blue-noise",
+      "stippling",
+      "temporal-persistence",
+      "audio-reactive",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "curvature",
+        "name": "Screen Curvature",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Barrel distortion strength"
+      },
+      {
+        "id": "phosphor_scale",
+        "name": "Phosphor Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Size of blue-noise phosphor dots"
+      },
+      {
+        "id": "scanlines",
+        "name": "Scanline Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "CRT scanline darkness"
+      },
+      {
+        "id": "flicker",
+        "name": "Flicker Intensity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Interlaced field flicker"
+      }
+    ],
+    "chunks_used": [
+      "Barrel distortion, scanlines, persistence (retro_phosphor_dream.wgsl)",
+      "Blue-noise offset, golden angle disk (spec-blue-noise-stipple.wgsl)"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent CB-6 - Alpha & Post-Process Enhancer",
+    "created_date": "2026-04-18",
+    "tags": [
+      "crt",
+      "retro",
+      "phosphor",
+      "blue-noise",
+      "stipple",
+      "vintage"
+    ]
+  },
+  {
+    "id": "sim-heat-haze-blackbody",
+    "name": "Heat Haze Blackbody",
+    "url": "shaders/sim-heat-haze-blackbody.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Temperature field convection simulation with physically-correct blackbody thermal glow. Hot ground and rising convection plumes radiate with Planck's law colors — cool air stays neutral while intense heat sources glow from red ember to blue-white.",
+    "tags": [
+      "blackbody",
+      "thermal",
+      "heat",
+      "haze",
+      "simulation",
+      "convection",
+      "physics"
+    ],
+    "features": [
+      "simulation",
+      "blackbody-radiation",
+      "temperature-field",
+      "convection",
       "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "temperature",
+        "name": "Temperature Intensity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "convection_speed",
+        "name": "Convection Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "heat_sources",
+        "name": "Heat Source Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "sim-smoke-trails-thermal",
+    "name": "Smoke Trails Thermal",
+    "url": "shaders/sim-smoke-trails-thermal.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Volumetric smoke fluid simulation with physically-correct blackbody thermal coloring. Smoke temperature maps to Kelvin via Planck's law — cool wisps glow ember-red, hot cores burn blue-white with Stefan-Boltzmann radiance scaling.",
+    "tags": [
+      "blackbody",
+      "thermal",
+      "smoke",
+      "simulation",
+      "fluid",
+      "volumetric",
+      "physics"
+    ],
+    "features": [
+      "simulation",
+      "blackbody-radiation",
+      "volumetric-smoke",
+      "vorticity",
+      "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "density_scale",
+        "name": "Smoke Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "rise_speed",
+        "name": "Rise Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "thermal_intensity",
+        "name": "Thermal Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "spec-blackbody-thermal",
+    "name": "Blackbody Thermal",
+    "url": "shaders/spec-blackbody-thermal.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Maps image luminance to physically-correct blackbody radiation colors using Planck's law. Dark regions glow like embers, medium = white heat, bright = blue plasma.",
+    "tags": [
+      "blackbody",
+      "thermal",
+      "radiation",
+      "physics",
+      "HDR",
+      "temperature"
+    ],
+    "features": [
+      "blackbody-radiation",
+      "HDR",
+      "physical-color",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "temp_low",
+        "name": "Low Temperature",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "temp_high",
+        "name": "High Temperature",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Thermal Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Ember Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "spec-importance-sampled-bokeh",
+    "name": "Importance Sampled Bokeh",
+    "url": "shaders/spec-importance-sampled-bokeh.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Bokeh blur guided by image brightness using importance sampling. Bright pixels act as point light sources creating crisp bokeh highlights with smooth backgrounds via golden angle spiral distribution.",
+    "tags": [
+      "bokeh",
+      "importance-sampling",
+      "blur",
+      "depth-of-field",
+      "golden-angle",
+      "HDR"
+    ],
+    "features": [
+      "importance-sampling",
+      "bokeh",
+      "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "radius",
+        "name": "Bokeh Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "shape",
+        "name": "Highlight Shape",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "brightness",
+        "name": "Brightness Boost",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chroma",
+        "name": "Chromatic Aberration",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "spec-iridescence-engine",
+    "name": "Iridescence Engine",
+    "url": "shaders/spec-iridescence-engine.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Thin-film interference simulation creating soap-bubble and oil-slick iridescence. Uses depth texture for film thickness and physically-correct optical path difference.",
+    "tags": [
+      "iridescence",
+      "thin-film",
+      "interference",
+      "spectral",
+      "oil-slick",
+      "soap-bubble"
+    ],
+    "features": [
+      "thin-film-interference",
+      "depth-aware",
+      "spectral-render",
+      "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "film_thickness",
+        "name": "Film Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "film_ior",
+        "name": "Film IOR",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "spec-prismatic-dispersion",
+    "name": "Prismatic Dispersion",
+    "url": "shaders/spec-prismatic-dispersion.wgsl",
+    "category": "advanced-hybrid",
+    "description": "4-band spectral dispersion through glass using Cauchy's equation. Treats RGBA as physical wavelengths with refractive index variation, reconstructing color via CIE color matching.",
+    "tags": [
+      "spectral",
+      "prismatic",
+      "dispersion",
+      "physical",
+      "chromatic",
+      "glass"
+    ],
+    "features": [
+      "spectral-rendering",
+      "mouse-driven",
+      "physical-dispersion",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "glass_curvature",
+        "name": "Glass Curvature",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "cauchy_b",
+        "name": "Cauchy B (Dispersion)",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glass_thickness",
+        "name": "Glass Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "spectral_saturation",
+        "name": "Spectral Saturation",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "spec-spherical-harmonics-light",
+    "name": "Spherical Harmonics Light",
+    "url": "shaders/spec-spherical-harmonics-light.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Spherical harmonics lighting derived from image content. Computes SH coefficients from local image samples and applies them to depth-derived normals for realistic ambient lighting.",
+    "tags": [
+      "spherical-harmonics",
+      "SH-lighting",
+      "normal-mapping",
+      "depth-aware",
+      "ambient-lighting"
+    ],
+    "features": [
+      "spherical-harmonics",
+      "SH-lighting",
+      "depth-aware",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "sh_strength",
+        "name": "SH Strength",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "normal_scale",
+        "name": "Normal Scale",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "specular",
+        "name": "Specular Power",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ambient",
+        "name": "Ambient Boost",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "spec-temporal-path-tracer",
+    "name": "Temporal Path Tracer",
+    "url": "shaders/spec-temporal-path-tracer.wgsl",
+    "category": "advanced-hybrid",
+    "description": "2D path tracer with temporal accumulation. Casts light rays that bounce off image edges, accumulating Monte Carlo samples over time for soft global illumination and color bleeding.",
+    "tags": [
+      "path-tracing",
+      "temporal",
+      "monte-carlo",
+      "global-illumination",
+      "ray-marching"
+    ],
+    "features": [
+      "temporal-accumulation",
+      "path-tracing",
+      "Monte-Carlo",
+      "mouse-driven",
+      "HDR",
+      "multi-pass-1"
+    ],
+    "params": [
+      {
+        "id": "bounces",
+        "name": "Max Bounces",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "edge_threshold",
+        "name": "Edge Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "radiance",
+        "name": "Radiance Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "roughness",
+        "name": "Surface Roughness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.9
+  },
+  {
+    "id": "spectral-flow-structure",
+    "name": "Spectral Flow Structure",
+    "url": "shaders/spectral-flow-structure.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Structure-tensor-guided pixel sorting with Line Integral Convolution. Eigenvectors from the structure tensor drive sort direction; coherency modulates blend strength. LIC adds flow-line texture. Audio-reactive with mouse vortices.",
+    "features": [
+      "advanced-hybrid",
+      "pixel-sorting",
+      "structure-tensor",
+      "LIC",
+      "audio-reactive",
+      "mouse-driven",
+      "randomization-safe",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "lic_steps",
+        "name": "LIC Steps",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Line Integral Convolution step count"
+      },
+      {
+        "id": "coherency_boost",
+        "name": "Coherency Boost",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Structure tensor coherency influence"
+      },
+      {
+        "id": "sort_threshold",
+        "name": "Sort Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Pixel sorting luminance threshold"
+      },
+      {
+        "id": "smoothing",
+        "name": "Temporal Smoothing",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Sort blend smoothing amount"
+      }
+    ],
+    "chunks_used": [
+      "structureTensor (conv-structure-tensor-flow)",
+      "LIC (conv-structure-tensor-flow)",
+      "pixel sorting (spectral-flow-sorting)",
+      "frequency analysis (spectral-flow-sorting)"
+    ],
+    "tags": [
+      "structure-tensor",
+      "LIC",
+      "pixel-sorting",
+      "flow",
+      "texture-analysis",
+      "audio"
+    ],
+    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
+    "created_date": "2026-04-18"
+  },
+  {
+    "id": "stellar-plasma-blackbody",
+    "name": "Stellar Plasma Blackbody",
+    "url": "shaders/stellar-plasma-blackbody.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Cosmic nebula domain-warped FBM blended with Planck's law blackbody thermal coloring. Energy intensity drives temperature mapping — cool voids glow ember-red, hot plasma cores burn blue-white with physically-correct radiance scaling.",
+    "tags": [
+      "blackbody",
+      "thermal",
+      "plasma",
+      "nebula",
+      "procedural",
+      "cosmic",
+      "HDR",
+      "physics"
+    ],
+    "features": [
+      "generative",
+      "blackbody-radiation",
+      "procedural",
+      "audio-reactive",
+      "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "temp_shift",
+        "name": "Temperature Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Evolution Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "zoom_scale",
+        "name": "Zoom Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "thermal_intensity",
+        "name": "Thermal Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "tensor-flow-morphological",
+    "name": "Tensor Flow Morphological",
+    "url": "shaders/tensor-flow-morphological.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Depth-aware tensor eigenwarp with morphological post-processing. Erosion darkens compressed tensor regions, dilation brightens tensile regions. Gradient highlights edges created by tensor warping.",
+    "features": [
+      "advanced-hybrid",
+      "tensor-warp",
+      "morphological",
+      "depth-aware",
+      "mouse-driven",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "strain_scale",
+        "name": "Strain Scale",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Amplitude of tensor-field deformation"
+      },
+      {
+        "id": "detail_preserve",
+        "name": "Detail Preserve",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "How much high-frequency detail is preserved"
+      },
+      {
+        "id": "depth_weight",
+        "name": "Depth Weight",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Influence of depth on deformation"
+      },
+      {
+        "id": "tensor_mode",
+        "name": "Tensor Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Blend from stretch-dominant to shear-dominant"
+      }
+    ],
+    "advanced_params": [
+      {
+        "id": "kernel_radius",
+        "name": "Kernel Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.x",
+        "description": "Morphological structuring element radius"
+      },
+      {
+        "id": "erosion_dilation_blend",
+        "name": "Erosion/Dilation Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.y",
+        "description": "0=erosion, 1=dilation"
+      },
+      {
+        "id": "gradient_boost",
+        "name": "Gradient Boost",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.z",
+        "description": "Morphological gradient amplification"
+      },
+      {
+        "id": "morph_blend",
+        "name": "Morphology Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_config.w",
+        "description": "Blend between sculpted and morphological result"
+      }
+    ],
+    "chunks_used": [
+      "sampleDepth (tensor-flow-sculpting.wgsl)",
+      "tensorEigen (tensor-flow-sculpting.wgsl)",
+      "vnoise (tensor-flow-sculpting.wgsl)",
+      "rippleDisp (tensor-flow-sculpting.wgsl)",
+      "fbm_tfs (tensor-flow-sculpting.wgsl)",
+      "stressColor (tensor-flow-sculpting.wgsl)",
+      "morphological operators (conv-morphological-erosion-dilation.wgsl)"
+    ],
+    "performance_target": "25-35 FPS (GTX 1060)",
+    "created_by": "Agent CB-3 — Convolution Post-Processor",
+    "created_date": "2026-04-18",
+    "tags": [
+      "tensor",
+      "warp",
+      "morphological",
+      "depth-aware",
+      "sculpt"
+    ]
+  },
+  {
+    "id": "thermal-touch-blackbody",
+    "name": "Thermal Touch Blackbody",
+    "url": "shaders/thermal-touch-blackbody.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Mouse-driven thermal camera with blackbody radiation coloring. The cursor acts as a localized heat source and image brightness maps to physically-correct temperature via Planck's law.",
+    "tags": [
+      "thermal",
+      "blackbody",
+      "mouse-driven",
+      "physics",
+      "spectral",
+      "HDR"
+    ],
+    "features": [
+      "blackbody-radiation",
+      "mouse-heat-source",
+      "physical-color",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "heat_intensity",
+        "name": "Heat Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "radius",
+        "name": "Heat Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ambient",
+        "name": "Ambient Temperature",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "blend",
+        "name": "Original Blend",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "thermal-vision-blackbody",
+    "name": "Thermal Vision Blackbody",
+    "url": "shaders/thermal-vision-blackbody.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Physically-correct thermal vision camera using blackbody radiation via Planck's law. Image luminance maps to real temperature colors, with mouse acting as a localized heat source and configurable sensor contrast.",
+    "tags": [
+      "thermal",
+      "blackbody",
+      "physics",
+      "spectral",
+      "HDR",
+      "mouse-driven"
+    ],
+    "features": [
+      "blackbody-radiation",
+      "thermal-vision",
+      "mouse-driven",
+      "HDR",
+      "physical-color"
+    ],
+    "params": [
+      {
+        "id": "temp_low",
+        "name": "Temperature Low",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "temp_high",
+        "name": "Temperature High",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "contrast",
+        "name": "Sensor Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "vhs-tracking-bilateral",
+    "name": "VHS Tracking Bilateral",
+    "url": "shaders/vhs-tracking-bilateral.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Full VHS signal chain physics with edge-preserving bilateral smoothing. Timebase jitter, chroma noise, and control track dropouts are filtered through a bilateral dream, creating a soft analog degradation while preserving edges.",
+    "features": [
+      "advanced-hybrid",
+      "vhs-simulation",
+      "bilateral-filter",
+      "chroma-noise",
       "temporal",
       "randomization-safe"
     ],
     "params": [
       {
-        "id": "brush_size",
-        "name": "Brush Size",
+        "id": "tracking",
+        "name": "Tracking Error",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Datamosh brush radius"
+        "description": "VHS tracking error intensity"
       },
       {
-        "id": "kappa",
-        "name": "Edge Sensitivity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "chroma_noise",
+        "name": "Chroma Noise",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Perona-Malik edge stopping threshold"
+        "description": "Chroma channel noise amount"
       },
       {
-        "id": "diffusion_rate",
-        "name": "Diffusion Rate",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "spatial_sigma",
+        "name": "Spatial Sigma",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
-        "description": "Anisotropic diffusion time step"
+        "description": "Bilateral spatial spread"
       },
       {
-        "id": "ghosting",
-        "name": "Ghost Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "color_sigma",
+        "name": "Color Sigma",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Alpha ghost trail intensity"
+        "description": "Bilateral color range sensitivity"
       }
     ],
     "chunks_used": [
-      "Datamosh brush, block corruption, alpha ghosting (datamosh-brush.wgsl)",
-      "Perona-Malik diffusion, edge coefficients (conv-anisotropic-diffusion.wgsl)"
+      "VHS jitter, chroma noise, dropouts, quantization (vhs-tracking.wgsl)",
+      "Bilateral filter core (conv-bilateral-dream.wgsl)"
     ],
-    "performance_target": "40 FPS (GTX 1060)",
-    "created_by": "Agent CB-13 \u2014 Retro & Glitch Enhancer",
+    "performance_target": "45 FPS (GTX 1060)",
+    "created_by": "Agent CB-13 — Retro & Glitch Enhancer",
     "created_date": "2026-04-18",
     "tags": [
-      "datamosh",
-      "glitch",
-      "diffusion",
+      "vhs",
+      "retro",
+      "bilateral",
+      "analog",
+      "noise",
+      "smoothing"
+    ]
+  },
+  {
+    "id": "wave-equation-rgba-fluid",
+    "name": "Wave Equation RGBA Fluid",
+    "url": "shaders/wave-equation-rgba-fluid.wgsl",
+    "category": "advanced-hybrid",
+    "description": "Coupled wave equation and incompressible fluid simulation packed into RGBA32FLOAT. Wave height and velocity drive fluid motion while fluid pressure dampens waves. Dye advection visualizes the combined flow field with rainbow phase coloring.",
+    "tags": [
+      "wave",
+      "fluid",
+      "simulation",
+      "physics",
+      "navier-stokes",
+      "rgba-state-machine",
+      "interactive",
       "mouse-driven",
-      "oil-paint",
-      "temporal"
+      "temporal",
+      "colorful"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "waveSpeed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "damping",
+        "name": "Wave Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "viscosity",
+        "name": "Fluid Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "sourceStrength",
+        "name": "Source Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
     ]
   }
 ]

--- a/public/shader-lists/artistic.json
+++ b/public/shader-lists/artistic.json
@@ -19,8 +19,8 @@
         "id": "red_feed",
         "name": "Red Feed Rate",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Feed rate for red channel"
@@ -29,8 +29,8 @@
         "id": "green_feed",
         "name": "Green Feed Rate",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Feed rate for green channel"
@@ -39,8 +39,8 @@
         "id": "blue_feed",
         "name": "Blue Feed Rate",
         "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Feed rate for blue channel"
@@ -49,8 +49,8 @@
         "id": "chromatic_sep",
         "name": "Chromatic Separation",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Amount of chromatic aberration"
@@ -71,514 +71,123 @@
     ]
   },
   {
-    "id": "sim-decay-system",
-    "name": "Decay System",
-    "url": "shaders/sim-decay-system.wgsl",
+    "id": "alpha-paint-thickness",
+    "name": "Alpha Paint Thickness",
+    "url": "shaders/alpha-paint-thickness.wgsl",
     "category": "artistic",
-    "description": "Multi-layer decay and corrosion simulation. Image corrodes from edges inward with different materials.",
+    "description": "Impasto paint thickness simulation where alpha tracks paint depth. Thin paint creates transparent washes, medium shows full color, thick paint catches specular highlights and casts micro-shadows. Mouse paints with color-cycling brush; ripples create splatters.",
+    "tags": [
+      "paint",
+      "impasto",
+      "artistic",
+      "interactive",
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine",
+      "texture"
+    ],
     "features": [
-      "simulation",
-      "cellular-automata",
-      "corrosion",
-      "layered-materials",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "decay_rate",
-        "name": "Decay Rate",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Speed of decay"
-      },
-      {
-        "id": "edge_vulnerability",
-        "name": "Edge Vulnerability",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "How much edges decay faster"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Amount of color shifting"
-      },
-      {
-        "id": "recovery",
-        "name": "Recovery Rate",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Recovery/regeneration rate (paint protection)"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "Edge detection",
-      "Cellular automata decay",
-      "Multi-material system"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "sim-ink-diffusion",
-    "name": "Ink Diffusion",
-    "url": "shaders/sim-ink-diffusion.wgsl",
-    "category": "artistic",
-    "description": "Fluid ink diffusion with paper absorption. Multi-channel Gray-Scott with Wolfram-validated parameters.",
-    "features": [
-      "simulation",
-      "reaction-diffusion",
-      "multi-channel",
-      "paper-texture",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "wetness",
-        "name": "Paper Wetness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Paper wetness affects diffusion rate"
-      },
-      {
-        "id": "viscosity",
-        "name": "Ink Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Ink viscosity"
-      },
-      {
-        "id": "feed_rate",
-        "name": "Feed Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Chemical feed rate"
-      },
-      {
-        "id": "color_mixing",
-        "name": "Color Mixing",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color mixing intensity"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "Gray-Scott reaction-diffusion",
-      "Multi-channel processing",
-      "Paper texture simulation"
-    ],
-    "wolfram_params": {
-      "coral": "F=0.0545, k=0.062",
-      "fingerprint": "F=0.0545, k=0.063",
-      "spots_waves": "F=0.018, k=0.050"
-    },
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "temporal-slit-paint",
-    "name": "Temporal Slit Paint",
-    "url": "shaders/temporal-slit-paint.wgsl",
-    "category": "artistic",
-    "description": "Parametric brush painting with shape selection, velocity-aware smearing, and diffusion-based color bleeding onto a temporal canvas.",
-    "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
     ],
     "params": [
       {
         "id": "brushSize",
         "name": "Brush Size",
+        "type": "float",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "shapeType",
-        "name": "Brush Shape",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
+        "id": "paintSaturation",
+        "name": "Paint Saturation",
+        "type": "float",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "softness",
-        "name": "Brush Softness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
+        "id": "specularPower",
+        "name": "Specular Power",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "diffusionStrength",
-        "name": "Diffusion",
+        "id": "dryingRate",
+        "name": "Drying Rate",
+        "type": "float",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
-    ],
+    ]
+  },
+  {
+    "id": "alpha-watercolor-wetness",
+    "name": "Alpha Watercolor Wetness",
+    "url": "shaders/alpha-watercolor-wetness.wgsl",
+    "category": "artistic",
+    "description": "Watercolor simulation with wetness map in alpha. Pigment flows with water gradients via capillary action. Wet areas allow bleeding; dry areas lock pigment. Mouse drops colored water; ripples add water drops. Authentic dark-edge effects at wet boundaries.",
     "tags": [
+      "watercolor",
       "paint",
-      "brush",
       "artistic",
-      "temporal"
-    ]
-  },
-  {
-    "id": "chrono-slit-scan",
-    "name": "Chrono Slit Scan",
-    "url": "shaders/chrono-slit-scan.wgsl",
-    "category": "artistic",
-    "description": "Multi-slit temporal scan with 2-3 simultaneous animated slits, feathered edges, and audio-reactive speed modulation.",
-    "params": [
-      {
-        "id": "slitCount",
-        "name": "Slit Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "slitWidth",
-        "name": "Slit Width",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "slitSpeed",
-        "name": "Slit Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "feather",
-        "name": "Feather",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "temporal-persistence",
-      "audio-reactive",
-      "fbm-warp",
-      "sdf-composition",
-      "upgraded-rgba",
-      "multi-slit"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "noise",
-      "fractal",
-      "temporal",
-      "artistic"
-    ]
-  },
-  {
-    "id": "time-slit-scan",
-    "name": "Time Slit Scan",
-    "url": "shaders/time-slit-scan.wgsl",
-    "category": "artistic",
-    "description": "Multi-slit temporal scan with curved parametric slits, polar drift, and time-warp color tinting.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "slitCount",
-        "name": "Slit Count",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "slitShape",
-        "name": "Slit Shape",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "driftSpeed",
-        "name": "Drift Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "slitWidth",
-        "name": "Slit Width",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "slit-scan",
-      "temporal",
-      "artistic",
-      "time-warp"
-    ]
-  },
-  {
-    "id": "spectral-bleed-confinement",
-    "name": "Spectral Bleed & Confinement",
-    "url": "shaders/spectral-bleed-confinement.wgsl",
-    "category": "artistic",
-    "description": "Specific color bands leak outward from image edges while being electromagnetically confined by competing channels, creating glowing halos that feel physically constrained. Audio reactivity pulses bleed radius and adds beat-synchronized flashes.",
-    "tags": [
-      "spectral",
-      "bleed",
-      "halo",
-      "edge",
-      "glow",
-      "chromatic",
-      "electromagnetic",
-      "alpha",
-      "luminance-key",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "advanced-alpha",
-      "audio-reactive"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Bleed Radius",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Distance color bleeds outward from edges."
-      },
-      {
-        "id": "param2",
-        "name": "Confinement",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Strength of cross-channel suppression (electromagnetic confinement)."
-      },
-      {
-        "id": "param3",
-        "name": "Curl Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Speed of the curl-noise vector field driving bleed direction."
-      },
-      {
-        "id": "param4",
-        "name": "Edge Threshold",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Minimum edge magnitude required to trigger spectral bleed."
-      }
-    ]
-  },
-  {
-    "id": "frosty-window",
-    "name": "Frosty Window",
-    "url": "shaders/frosty-window.wgsl",
-    "category": "artistic",
-    "description": "Animated frost crystal patterns on glass with audio-reactive growth and mouse-driven melting.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Frost Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "crystal_size",
-        "name": "Crystal Size",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "blur",
-        "name": "Blur Amount",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "sparkle",
-        "name": "Sparkle",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "animated",
-      "crystalline",
       "interactive",
       "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "frost",
-      "ice",
-      "glass",
-      "winter",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chromatic-focus",
-    "name": "Chromatic Focus",
-    "url": "shaders/chromatic-focus.wgsl",
-    "category": "artistic",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Chromatic aberration that intensifies away from the mouse cursor (focus point).",
-    "params": [
-      {
-        "id": "aberStrength",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "focusRadius",
-        "name": "Focus Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "blurStrength",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angleOffset",
-        "name": "Angle Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "stylized",
-      "artistic"
-    ]
-  },
-  {
-    "id": "stipple-render",
-    "name": "Stipple Render",
-    "url": "shaders/stipple-render.wgsl",
-    "category": "artistic",
-    "description": "Converts the image to a stippled ink drawing with dynamic density based on mouse position and bass-driven audio reactivity.",
-    "params": [
-      {
-        "name": "Dot Scale",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "id": "dot_scale"
-      },
-      {
-        "name": "Contrast",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "id": "contrast"
-      },
-      {
-        "name": "Focus Radius",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "id": "focus_radius"
-      },
-      {
-        "name": "Color Reveal",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "id": "color_reveal"
-      }
+      "temporal",
+      "rgba-state-machine",
+      "wetness"
     ],
     "features": [
       "mouse-driven",
-      "audio-reactive"
+      "temporal",
+      "rgba-state-machine"
     ],
-    "tags": [
-      "stylized",
-      "artistic",
-      "stipple",
-      "ink",
-      "audio-reactive"
+    "params": [
+      {
+        "id": "dryRate",
+        "name": "Drying Rate",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "pigmentDeposit",
+        "name": "Pigment Deposit",
+        "type": "float",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "waterCapacity",
+        "name": "Water Capacity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "flowStrength",
+        "name": "Flow Strength",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
     ]
   },
   {
@@ -626,392 +235,6 @@
     "tags": [
       "stylized",
       "artistic"
-    ]
-  },
-  {
-    "id": "rotoscope-ink",
-    "name": "Rotoscope Ink",
-    "url": "shaders/rotoscope-ink.wgsl",
-    "category": "artistic",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Transforms the image into a stylized rotoscope animation with interactive ink lines.",
-    "params": [
-      {
-        "id": "line_thickness",
-        "name": "Line Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "quantization",
-        "name": "Color Levels",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Edge Sensitivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ink_strength",
-        "name": "Ink Opacity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "stylized",
-      "artistic"
-    ]
-  },
-  {
-    "id": "alpha-paint-thickness",
-    "name": "Alpha Paint Thickness",
-    "url": "shaders/alpha-paint-thickness.wgsl",
-    "category": "artistic",
-    "description": "Impasto paint thickness simulation where alpha tracks paint depth. Thin paint creates transparent washes, medium shows full color, thick paint catches specular highlights and casts micro-shadows. Mouse paints with color-cycling brush; ripples create splatters.",
-    "tags": [
-      "paint",
-      "impasto",
-      "artistic",
-      "interactive",
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "texture"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "brushSize",
-        "name": "Brush Size",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "paintSaturation",
-        "name": "Paint Saturation",
-        "type": "float",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "specularPower",
-        "name": "Specular Power",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "dryingRate",
-        "name": "Drying Rate",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "echo-trace",
-    "name": "Structure Tensor Echo Field",
-    "url": "shaders/echo-trace.wgsl",
-    "category": "artistic",
-    "description": "Anisotropic echo smearing via structure tensor analysis, flow-field advection with curl noise, multi-octave temporal feedback, audio-driven hue rotation, and luminance-gradient feedback displacement.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trace Decay",
-        "default": 0.96,
-        "min": 0.8,
-        "max": 0.999
-      },
-      {
-        "id": "size",
-        "name": "Brush Size",
-        "default": 0.15,
-        "min": 0.01,
-        "max": 0.4
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.05,
-        "min": 0.0,
-        "max": 0.2
-      },
-      {
-        "id": "flow",
-        "name": "Flow Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "audio-reactive",
-      "structure-tensor",
-      "flow-advection",
-      "multi-octave-echo",
-      "velocity-sensing",
-      "feedback-displacement",
-      "curl-noise"
-    ],
-    "tags": [
-      "stylized",
-      "artistic",
-      "echo",
-      "flow",
-      "anisotropic",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "chromatic-phase-inversion",
-    "name": "Chromatic Phase Inversion",
-    "url": "shaders/chromatic-phase-inversion.wgsl",
-    "category": "artistic",
-    "description": "Individual color channels are inverted by a slowly evolving temporal phase, causing color ghosts that drift ahead or behind the true image in surreal independent waves. Audio reactivity pulses phase speed and ghost offset with the beat.",
-    "tags": [
-      "chromatic",
-      "phase",
-      "inversion",
-      "ghost",
-      "temporal",
-      "color",
-      "surreal",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Phase Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.35,
-        "step": 0.01,
-        "description": "Speed of the temporal phase oscillation per channel."
-      },
-      {
-        "id": "param2",
-        "name": "Ghost Offset",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Spatial displacement of each color ghost from the source."
-      },
-      {
-        "id": "param3",
-        "name": "Inversion Depth",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "How much depth accumulates extra phase (near objects phase faster)."
-      },
-      {
-        "id": "param4",
-        "name": "Spatial Coherence",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Mix of spatial noise field into the phase (low=global, high=local)."
-      }
-    ]
-  },
-  {
-    "id": "recursion-mirror-vortex",
-    "name": "Recursion Mirror Vortex",
-    "url": "shaders/recursion-mirror-vortex.wgsl",
-    "category": "artistic",
-    "description": "Nested M\u00f6bius-fold mirrors that fold the image into itself at precise singularity points, creating infinite-hallway illusions that remain spatially coherent.",
-    "tags": [
-      "mirror",
-      "vortex",
-      "fractal",
-      "recursive",
-      "mobius",
-      "warp",
-      "psychedelic"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Fold Depth",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Number of M\u00f6bius fold iterations (1\u20136)."
-      },
-      {
-        "id": "param2",
-        "name": "Fold Radius",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Radius of each fold's influence sphere."
-      },
-      {
-        "id": "param3",
-        "name": "Vortex Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Speed and direction of the vortex rotation."
-      },
-      {
-        "id": "param4",
-        "name": "Mirror Blend",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.6,
-        "step": 0.01,
-        "description": "Blend strength between original and folded image."
-      }
-    ]
-  },
-  {
-    "id": "liquid-prism-cascade",
-    "name": "Liquid Prism Cascade",
-    "url": "shaders/liquid-prism-cascade.wgsl",
-    "category": "artistic",
-    "description": "Colors separate along curved planes like light through prisms, creating a layered 3-D depth illusion where R, G, and B channels drift independently through warped color-space.",
-    "tags": [
-      "chromatic",
-      "prism",
-      "dispersion",
-      "depth",
-      "color",
-      "warp",
-      "artistic"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Dispersion Strength",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "How far each color channel drifts from the source."
-      },
-      {
-        "id": "param2",
-        "name": "Depth Curvature",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "How strongly depth data amplifies the prism bending."
-      },
-      {
-        "id": "param3",
-        "name": "Prism Twist",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Rotational twist applied to each channel's dispersion vector."
-      },
-      {
-        "id": "param4",
-        "name": "Depth Weight",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.6,
-        "step": 0.01,
-        "description": "Blend weight between luminance gradient and depth curvature."
-      }
-    ]
-  },
-  {
-    "id": "neon-contour-interactive",
-    "name": "Neon Contour",
-    "category": "artistic",
-    "url": "shaders/neon-contour-interactive.wgsl",
-    "description": "Interactive edge detection with neon glow responsive to mouse proximity.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "threshold",
-        "name": "Edge Thresh",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "glow",
-        "name": "Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "cycle",
-        "name": "Color Cycle",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulse",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "stylized",
-      "artistic",
-      "audio",
-      "music",
-      "reactive"
     ]
   },
   {
@@ -1070,6 +293,492 @@
     "target_rating": 4.5
   },
   {
+    "id": "chromatic-focus",
+    "name": "Chromatic Focus",
+    "url": "shaders/chromatic-focus.wgsl",
+    "category": "artistic",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Chromatic aberration that intensifies away from the mouse cursor (focus point).",
+    "params": [
+      {
+        "id": "aberStrength",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "focusRadius",
+        "name": "Focus Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blurStrength",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angleOffset",
+        "name": "Angle Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "stylized",
+      "artistic"
+    ]
+  },
+  {
+    "id": "chromatic-phase-inversion",
+    "name": "Chromatic Phase Inversion",
+    "url": "shaders/chromatic-phase-inversion.wgsl",
+    "category": "artistic",
+    "description": "Individual color channels are inverted by a slowly evolving temporal phase, causing color ghosts that drift ahead or behind the true image in surreal independent waves. Audio reactivity pulses phase speed and ghost offset with the beat.",
+    "tags": [
+      "chromatic",
+      "phase",
+      "inversion",
+      "ghost",
+      "temporal",
+      "color",
+      "surreal",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Phase Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.35,
+        "step": 0.01,
+        "description": "Speed of the temporal phase oscillation per channel."
+      },
+      {
+        "id": "param2",
+        "name": "Ghost Offset",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Spatial displacement of each color ghost from the source."
+      },
+      {
+        "id": "param3",
+        "name": "Inversion Depth",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "How much depth accumulates extra phase (near objects phase faster)."
+      },
+      {
+        "id": "param4",
+        "name": "Spatial Coherence",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Mix of spatial noise field into the phase (low=global, high=local)."
+      }
+    ]
+  },
+  {
+    "id": "echo-trace",
+    "name": "Structure Tensor Echo Field",
+    "url": "shaders/echo-trace.wgsl",
+    "category": "artistic",
+    "description": "Anisotropic echo smearing via structure tensor analysis, flow-field advection with curl noise, multi-octave temporal feedback, audio-driven hue rotation, and luminance-gradient feedback displacement.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trace Decay",
+        "default": 0.96,
+        "min": 0.8,
+        "max": 0.999
+      },
+      {
+        "id": "size",
+        "name": "Brush Size",
+        "default": 0.15,
+        "min": 0.01,
+        "max": 0.4
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0.05,
+        "min": 0,
+        "max": 0.2
+      },
+      {
+        "id": "flow",
+        "name": "Flow Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "audio-reactive",
+      "structure-tensor",
+      "flow-advection",
+      "multi-octave-echo",
+      "velocity-sensing",
+      "feedback-displacement",
+      "curl-noise"
+    ],
+    "tags": [
+      "stylized",
+      "artistic",
+      "echo",
+      "flow",
+      "anisotropic",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "engraving-stipple",
+    "name": "Engraving Stipple",
+    "url": "shaders/engraving-stipple.wgsl",
+    "category": "artistic",
+    "description": "Transforms the image into a stippled engraving style. Mouse acts as a light source to reveal details.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Stipple Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of stipple dots"
+      },
+      {
+        "id": "bias",
+        "name": "Ink Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Threshold for ink vs paper"
+      },
+      {
+        "id": "light",
+        "name": "Mouse Light",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Strength of mouse light source"
+      },
+      {
+        "id": "burr_texture",
+        "name": "Burr Texture",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Engraving burr and texture amount"
+      }
+    ],
+    "tags": [
+      "stylized",
+      "artistic"
+    ]
+  },
+  {
+    "id": "frosty-window",
+    "name": "Frosty Window",
+    "url": "shaders/frosty-window.wgsl",
+    "category": "artistic",
+    "description": "Animated frost crystal patterns on glass with audio-reactive growth and mouse-driven melting.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Frost Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "crystal_size",
+        "name": "Crystal Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blur",
+        "name": "Blur Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sparkle",
+        "name": "Sparkle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "upgraded-rgba",
+      "depth-aware",
+      "animated",
+      "crystalline",
+      "interactive",
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "frost",
+      "ice",
+      "glass",
+      "winter",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "gen-chrono-erosion-feedback-melting",
+    "name": "Chrono Erosion",
+    "url": "shaders/gen-chrono-erosion-feedback-melting.wgsl",
+    "category": "artistic",
+    "description": "Datamosh-like flow effect where video melts along a curl-noise vector field with feedback decay and audio-driven turbulence.",
+    "features": [
+      "audio-reactive",
+      "temporal",
+      "mouse-driven",
+      "feedback"
+    ],
+    "tags": [
+      "erosion",
+      "melt",
+      "datamosh",
+      "feedback",
+      "curl-noise",
+      "audio",
+      "artistic"
+    ],
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "flowIntensity",
+        "name": "Flow Intensity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "feedbackMix",
+        "name": "Feedback Mix",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-glass-mosaic-liquid-refraction",
+    "name": "Glass Mosaic Refraction",
+    "url": "/shaders/gen-glass-mosaic-liquid-refraction.wgsl",
+    "category": "artistic",
+    "description": "Stained-glass polygon mosaic with pseudo-depth height-field refraction, audio-reactive ripples, and depth output.",
+    "tags": [
+      "glass",
+      "mosaic",
+      "refraction",
+      "stained-glass",
+      "audio-reactive",
+      "ornate",
+      "caustics"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "facets",
+        "name": "Facet Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "bevel",
+        "name": "Bevel Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ripple",
+        "name": "Ripple Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-sonic-lava-flow",
+    "name": "Sonic Lava Flow",
+    "url": "/shaders/gen-sonic-lava-flow.wgsl",
+    "category": "artistic",
+    "description": "Navier-Stokes-style fluid solver with decayed feedback creating a molten lava overlay, audio-reactive heat and chromatic shimmer.",
+    "tags": [
+      "lava",
+      "fluid",
+      "fire",
+      "audio-reactive",
+      "molten",
+      "heat",
+      "temporal",
+      "organic"
+    ],
+    "features": [
+      "audio-reactive",
+      "mouse-driven",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "decay",
+        "name": "Decay",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "heatGlow",
+        "name": "Heat Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "holographic-contour",
+    "name": "Holographic Contour",
+    "url": "shaders/holographic-contour.wgsl",
+    "category": "artistic",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "threshold",
+        "name": "Edge Threshold",
+        "default": 0.1,
+        "min": 0.01,
+        "max": 0.5
+      },
+      {
+        "id": "glow_strength",
+        "name": "Glow Strength",
+        "default": 2,
+        "min": 0,
+        "max": 5
+      },
+      {
+        "id": "shift_amount",
+        "name": "Hologram Shift",
+        "default": 0.05,
+        "min": 0,
+        "max": 0.2
+      },
+      {
+        "id": "dim_bg",
+        "name": "Darken Background",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "stylized",
+      "artistic",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
     "id": "iridescent-oil-slick",
     "name": "Iridescent Oil Slick",
     "url": "shaders/iridescent-oil-slick.wgsl",
@@ -1096,93 +805,505 @@
         "id": "filmScale",
         "name": "Film Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "flowSpeed",
         "name": "Flow Speed",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "turbulence",
         "name": "Turbulence",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "colorShift",
         "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "alpha-watercolor-wetness",
-    "name": "Alpha Watercolor Wetness",
-    "url": "shaders/alpha-watercolor-wetness.wgsl",
+    "id": "iso-hills",
+    "name": "Iso Hills",
+    "url": "shaders/iso-hills.wgsl",
     "category": "artistic",
-    "description": "Watercolor simulation with wetness map in alpha. Pigment flows with water gradients via capillary action. Wet areas allow bleeding; dry areas lock pigment. Mouse drops colored water; ripples add water drops. Authentic dark-edge effects at wet boundaries.",
-    "tags": [
-      "watercolor",
-      "paint",
-      "artistic",
-      "interactive",
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "wetness"
+    "description": "Renders the image as stepped topographic terraces. Mouse controls the lighting direction.",
+    "params": [
+      {
+        "name": "Steps",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "id": "steps"
+      },
+      {
+        "name": "Height Scale",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "height_scale"
+      },
+      {
+        "name": "Smoothness",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0,
+        "id": "smoothness"
+      },
+      {
+        "name": "Shadow Strength",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.8,
+        "id": "shadow_strength"
+      }
     ],
     "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
+      "mouse-driven"
+    ],
+    "tags": [
+      "stylized",
+      "artistic"
+    ]
+  },
+  {
+    "id": "liquid-prism-cascade",
+    "name": "Liquid Prism Cascade",
+    "url": "shaders/liquid-prism-cascade.wgsl",
+    "category": "artistic",
+    "description": "Colors separate along curved planes like light through prisms, creating a layered 3-D depth illusion where R, G, and B channels drift independently through warped color-space.",
+    "tags": [
+      "chromatic",
+      "prism",
+      "dispersion",
+      "depth",
+      "color",
+      "warp",
+      "artistic"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Dispersion Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "How far each color channel drifts from the source."
+      },
+      {
+        "id": "param2",
+        "name": "Depth Curvature",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "How strongly depth data amplifies the prism bending."
+      },
+      {
+        "id": "param3",
+        "name": "Prism Twist",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Rotational twist applied to each channel's dispersion vector."
+      },
+      {
+        "id": "param4",
+        "name": "Depth Weight",
+        "min": 0,
+        "max": 1,
+        "default": 0.6,
+        "step": 0.01,
+        "description": "Blend weight between luminance gradient and depth curvature."
+      }
+    ]
+  },
+  {
+    "id": "mirror-dimension",
+    "name": "Mirror Dimension",
+    "url": "shaders/mirror-dimension.wgsl",
+    "category": "artistic",
+    "description": "A rotating kaleidoscope that fractures reality. Mouse moves the center of symmetry.",
+    "features": [
+      "mouse-driven"
     ],
     "params": [
       {
-        "id": "dryRate",
-        "name": "Drying Rate",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "segments",
+        "name": "Segments",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
       },
       {
-        "id": "pigmentDeposit",
-        "name": "Pigment Deposit",
-        "type": "float",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "rotation-speed",
+        "name": "Spin Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.6
       },
       {
-        "id": "waterCapacity",
-        "name": "Water Capacity",
-        "type": "float",
+        "id": "offset",
+        "name": "Shift",
+        "min": 0,
+        "max": 1,
+        "default": 0
+      },
+      {
+        "id": "zoom",
+        "name": "Zoom",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      }
+    ],
+    "tags": [
+      "stylized",
+      "artistic"
+    ]
+  },
+  {
+    "id": "neon-contour-interactive",
+    "name": "Neon Contour",
+    "category": "artistic",
+    "url": "shaders/neon-contour-interactive.wgsl",
+    "description": "Interactive edge detection with neon glow responsive to mouse proximity.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "threshold",
+        "name": "Edge Thresh",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "glow",
+        "name": "Glow",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "cycle",
+        "name": "Color Cycle",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulse",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "stylized",
+      "artistic",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "polka-dot-reveal",
+    "name": "Polka Dot Reveal",
+    "url": "shaders/polka-dot-reveal.wgsl",
+    "category": "artistic",
+    "description": "Interactive halftone effect where mouse proximity increases the dot density, revealing more detail. Now with audio-reactive dot sizing and parameter-driven density, speed, and detail.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "halftone",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "flowStrength",
-        "name": "Flow Strength",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "recursion-mirror-vortex",
+    "name": "Recursion Mirror Vortex",
+    "url": "shaders/recursion-mirror-vortex.wgsl",
+    "category": "artistic",
+    "description": "Nested Möbius-fold mirrors that fold the image into itself at precise singularity points, creating infinite-hallway illusions that remain spatially coherent.",
+    "tags": [
+      "mirror",
+      "vortex",
+      "fractal",
+      "recursive",
+      "mobius",
+      "warp",
+      "psychedelic"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Fold Depth",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Number of Möbius fold iterations (1–6)."
+      },
+      {
+        "id": "param2",
+        "name": "Fold Radius",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Radius of each fold's influence sphere."
+      },
+      {
+        "id": "param3",
+        "name": "Vortex Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Speed and direction of the vortex rotation."
+      },
+      {
+        "id": "param4",
+        "name": "Mirror Blend",
+        "min": 0,
+        "max": 1,
+        "default": 0.6,
+        "step": 0.01,
+        "description": "Blend strength between original and folded image."
+      }
+    ]
+  },
+  {
+    "id": "rotoscope-ink",
+    "name": "Rotoscope Ink",
+    "url": "shaders/rotoscope-ink.wgsl",
+    "category": "artistic",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Transforms the image into a stylized rotoscope animation with interactive ink lines.",
+    "params": [
+      {
+        "id": "line_thickness",
+        "name": "Line Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "quantization",
+        "name": "Color Levels",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Edge Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ink_strength",
+        "name": "Ink Opacity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "stylized",
+      "artistic"
+    ]
+  },
+  {
+    "id": "spec-blue-noise-stipple",
+    "name": "Blue Noise Stipple",
+    "url": "shaders/spec-blue-noise-stipple.wgsl",
+    "category": "artistic",
+    "description": "Blue-noise dithered pointillism rendering. Uses golden-ratio low-discrepancy sequences for perceptually optimal, uniformly-spaced dot distributions with smooth gradients and no aliasing.",
+    "tags": [
+      "pointillism",
+      "blue-noise",
+      "stipple",
+      "artistic",
+      "dithering",
+      "seurat"
+    ],
+    "features": [
+      "blue-noise",
+      "pointillism",
+      "stochastic-sampling",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "dot_scale",
+        "name": "Dot Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dot_size",
+        "name": "Dot Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_var",
+        "name": "Color Variation",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "density",
+        "name": "Dot Density",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "spectral-bleed-confinement",
+    "name": "Spectral Bleed & Confinement",
+    "url": "shaders/spectral-bleed-confinement.wgsl",
+    "category": "artistic",
+    "description": "Specific color bands leak outward from image edges while being electromagnetically confined by competing channels, creating glowing halos that feel physically constrained. Audio reactivity pulses bleed radius and adds beat-synchronized flashes.",
+    "tags": [
+      "spectral",
+      "bleed",
+      "halo",
+      "edge",
+      "glow",
+      "chromatic",
+      "electromagnetic",
+      "alpha",
+      "luminance-key",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "advanced-alpha",
+      "audio-reactive"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Bleed Radius",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Distance color bleeds outward from edges."
+      },
+      {
+        "id": "param2",
+        "name": "Confinement",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Strength of cross-channel suppression (electromagnetic confinement)."
+      },
+      {
+        "id": "param3",
+        "name": "Curl Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Speed of the curl-noise vector field driving bleed direction."
+      },
+      {
+        "id": "param4",
+        "name": "Edge Threshold",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Minimum edge magnitude required to trigger spectral bleed."
       }
     ]
   },
@@ -1245,362 +1366,352 @@
     ]
   },
   {
-    "id": "mirror-dimension",
-    "name": "Mirror Dimension",
-    "url": "shaders/mirror-dimension.wgsl",
+    "id": "stipple-render",
+    "name": "Stipple Render",
+    "url": "shaders/stipple-render.wgsl",
     "category": "artistic",
-    "description": "A rotating kaleidoscope that fractures reality. Mouse moves the center of symmetry.",
-    "features": [
-      "mouse-driven"
-    ],
+    "description": "Converts the image to a stippled ink drawing with dynamic density based on mouse position and bass-driven audio reactivity.",
     "params": [
       {
-        "id": "segments",
-        "name": "Segments",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
+        "name": "Dot Scale",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "dot_scale"
       },
       {
-        "id": "rotation-speed",
-        "name": "Spin Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.6
+        "name": "Contrast",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "contrast"
       },
       {
-        "id": "offset",
-        "name": "Shift",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0
+        "name": "Focus Radius",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "focus_radius"
       },
       {
-        "id": "zoom",
-        "name": "Zoom",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
+        "name": "Color Reveal",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "id": "color_reveal"
       }
     ],
-    "tags": [
-      "stylized",
-      "artistic"
-    ]
-  },
-  {
-    "id": "polka-dot-reveal",
-    "name": "Polka Dot Reveal",
-    "url": "shaders/polka-dot-reveal.wgsl",
-    "category": "artistic",
-    "description": "Interactive halftone effect where mouse proximity increases the dot density, revealing more detail. Now with audio-reactive dot sizing and parameter-driven density, speed, and detail.",
     "features": [
       "mouse-driven",
       "audio-reactive"
+    ],
+    "tags": [
+      "stylized",
+      "artistic",
+      "stipple",
+      "ink",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "chrono-slit-scan",
+    "name": "Chrono Slit Scan",
+    "url": "shaders/chrono-slit-scan.wgsl",
+    "category": "artistic",
+    "description": "Multi-slit temporal scan with 2-3 simultaneous animated slits, feathered edges, and audio-reactive speed modulation.",
+    "params": [
+      {
+        "id": "slitCount",
+        "name": "Slit Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "slitWidth",
+        "name": "Slit Width",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "slitSpeed",
+        "name": "Slit Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "feather",
+        "name": "Feather",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "temporal-persistence",
+      "audio-reactive",
+      "fbm-warp",
+      "sdf-composition",
+      "upgraded-rgba",
+      "multi-slit"
     ],
     "tags": [
       "filter",
       "image-processing",
-      "halftone",
+      "noise",
+      "fractal",
+      "temporal",
+      "artistic"
+    ]
+  },
+  {
+    "id": "temporal-slit-paint",
+    "name": "Temporal Slit Paint",
+    "url": "shaders/temporal-slit-paint.wgsl",
+    "category": "artistic",
+    "description": "Parametric brush painting with shape selection, velocity-aware smearing, and diffusion-based color bleeding onto a temporal canvas.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "brushSize",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "shapeType",
+        "name": "Brush Shape",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "softness",
+        "name": "Brush Softness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "diffusionStrength",
+        "name": "Diffusion",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "paint",
+      "brush",
+      "artistic",
+      "temporal"
+    ]
+  },
+  {
+    "id": "sim-decay-system",
+    "name": "Decay System",
+    "url": "shaders/sim-decay-system.wgsl",
+    "category": "artistic",
+    "description": "Multi-layer decay and corrosion simulation. Image corrodes from edges inward with different materials.",
+    "features": [
+      "simulation",
+      "cellular-automata",
+      "corrosion",
+      "layered-materials",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "decay_rate",
+        "name": "Decay Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Speed of decay"
+      },
+      {
+        "id": "edge_vulnerability",
+        "name": "Edge Vulnerability",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "How much edges decay faster"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Amount of color shifting"
+      },
+      {
+        "id": "recovery",
+        "name": "Recovery Rate",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Recovery/regeneration rate (paint protection)"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "Edge detection",
+      "Cellular automata decay",
+      "Multi-material system"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "sim-ink-diffusion",
+    "name": "Ink Diffusion",
+    "url": "shaders/sim-ink-diffusion.wgsl",
+    "category": "artistic",
+    "description": "Fluid ink diffusion with paper absorption. Multi-channel Gray-Scott with Wolfram-validated parameters.",
+    "features": [
+      "simulation",
+      "reaction-diffusion",
+      "multi-channel",
+      "paper-texture",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "wetness",
+        "name": "Paper Wetness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Paper wetness affects diffusion rate"
+      },
+      {
+        "id": "viscosity",
+        "name": "Ink Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Ink viscosity"
+      },
+      {
+        "id": "feed_rate",
+        "name": "Feed Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Chemical feed rate"
+      },
+      {
+        "id": "color_mixing",
+        "name": "Color Mixing",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color mixing intensity"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "Gray-Scott reaction-diffusion",
+      "Multi-channel processing",
+      "Paper texture simulation"
+    ],
+    "wolfram_params": {
+      "coral": "F=0.0545, k=0.062",
+      "fingerprint": "F=0.0545, k=0.063",
+      "spots_waves": "F=0.018, k=0.050"
+    },
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "time-slit-scan",
+    "name": "Time Slit Scan",
+    "url": "shaders/time-slit-scan.wgsl",
+    "category": "artistic",
+    "description": "Multi-slit temporal scan with curved parametric slits, polar drift, and time-warp color tinting.",
+    "features": [
+      "mouse-driven",
       "audio-reactive"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
+        "id": "slitCount",
+        "name": "Slit Count",
+        "default": 0,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.x"
       },
       {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
+        "id": "slitShape",
+        "name": "Slit Shape",
+        "default": 0,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.y"
       },
       {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "iso-hills",
-    "name": "Iso Hills",
-    "url": "shaders/iso-hills.wgsl",
-    "category": "artistic",
-    "description": "Renders the image as stepped topographic terraces. Mouse controls the lighting direction.",
-    "params": [
-      {
-        "name": "Steps",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
+        "id": "driftSpeed",
+        "name": "Drift Speed",
         "default": 0.3,
-        "id": "steps"
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
       },
       {
-        "name": "Height Scale",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "id": "height_scale"
-      },
-      {
-        "name": "Smoothness",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0,
-        "id": "smoothness"
-      },
-      {
-        "name": "Shadow Strength",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.8,
-        "id": "shadow_strength"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "stylized",
-      "artistic"
-    ]
-  },
-  {
-    "id": "gen-chrono-erosion-feedback-melting",
-    "name": "Chrono Erosion",
-    "url": "shaders/gen-chrono-erosion-feedback-melting.wgsl",
-    "category": "artistic",
-    "description": "Datamosh-like flow effect where video melts along a curl-noise vector field with feedback decay and audio-driven turbulence.",
-    "features": [
-      "audio-reactive",
-      "temporal",
-      "mouse-driven",
-      "feedback"
-    ],
-    "tags": [
-      "erosion",
-      "melt",
-      "datamosh",
-      "feedback",
-      "curl-noise",
-      "audio",
-      "artistic"
-    ],
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "flowIntensity",
-        "name": "Flow Intensity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "feedbackMix",
-        "name": "Feedback Mix",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "holographic-contour",
-    "name": "Holographic Contour",
-    "url": "shaders/holographic-contour.wgsl",
-    "category": "artistic",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "threshold",
-        "name": "Edge Threshold",
-        "default": 0.1,
-        "min": 0.01,
-        "max": 0.5
-      },
-      {
-        "id": "glow_strength",
-        "name": "Glow Strength",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0
-      },
-      {
-        "id": "shift_amount",
-        "name": "Hologram Shift",
-        "default": 0.05,
-        "min": 0.0,
-        "max": 0.2
-      },
-      {
-        "id": "dim_bg",
-        "name": "Darken Background",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "stylized",
-      "artistic",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "spec-blue-noise-stipple",
-    "name": "Blue Noise Stipple",
-    "url": "shaders/spec-blue-noise-stipple.wgsl",
-    "category": "artistic",
-    "description": "Blue-noise dithered pointillism rendering. Uses golden-ratio low-discrepancy sequences for perceptually optimal, uniformly-spaced dot distributions with smooth gradients and no aliasing.",
-    "tags": [
-      "pointillism",
-      "blue-noise",
-      "stipple",
-      "artistic",
-      "dithering",
-      "seurat"
-    ],
-    "features": [
-      "blue-noise",
-      "pointillism",
-      "stochastic-sampling",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "dot_scale",
-        "name": "Dot Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "dot_size",
-        "name": "Dot Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color_var",
-        "name": "Color Variation",
+        "id": "slitWidth",
+        "name": "Slit Width",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "density",
-        "name": "Dot Density",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.6
-  },
-  {
-    "id": "engraving-stipple",
-    "name": "Engraving Stipple",
-    "url": "shaders/engraving-stipple.wgsl",
-    "category": "artistic",
-    "description": "Transforms the image into a stippled engraving style. Mouse acts as a light source to reveal details.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Stipple Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of stipple dots"
-      },
-      {
-        "id": "bias",
-        "name": "Ink Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Threshold for ink vs paper"
-      },
-      {
-        "id": "light",
-        "name": "Mouse Light",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Strength of mouse light source"
-      },
-      {
-        "id": "burr_texture",
-        "name": "Burr Texture",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Engraving burr and texture amount"
+        "mapping": "zoom_params.w"
       }
     ],
     "tags": [
-      "stylized",
-      "artistic"
+      "slit-scan",
+      "temporal",
+      "artistic",
+      "time-warp"
     ]
   }
 ]

--- a/public/shader-lists/distortion.json
+++ b/public/shader-lists/distortion.json
@@ -1,277 +1,78 @@
 [
   {
-    "id": "hybrid-chromatic-liquid",
-    "name": "Hybrid Chromatic Liquid",
-    "url": "shaders/hybrid-chromatic-liquid.wgsl",
+    "id": "audio-voronoi-displacement",
+    "name": "Audio Voronoi Displacement",
+    "url": "shaders/audio-voronoi-displacement.wgsl",
     "category": "distortion",
-    "description": "Fluid-like distortion with RGB channel separation flowing along a noise-generated flow field. Audio reactivity pulses dot size and ink density with the music.",
+    "description": "Audio-reactive Voronoi cells that displace the image. Image fractured into cells that pulse with music.",
     "features": [
       "mouse-driven",
-      "hybrid",
-      "liquid-distortion",
-      "chromatic-aberration",
-      "flow-field",
-      "fresnel",
-      "randomization-safe",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "flow_scale",
-        "name": "Flow Field Scale",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Scale of the flow field pattern"
-      },
-      {
-        "id": "distortion",
-        "name": "Liquid Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Amount of liquid displacement"
-      },
-      {
-        "id": "chromatic",
-        "name": "RGB Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Chromatic aberration strength"
-      },
-      {
-        "id": "flow_speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Animation speed of flow field"
-      }
-    ],
-    "tags": [
-      "interactive",
-      "cursor",
-      "audio",
-      "music"
-    ],
-    "chunks_used": [
-      "fbm2 (gen_grid.wgsl)",
-      "fresnelSchlick (crystal-facets.wgsl)",
-      "flow-field pattern (luma-flow-field.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-voronoi-glass",
-    "name": "Hybrid Voronoi Glass",
-    "url": "shaders/hybrid-voronoi-glass.wgsl",
-    "category": "distortion",
-    "description": "Voronoi diagram rendered as glass blocks with chromatic dispersion and physically-inspired refraction",
-    "features": [
-      "mouse-driven",
-      "hybrid",
+      "advanced-hybrid",
       "voronoi",
-      "glass-refraction",
-      "chromatic-dispersion",
-      "fresnel",
-      "randomization-safe"
+      "audio-fft",
+      "displacement-mapping",
+      "randomization-safe",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
       {
-        "id": "cell_density",
-        "name": "Cell Density",
+        "id": "cell_count",
+        "name": "Cell Count",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Number of Voronoi cells"
       },
       {
-        "id": "ior",
-        "name": "Refraction Index",
+        "id": "audio_reactivity",
+        "name": "Audio Reactivity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Index of refraction (glass to diamond)"
-      },
-      {
-        "id": "dispersion",
-        "name": "Chromatic Dispersion",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "RGB channel separation on refraction"
-      },
-      {
-        "id": "thickness",
-        "name": "Glass Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Virtual thickness of glass blocks"
-      }
-    ],
-    "tags": [
-      "interactive",
-      "cursor"
-    ],
-    "chunks_used": [
-      "hash22 (voronoi-glass.wgsl)",
-      "fresnelSchlick (crystal-facets.wgsl)",
-      "dispersion pattern (hyperbolic-dreamweaver.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-spectral-sorting",
-    "name": "Hybrid Spectral Sorting",
-    "url": "shaders/hybrid-spectral-sorting.wgsl",
-    "category": "distortion",
-    "description": "Audio-reactive pixel sorting with frequency-based color shifts and displacement based on spectral analysis",
-    "features": [
-      "mouse-driven",
-      "hybrid",
-      "pixel-sorting",
-      "spectral-analysis",
-      "audio-reactive",
-      "hue-shift",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "sort_threshold",
-        "name": "Sort Sensitivity",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Luminance threshold for pixel sorting"
-      },
-      {
-        "id": "spectral_bands",
-        "name": "Spectral Bands",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Number of frequency bands"
+        "description": "How much audio affects the cells"
       },
       {
         "id": "displacement",
-        "name": "Spectral Displacement",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Displacement based on spectral energy"
-      },
-      {
-        "id": "hue_shift",
-        "name": "Hue Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color shift based on frequency band"
-      }
-    ],
-    "tags": [
-      "interactive",
-      "cursor"
-    ],
-    "chunks_used": [
-      "pixel sorting pattern (bitonic-sort)",
-      "spectral analysis (spectrogram-displace)",
-      "audio-reactive pattern",
-      "fbm2 (gen_grid.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)",
-      "hueShift (stellar-plasma.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "temporal_echo",
-    "name": "Temporal Echo",
-    "url": "shaders/temporal_echo.wgsl",
-    "category": "distortion",
-    "description": "Time-warp effect with multi-frame temporal accumulation, RGB channel time offsets, ghost trails, motion-based displacement, and audio-reactive feedback pulses",
-    "tags": [
-      "temporal",
-      "echo",
-      "time",
-      "ghost",
-      "trail",
-      "warp",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "rgba",
-      "temporal",
-      "echo",
-      "motion",
-      "feedback",
-      "time-warp",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Echo Count",
+        "name": "Displacement Strength",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Strength of displacement effect"
       },
       {
-        "id": "param2",
-        "name": "Time Offset",
-        "default": 0.3,
+        "id": "color_intensity",
+        "name": "Color Intensity",
+        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Decay",
-        "default": 0.7,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Displacement",
-        "default": 0.2,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Intensity of frequency-based coloring"
       }
     ],
-    "target_rating": 4.7
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "hash22 (gen_grid.wgsl)",
+      "Voronoi pattern",
+      "Audio band simulation"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22",
+    "tags": [
+      "interactive",
+      "cursor",
+      "audio",
+      "music",
+      "reactive"
+    ]
   },
   {
     "id": "gravitational-lensing",
@@ -293,8 +94,8 @@
         "id": "black_hole_mass",
         "name": "Black Hole Mass",
         "default": 0.25,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Mass of the black hole"
@@ -303,8 +104,8 @@
         "id": "disk_brightness",
         "name": "Accretion Disk Brightness",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Brightness of accretion disk"
@@ -312,9 +113,9 @@
       {
         "id": "camera_orbit",
         "name": "Camera Orbit",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Camera orbit position"
@@ -323,8 +124,8 @@
         "id": "redshift",
         "name": "Gravitational Redshift",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Intensity of gravitational redshift"
@@ -337,81 +138,6 @@
       "Doppler beaming"
     ],
     "performance_target": "30-45 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22",
-    "tags": [
-      "interactive",
-      "cursor",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "audio-voronoi-displacement",
-    "name": "Audio Voronoi Displacement",
-    "url": "shaders/audio-voronoi-displacement.wgsl",
-    "category": "distortion",
-    "description": "Audio-reactive Voronoi cells that displace the image. Image fractured into cells that pulse with music.",
-    "features": [
-      "mouse-driven",
-      "advanced-hybrid",
-      "voronoi",
-      "audio-fft",
-      "displacement-mapping",
-      "randomization-safe",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "cell_count",
-        "name": "Cell Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Number of Voronoi cells"
-      },
-      {
-        "id": "audio_reactivity",
-        "name": "Audio Reactivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "How much audio affects the cells"
-      },
-      {
-        "id": "displacement",
-        "name": "Displacement Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Strength of displacement effect"
-      },
-      {
-        "id": "color_intensity",
-        "name": "Color Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Intensity of frequency-based coloring"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "hash22 (gen_grid.wgsl)",
-      "Voronoi pattern",
-      "Audio band simulation"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
     "created_by": "Agent 3B - Advanced Hybrid Creator",
     "created_date": "2026-03-22",
     "tags": [
@@ -443,8 +169,8 @@
         "id": "flow_sensitivity",
         "name": "Flow Sensitivity",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Sensitivity to motion"
@@ -453,8 +179,8 @@
         "id": "sort_threshold",
         "name": "Sort Threshold",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Pixel sorting threshold"
@@ -463,8 +189,8 @@
         "id": "freq_influence",
         "name": "Frequency Influence",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Influence of frequency analysis"
@@ -473,8 +199,8 @@
         "id": "smoothing",
         "name": "Temporal Smoothing",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Temporal smoothing amount"
@@ -497,175 +223,178 @@
     ]
   },
   {
-    "id": "sim-heat-haze-field",
-    "name": "Heat Haze Field",
-    "url": "shaders/sim-heat-haze-field.wgsl",
+    "id": "distortion_gravitational_lens",
+    "name": "Gravitational Lens",
+    "url": "shaders/distortion_gravitational_lens.wgsl",
     "category": "distortion",
-    "description": "Temperature simulation with convection currents. Desert mirage effect with rising heat patterns.",
-    "features": [
-      "simulation",
-      "temperature-field",
-      "convection",
-      "refraction",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "temperature",
-        "name": "Temperature Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Temperature intensity"
-      },
-      {
-        "id": "convection_speed",
-        "name": "Convection Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Speed of convection currents"
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Refraction distortion strength"
-      },
-      {
-        "id": "heat_sources",
-        "name": "Heat Source Count",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Number of heat sources"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "Temperature diffusion",
-      "Convection simulation",
-      "Refraction mapping"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "chroma-shift-grid",
-    "name": "Chroma Shift Grid",
-    "url": "shaders/chroma-shift-grid.wgsl",
-    "category": "distortion",
-    "description": "Grid-based multi-mode chromatic aberration with temporal animation, per-cell lens distortion, and depth awareness.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "mode",
-        "name": "Chroma Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "animationSpeed",
-        "name": "Animation Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "distortionStrength",
-        "name": "Lens Distortion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "chromaStrength",
-        "name": "Chroma Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
+    "description": "Einstein ring gravitational lensing with Schwarzschild metric deflection, accretion disk blackbody radiation, and chromatic aberration",
     "tags": [
-      "chromatic",
+      "gravity",
       "lens",
-      "grid",
-      "distortion"
-    ]
-  },
-  {
-    "id": "chromatic-mosaic-projector",
-    "name": "Chromatic Mosaic Projector",
-    "url": "shaders/chromatic-mosaic-projector.wgsl",
-    "category": "distortion",
-    "description": "Animated Voronoi cell mosaic with per-cell chromatic aberration, mouse gravity wells, and audio-reactive cell pulsing.",
-    "params": [
-      {
-        "id": "cellSize",
-        "name": "Cell Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chromatic",
-        "name": "Chromatic Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "voronoi",
-        "name": "Voronoi Distort",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Projection Angle",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
+      "einstein",
+      "relativity",
+      "space",
+      "accretion"
     ],
     "features": [
       "mouse-driven",
       "audio-reactive",
+      "relativistic",
+      "hdr"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Lens Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Mass Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Disk Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Chromatic Aberration",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "glass_refraction_alpha",
+    "name": "Glass Refraction RGBA",
+    "url": "shaders/glass_refraction_alpha.wgsl",
+    "category": "distortion",
+    "description": "Ray-marched glass blobs with Snell's law refraction, Fresnel reflectivity, chromatic dispersion. Alpha = transparency based on thickness and angle.",
+    "tags": [
+      "interactive",
+      "cursor",
+      "glass",
+      "refraction",
+      "dispersion",
+      "fresnel",
+      "raymarch",
+      "transparent",
+      "alpha",
+      "physical-transmittance"
+    ],
+    "features": [
+      "mouse-driven",
+      "rgba",
+      "ray-marching",
+      "refraction",
+      "fresnel",
+      "chromatic",
+      "glass",
+      "advanced-alpha"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Transparency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Roughness",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "mosaic-reveal",
+    "name": "Mosaic Reveal",
+    "url": "shaders/mosaic-reveal.wgsl",
+    "category": "distortion",
+    "description": "Mosaic reveal with hexagonal/square grid options, flood-fill reveal animation from mouse, edge glow, and audio-reactive pulse.",
+    "features": [
       "upgraded-rgba",
-      "voronoi",
-      "chromatic-dispersion"
+      "depth-aware",
+      "mosaic",
+      "interactive-reveal",
+      "mouse-driven",
+      "hex-grid",
+      "flood-fill-reveal",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "cellSize",
+        "name": "Cell Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "revealSpeed",
+        "name": "Reveal Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edgeGlow",
+        "name": "Edge Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gridType",
+        "name": "Grid Type",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
     ],
     "tags": [
       "filter",
       "image-processing",
       "mosaic",
-      "chromatic",
-      "voronoi",
-      "audio-reactive",
-      "interactive"
+      "reveal",
+      "interactive",
+      "audio-reactive"
     ]
   },
   {
@@ -700,10 +429,10 @@
       {
         "id": "param4",
         "name": "Auto Rotation",
-        "default": 0.0,
+        "default": 0,
         "min": 0,
         "max": 1,
-        "step": 1.0
+        "step": 1
       }
     ],
     "category": "distortion",
@@ -715,27 +444,334 @@
     "name": "Chromatic Swirl"
   },
   {
-    "id": "vortex-pass2",
-    "name": "Clean Vortex (Pass 2)",
-    "url": "shaders/vortex-pass2.wgsl",
+    "id": "complex-exponent-warp",
+    "name": "Complex Exponent Warp",
     "category": "distortion",
-    "description": "Distortion rendering pass: UV displacement by velocity field, swirling rotation, texture warping, vorticity-based color grading, velocity glow, and turbulent alpha compositing. Reads velocity field from dataTextureC.",
+    "url": "shaders/complex-exponent-warp.wgsl",
+    "description": "Applies a complex domain distortion z -> z^p where p is controlled by mouse position. Creates spirals, fractals, and inversions.",
+    "features": [
+      "mouse-driven",
+      "complex-math"
+    ],
+    "params": [
+      {
+        "id": "scale",
+        "name": "Scale",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Zoom scale into the complex plane"
+      },
+      {
+        "id": "spiral",
+        "name": "Spiral Rotation",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Additional spiral rotation amount"
+      },
+      {
+        "id": "exponent_spread",
+        "name": "Exponent Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Spread of the complex exponent from mouse position"
+      },
+      {
+        "id": "uv_warp",
+        "name": "UV Warp Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Scale of the UV warp output"
+      }
+    ],
     "tags": [
-      "vortex",
-      "distortion",
       "warp",
-      "multi-pass",
-      "audio-reactive"
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "crystal-facets",
+    "name": "Crystal Facets",
+    "category": "distortion",
+    "url": "shaders/crystal-facets.wgsl",
+    "description": "Physical crystal refraction with light transmission. Simulates radial-cut crystal with proper Fresnel reflection, internal scattering from fractures, and chromatic dispersion based on refractive index.",
+    "params": [
+      {
+        "name": "Facet Count",
+        "id": "zoomParam1",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Number of crystal facets (3-16)"
+      },
+      {
+        "name": "Refractive Index",
+        "id": "zoomParam2",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "IOR mix: Glass (1.5) to Diamond (2.42)"
+      },
+      {
+        "name": "Fracture Density",
+        "id": "zoomParam3",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "description": "Internal fractures reduce transmission (0=pure, 1=heavily fractured)"
+      },
+      {
+        "name": "Crystal Thickness",
+        "id": "zoomParam4",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Physical thickness affecting light path and absorption"
+      }
     ],
     "features": [
-      "multi-pass-2",
+      "mouse-driven",
+      "alpha-transmission",
+      "physical-refraction",
+      "advanced-alpha"
+    ],
+    "tags": [
+      "crystal",
+      "refraction",
+      "transmission",
+      "fresnel",
+      "dispersion",
+      "physical",
+      "alpha",
+      "physical-transmittance"
+    ]
+  },
+  {
+    "id": "dimension-slicer",
+    "name": "Dimension Slicer",
+    "url": "shaders/dimension-slicer.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "description": "Opens a dimensional rift at the mouse position, distorting space inside a rotating slice.",
+    "params": [
+      {
+        "id": "width",
+        "name": "Slice Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Rotation",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "fractal-glass-distort",
+    "name": "Fractal Glass Distort",
+    "url": "shaders/fractal-glass-distort.wgsl",
+    "category": "distortion",
+    "description": "Recursive refraction effect that creates a fractal-like kaleidoscope. Mouse position controls the distortion center.",
+    "features": [
       "mouse-driven",
       "audio-reactive"
     ],
-    "multipass": {
-      "pass": 2,
-      "totalPasses": 2
-    },
+    "params": [
+      {
+        "id": "rotation",
+        "name": "Rotation Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Fractal Scale",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "gen-chromatic-vortex",
+    "name": "Chromatic Vortex",
+    "url": "shaders/gen-chromatic-vortex.wgsl",
+    "category": "distortion",
+    "description": "Rotates image in polar coordinates with psychedelic color-space warping driven by audio. Combines spiral distortion with YUV hue shifting.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "distortion"
+    ],
+    "tags": [
+      "vortex",
+      "polar",
+      "kaleidoscope",
+      "color-warp",
+      "audio",
+      "distortion",
+      "psychedelic"
+    ],
+    "params": [
+      {
+        "id": "swirlStrength",
+        "name": "Swirl Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "radiusScale",
+        "name": "Radius Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "polarDistort",
+        "name": "Polar Distortion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorWarp",
+        "name": "Color Warp",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "glass-brick-wall",
+    "name": "Glass Brick Wall",
+    "url": "shaders/glass-brick-wall.wgsl",
+    "category": "distortion",
+    "description": "Simulates a wall of refractive glass bricks with mouse-controlled lighting.",
+    "params": [
+      {
+        "name": "Brick Size",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "brick_size"
+      },
+      {
+        "name": "Distortion",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "distortion"
+      },
+      {
+        "name": "Mortar Size",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.2,
+        "id": "mortar_size"
+      },
+      {
+        "name": "Glossiness",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.6,
+        "id": "glossiness"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "glitch-slice-mirror",
+    "name": "Glitch Slice Mirror",
+    "url": "shaders/glitch-slice-mirror.wgsl",
+    "category": "distortion",
+    "description": "Mirrors the image at the mouse position with digital glitch artifacts, chromatic aberration, and scanlines along the seam. Audio-reactive intensity boost.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "glitch",
+      "mirror",
+      "distortion",
+      "chromatic-aberration",
+      "scanlines",
+      "filter"
+    ],
     "params": [
       {
         "id": "param1",
@@ -772,145 +808,47 @@
     ]
   },
   {
-    "id": "liquid-warp-interactive",
-    "name": "Liquid Warp",
+    "id": "gravity-well",
+    "name": "Gravity Well",
+    "url": "shaders/gravity-well.wgsl",
     "category": "distortion",
-    "url": "shaders/liquid-warp-interactive.wgsl",
-    "description": "Fluid-like distortion driven by mouse flow and noise.",
     "features": [
       "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "distort",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scale",
-        "name": "Noise Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "visc",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "glass-brick-wall",
-    "name": "Glass Brick Wall",
-    "url": "shaders/glass-brick-wall.wgsl",
-    "category": "distortion",
-    "description": "Simulates a wall of refractive glass bricks with mouse-controlled lighting.",
-    "params": [
-      {
-        "name": "Brick Size",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "id": "brick_size"
-      },
-      {
-        "name": "Distortion",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "id": "distortion"
-      },
-      {
-        "name": "Mortar Size",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.2,
-        "id": "mortar_size"
-      },
-      {
-        "name": "Glossiness",
-        "type": "f32",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.6,
-        "id": "glossiness"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "interactive-rgb-split",
-    "name": "Interactive RGB Split",
-    "url": "shaders/interactive-rgb-split.wgsl",
-    "category": "distortion",
-    "description": "Chromatic aberration that reacts to mouse position and audio bass.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
     ],
     "params": [
       {
         "id": "strength",
-        "name": "Strength",
+        "name": "Gravity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Event Horizon",
+        "default": 0.2,
+        "min": 0.01,
+        "max": 0.5
+      },
+      {
+        "id": "aberration",
+        "name": "Prism",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.1
       },
       {
         "id": "falloff",
-        "name": "Localization",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mode",
-        "name": "Mode (Rad/Dir)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Angle Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Density",
+        "default": 2,
+        "min": 0.1,
+        "max": 5
       }
     ],
     "tags": [
-      "filter",
-      "image-processing",
-      "chromatic-aberration",
-      "audio-reactive",
-      "distortion"
+      "warp",
+      "distort",
+      "transform"
     ]
   },
   {
@@ -1013,6 +951,919 @@
     ]
   },
   {
+    "id": "interactive-rgb-split",
+    "name": "Interactive RGB Split",
+    "url": "shaders/interactive-rgb-split.wgsl",
+    "category": "distortion",
+    "description": "Chromatic aberration that reacts to mouse position and audio bass.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "strength",
+        "name": "Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "falloff",
+        "name": "Localization",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Mode (Rad/Dir)",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Angle Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "chromatic-aberration",
+      "audio-reactive",
+      "distortion"
+    ]
+  },
+  {
+    "id": "interactive-zoom-blur",
+    "name": "Interactive Zoom Blur",
+    "url": "shaders/interactive-zoom-blur.wgsl",
+    "category": "distortion",
+    "description": "Radial zoom blur centered on the mouse cursor with audio-reactive intensity and chromatic aberration.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "strength",
+        "name": "Blur Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "samples",
+        "name": "Quality",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bias",
+        "name": "Center Bias",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "zoom",
+      "radial",
+      "blur",
+      "chromatic"
+    ]
+  },
+  {
+    "id": "julia-warp",
+    "name": "Julia Warp",
+    "url": "shaders/julia-warp.wgsl",
+    "category": "distortion",
+    "description": "Julia fractal-based warping with orbit traps for psychedelic coloring.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-prism",
+    "url": "shaders/liquid-prism.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "description": "Chromatic aberration waves ripple from your cursor, refracting the image like a liquid lens. Audio reactivity pulses ripple strength and prism highlights with the beat.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Prism Strength",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "frequency",
+        "name": "Wave Frequency",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform",
+      "audio",
+      "music"
+    ],
+    "name": "Liquid Prism"
+  },
+  {
+    "id": "liquid-swirl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "url": "shaders/liquid-swirl.wgsl",
+    "description": "Swirls the image around the cursor like mixing paint.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Swirl Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Swirl Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smoothness",
+        "name": "Smoothness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Auto Rotation",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "name": "Liquid Swirl"
+  },
+  {
+    "id": "liquid-warp-interactive",
+    "name": "Liquid Warp",
+    "category": "distortion",
+    "url": "shaders/liquid-warp-interactive.wgsl",
+    "description": "Fluid-like distortion driven by mouse flow and noise.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "distort",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Noise Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "visc",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "luma-glass",
+    "name": "Luma Glass",
+    "category": "distortion",
+    "url": "shaders/luma-glass.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Dynamic refraction shader where the image luminance creates a glass-like surface, lit by the mouse.",
+    "params": [
+      {
+        "id": "refract-str",
+        "name": "Refraction Depth",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smoothness",
+        "name": "Surface Smoothness",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "specular",
+        "name": "Specular Shine",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "light-height",
+        "name": "Light Distance",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "luminescent-glass-tiles",
+    "url": "shaders/luminescent-glass-tiles.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Grid Density",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Mouse Radius",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "turbulence",
+        "name": "Mouse Chaos",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "description": "Glass tiles that refract based on video brightness and mouse interaction.",
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ],
+    "name": "Luminescent Glass"
+  },
+  {
+    "id": "parallax-shift",
+    "category": "distortion",
+    "url": "shaders/parallax-shift.wgsl",
+    "description": "Uses luminance as depth to create a mouse-controlled 3D parallax effect.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Depth Scale",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "zoom",
+        "name": "Edge Zoom",
+        "type": "float",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "focus",
+        "name": "Focus Plane",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ],
+    "name": "Parallax Shift"
+  },
+  {
+    "id": "pixel-sort-glitch",
+    "name": "Pixel Sort Glitch",
+    "url": "shaders/pixel-sort-glitch.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Edge-aware pixel sorting glitch with threshold masking. Creates melting pixels that flow along detected edges. Features horizontal, vertical, and angular sorting directions with adjustable window size and edge influence.",
+    "params": [
+      {
+        "id": "threshold",
+        "name": "Brightness Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Pixels brighter than this threshold will be sorted; darks are protected"
+      },
+      {
+        "id": "direction",
+        "name": "Sorting Direction",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "labels": [
+          "Horizontal",
+          "Vertical",
+          "Angular/Edge"
+        ]
+      },
+      {
+        "id": "windowSize",
+        "name": "Sort Window Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "description": "Size of the local window for sorting (1-32 pixels)"
+      },
+      {
+        "id": "edgeInfluence",
+        "name": "Edge Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "How much detected edges affect sorting direction and flow"
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform",
+      "glitch",
+      "edge",
+      "sort"
+    ]
+  },
+  {
+    "id": "predator-camouflage",
+    "name": "Predator Camouflage",
+    "url": "shaders/predator-camouflage.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Simulates an optical camouflage cloaking device around the mouse cursor, with refraction, chromatic aberration, and shimmer.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Cloak Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Radius of the camouflage cloaking field"
+      },
+      {
+        "id": "distortion",
+        "name": "Refraction Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of refraction distortion"
+      },
+      {
+        "id": "shimmer",
+        "name": "Shimmer Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Speed of the shimmer animation"
+      },
+      {
+        "id": "noise_scale",
+        "name": "Noise Scale",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Scale of the camouflage noise pattern"
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "prism-displacement",
+    "name": "Prism Lens",
+    "category": "distortion",
+    "url": "shaders/prism-displacement.wgsl",
+    "description": "Creates a prismatic lens effect with chromatic dispersion, magnification, and edge shine. Audio-reactive refraction responds to bass.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Size",
+        "default": 0.25,
+        "min": 0.1,
+        "max": 0.8
+      },
+      {
+        "id": "param2",
+        "name": "Refraction",
+        "default": 0.05,
+        "min": 0,
+        "max": 0.2
+      },
+      {
+        "id": "param3",
+        "name": "Rotation",
+        "default": 0,
+        "min": 0,
+        "max": 6.28
+      },
+      {
+        "id": "param4",
+        "name": "Edge Shine",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform",
+      "prism",
+      "chromatic",
+      "lens"
+    ]
+  },
+  {
+    "id": "radial-rgb",
+    "name": "Radial RGB",
+    "url": "shaders/radial-rgb.wgsl",
+    "category": "distortion",
+    "description": "Spectral chromatic aberration with lens distortion, anamorphic stretch, 7-wavelength sampling, and vignette.",
+    "params": [
+      {
+        "id": "k1",
+        "name": "Barrel / Pincushion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "k2",
+        "name": "Lens Curvature",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "anamorphic",
+        "name": "Anamorphic Stretch",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dispersion",
+        "name": "Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "lens",
+      "chromatic",
+      "spectral",
+      "distortion",
+      "anamorphic"
+    ]
+  },
+  {
+    "id": "scan-distort-gpt52",
+    "name": "Scan Distort Matrix gpt52",
+    "url": "shaders/scan-distort-gpt52.wgsl",
+    "category": "distortion",
+    "description": "High-density scanlines with 3-band frequency distortion, FBM-perturbed scan positions, rolling jitter, curvature, chromatic tearing, and mids-driven band distortion.",
+    "params": [
+      {
+        "id": "scan_intensity",
+        "name": "Scan Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "band_split",
+        "name": "Band Split",
+        "default": 0.35,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fbm_scale",
+        "name": "FBM Scale",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chromatic_mix",
+        "name": "Chromatic Mix",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "glitch",
+      "animated",
+      "depth-aware",
+      "upgraded-rgba",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "cinematic",
+      "vintage",
+      "atmospheric",
+      "fbm",
+      "bands"
+    ]
+  },
+  {
+    "id": "sonic-boom",
+    "name": "Sonic Boom",
+    "url": "shaders/sonic-boom.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "radius",
+        "name": "Ring Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Ring Width",
+        "default": 0.05,
+        "min": 0.01,
+        "max": 0.2
+      },
+      {
+        "id": "strength",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "split",
+        "name": "Chrom. Split",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.1
+      }
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
+    "id": "spec-bicubic-crystal",
+    "name": "Bicubic Crystal",
+    "url": "shaders/spec-bicubic-crystal.wgsl",
+    "category": "distortion",
+    "description": "Bicubic Catmull-Rom crystalline distortion. Full 16-sample bicubic interpolation for perfectly smooth magnification, applied to prismatic crystalline faceting with chromatic separation.",
+    "tags": [
+      "bicubic",
+      "catmull-rom",
+      "crystalline",
+      "distortion",
+      "prismatic",
+      "high-order-sampling"
+    ],
+    "features": [
+      "bicubic",
+      "catmull-rom",
+      "crystalline",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "crystal_scale",
+        "name": "Crystal Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "facet_sharp",
+        "name": "Facet Sharpness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chroma",
+        "name": "Chromatic Sep",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "spiral-lens",
+    "name": "Spiral Lens",
+    "url": "shaders/spiral-lens.wgsl",
+    "category": "distortion",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "temporal",
+      "depth-aware",
+      "upgraded-rgba",
+      "archimedean-spiral",
+      "chromatic-dispersion"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Spiral Tightness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Lens Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Chromatic",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Rotation Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio-reactive",
+      "feedback",
+      "interactive",
+      "lens",
+      "distortion",
+      "spiral"
+    ]
+  },
+  {
+    "id": "temporal-distortion-field",
+    "name": "Temporal Distortion Field",
+    "url": "shaders/temporal-distortion-field.wgsl",
+    "category": "distortion",
+    "description": "Creates a localized time-dilation field. Areas near the mouse update instantly, while distant areas lag behind in time.",
+    "params": [
+      {
+        "id": "field_radius",
+        "name": "Field Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "time_lag",
+        "name": "Time Lag",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ghosting",
+        "name": "Ghosting",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Warp",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "warp",
+      "distort",
+      "transform"
+    ]
+  },
+  {
     "id": "voronoi-chaos",
     "name": "Voronoi Chaos",
     "url": "shaders/voronoi-chaos.wgsl",
@@ -1062,59 +1913,53 @@
     ]
   },
   {
-    "id": "pixel-sort-glitch",
-    "name": "Pixel Sort Glitch",
-    "url": "shaders/pixel-sort-glitch.wgsl",
+    "id": "vortex-distortion",
+    "name": "Vortex Distortion",
+    "url": "shaders/vortex-distortion.wgsl",
     "category": "distortion",
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
     ],
-    "description": "Edge-aware pixel sorting glitch with threshold masking. Creates melting pixels that flow along detected edges. Features horizontal, vertical, and angular sorting directions with adjustable window size and edge influence.",
+    "description": "A swirling vortex centered on the mouse that twists the image and adds chromatic aberration.",
     "params": [
       {
-        "id": "threshold",
-        "name": "Brightness Threshold",
+        "id": "twistStrength",
+        "name": "Twist Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Pixels brighter than this threshold will be sorted; darks are protected"
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "direction",
-        "name": "Sorting Direction",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "labels": [
-          "Horizontal",
-          "Vertical",
-          "Angular/Edge"
-        ]
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "windowSize",
-        "name": "Sort Window Size",
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "darkness",
+        "name": "Center Darkness",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Size of the local window for sorting (1-32 pixels)"
-      },
-      {
-        "id": "edgeInfluence",
-        "name": "Edge Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "How much detected edges affect sorting direction and flow"
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
       "warp",
       "distort",
       "transform",
-      "glitch",
-      "edge",
-      "sort"
+      "audio",
+      "music",
+      "reactive"
     ]
   },
   {
@@ -1176,942 +2021,27 @@
     ]
   },
   {
-    "id": "parallax-shift",
+    "id": "vortex-pass2",
+    "name": "Clean Vortex (Pass 2)",
+    "url": "shaders/vortex-pass2.wgsl",
     "category": "distortion",
-    "url": "shaders/parallax-shift.wgsl",
-    "description": "Uses luminance as depth to create a mouse-controlled 3D parallax effect.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Depth Scale",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "zoom",
-        "name": "Edge Zoom",
-        "type": "float",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "focus",
-        "name": "Focus Plane",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ],
-    "name": "Parallax Shift"
-  },
-  {
-    "id": "dimension-slicer",
-    "name": "Dimension Slicer",
-    "url": "shaders/dimension-slicer.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "description": "Opens a dimensional rift at the mouse position, distorting space inside a rotating slice.",
-    "params": [
-      {
-        "id": "width",
-        "name": "Slice Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Rotation",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "spiral-lens",
-    "name": "Spiral Lens",
-    "url": "shaders/spiral-lens.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "temporal",
-      "depth-aware",
-      "upgraded-rgba",
-      "archimedean-spiral",
-      "chromatic-dispersion"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Spiral Tightness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Lens Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Chromatic",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Rotation Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio-reactive",
-      "feedback",
-      "interactive",
-      "lens",
-      "distortion",
-      "spiral"
-    ]
-  },
-  {
-    "id": "spec-bicubic-crystal",
-    "name": "Bicubic Crystal",
-    "url": "shaders/spec-bicubic-crystal.wgsl",
-    "category": "distortion",
-    "description": "Bicubic Catmull-Rom crystalline distortion. Full 16-sample bicubic interpolation for perfectly smooth magnification, applied to prismatic crystalline faceting with chromatic separation.",
-    "tags": [
-      "bicubic",
-      "catmull-rom",
-      "crystalline",
-      "distortion",
-      "prismatic",
-      "high-order-sampling"
-    ],
-    "features": [
-      "bicubic",
-      "catmull-rom",
-      "crystalline",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "crystal_scale",
-        "name": "Crystal Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "facet_sharp",
-        "name": "Facet Sharpness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chroma",
-        "name": "Chromatic Sep",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "interactive-zoom-blur",
-    "name": "Interactive Zoom Blur",
-    "url": "shaders/interactive-zoom-blur.wgsl",
-    "category": "distortion",
-    "description": "Radial zoom blur centered on the mouse cursor with audio-reactive intensity and chromatic aberration.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "strength",
-        "name": "Blur Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "samples",
-        "name": "Quality",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "bias",
-        "name": "Center Bias",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "zoom",
-      "radial",
-      "blur",
-      "chromatic"
-    ]
-  },
-  {
-    "id": "complex-exponent-warp",
-    "name": "Complex Exponent Warp",
-    "category": "distortion",
-    "url": "shaders/complex-exponent-warp.wgsl",
-    "description": "Applies a complex domain distortion z -> z^p where p is controlled by mouse position. Creates spirals, fractals, and inversions.",
-    "features": [
-      "mouse-driven",
-      "complex-math"
-    ],
-    "params": [
-      {
-        "id": "scale",
-        "name": "Scale",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Zoom scale into the complex plane"
-      },
-      {
-        "id": "spiral",
-        "name": "Spiral Rotation",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Additional spiral rotation amount"
-      },
-      {
-        "id": "exponent_spread",
-        "name": "Exponent Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Spread of the complex exponent from mouse position"
-      },
-      {
-        "id": "uv_warp",
-        "name": "UV Warp Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Scale of the UV warp output"
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "glitch-slice-mirror",
-    "name": "Glitch Slice Mirror",
-    "url": "shaders/glitch-slice-mirror.wgsl",
-    "category": "distortion",
-    "description": "Mirrors the image at the mouse position with digital glitch artifacts, chromatic aberration, and scanlines along the seam. Audio-reactive intensity boost.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "glitch",
-      "mirror",
-      "distortion",
-      "chromatic-aberration",
-      "scanlines",
-      "filter"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gravity-well",
-    "name": "Gravity Well",
-    "url": "shaders/gravity-well.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "strength",
-        "name": "Gravity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Event Horizon",
-        "default": 0.2,
-        "min": 0.01,
-        "max": 0.5
-      },
-      {
-        "id": "aberration",
-        "name": "Prism",
-        "default": 0.02,
-        "min": 0.0,
-        "max": 0.1
-      },
-      {
-        "id": "falloff",
-        "name": "Density",
-        "default": 2.0,
-        "min": 0.1,
-        "max": 5.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "temporal-distortion-field",
-    "name": "Temporal Distortion Field",
-    "url": "shaders/temporal-distortion-field.wgsl",
-    "category": "distortion",
-    "description": "Creates a localized time-dilation field. Areas near the mouse update instantly, while distant areas lag behind in time.",
-    "params": [
-      {
-        "id": "field_radius",
-        "name": "Field Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "time_lag",
-        "name": "Time Lag",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ghosting",
-        "name": "Ghosting",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Warp",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "liquid-swirl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "url": "shaders/liquid-swirl.wgsl",
-    "description": "Swirls the image around the cursor like mixing paint.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Swirl Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Swirl Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smoothness",
-        "name": "Smoothness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Auto Rotation",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "name": "Liquid Swirl"
-  },
-  {
-    "id": "liquid-prism",
-    "url": "shaders/liquid-prism.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "description": "Chromatic aberration waves ripple from your cursor, refracting the image like a liquid lens. Audio reactivity pulses ripple strength and prism highlights with the beat.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Prism Strength",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "frequency",
-        "name": "Wave Frequency",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform",
-      "audio",
-      "music"
-    ],
-    "name": "Liquid Prism"
-  },
-  {
-    "id": "prism-displacement",
-    "name": "Prism Lens",
-    "category": "distortion",
-    "url": "shaders/prism-displacement.wgsl",
-    "description": "Creates a prismatic lens effect with chromatic dispersion, magnification, and edge shine. Audio-reactive refraction responds to bass.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Size",
-        "default": 0.25,
-        "min": 0.1,
-        "max": 0.8
-      },
-      {
-        "id": "param2",
-        "name": "Refraction",
-        "default": 0.05,
-        "min": 0.0,
-        "max": 0.2
-      },
-      {
-        "id": "param3",
-        "name": "Rotation",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 6.28
-      },
-      {
-        "id": "param4",
-        "name": "Edge Shine",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform",
-      "prism",
-      "chromatic",
-      "lens"
-    ]
-  },
-  {
-    "id": "radial-rgb",
-    "name": "Radial RGB",
-    "url": "shaders/radial-rgb.wgsl",
-    "category": "distortion",
-    "description": "Spectral chromatic aberration with lens distortion, anamorphic stretch, 7-wavelength sampling, and vignette.",
-    "params": [
-      {
-        "id": "k1",
-        "name": "Barrel / Pincushion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "k2",
-        "name": "Lens Curvature",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "anamorphic",
-        "name": "Anamorphic Stretch",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "dispersion",
-        "name": "Dispersion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "lens",
-      "chromatic",
-      "spectral",
-      "distortion",
-      "anamorphic"
-    ]
-  },
-  {
-    "id": "sonic-boom",
-    "name": "Sonic Boom",
-    "url": "shaders/sonic-boom.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "radius",
-        "name": "Ring Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Ring Width",
-        "default": 0.05,
-        "min": 0.01,
-        "max": 0.2
-      },
-      {
-        "id": "strength",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "split",
-        "name": "Chrom. Split",
-        "default": 0.02,
-        "min": 0.0,
-        "max": 0.1
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "scan-distort-gpt52",
-    "name": "Scan Distort Matrix gpt52",
-    "url": "shaders/scan-distort-gpt52.wgsl",
-    "category": "distortion",
-    "description": "High-density scanlines with 3-band frequency distortion, FBM-perturbed scan positions, rolling jitter, curvature, chromatic tearing, and mids-driven band distortion.",
-    "params": [
-      {
-        "id": "scan_intensity",
-        "name": "Scan Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "band_split",
-        "name": "Band Split",
-        "default": 0.35,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fbm_scale",
-        "name": "FBM Scale",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chromatic_mix",
-        "name": "Chromatic Mix",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "glitch",
-      "animated",
-      "depth-aware",
-      "upgraded-rgba",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "cinematic",
-      "vintage",
-      "atmospheric",
-      "fbm",
-      "bands"
-    ]
-  },
-  {
-    "id": "crystal-facets",
-    "name": "Crystal Facets",
-    "category": "distortion",
-    "url": "shaders/crystal-facets.wgsl",
-    "description": "Physical crystal refraction with light transmission. Simulates radial-cut crystal with proper Fresnel reflection, internal scattering from fractures, and chromatic dispersion based on refractive index.",
-    "params": [
-      {
-        "name": "Facet Count",
-        "id": "zoomParam1",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Number of crystal facets (3-16)"
-      },
-      {
-        "name": "Refractive Index",
-        "id": "zoomParam2",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "IOR mix: Glass (1.5) to Diamond (2.42)"
-      },
-      {
-        "name": "Fracture Density",
-        "id": "zoomParam3",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Internal fractures reduce transmission (0=pure, 1=heavily fractured)"
-      },
-      {
-        "name": "Crystal Thickness",
-        "id": "zoomParam4",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Physical thickness affecting light path and absorption"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "alpha-transmission",
-      "physical-refraction",
-      "advanced-alpha"
-    ],
-    "tags": [
-      "crystal",
-      "refraction",
-      "transmission",
-      "fresnel",
-      "dispersion",
-      "physical",
-      "alpha",
-      "physical-transmittance"
-    ]
-  },
-  {
-    "id": "gen-chromatic-vortex",
-    "name": "Chromatic Vortex",
-    "url": "shaders/gen-chromatic-vortex.wgsl",
-    "category": "distortion",
-    "description": "Rotates image in polar coordinates with psychedelic color-space warping driven by audio. Combines spiral distortion with YUV hue shifting.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "distortion"
-    ],
+    "description": "Distortion rendering pass: UV displacement by velocity field, swirling rotation, texture warping, vorticity-based color grading, velocity glow, and turbulent alpha compositing. Reads velocity field from dataTextureC.",
     "tags": [
       "vortex",
-      "polar",
-      "kaleidoscope",
-      "color-warp",
-      "audio",
       "distortion",
-      "psychedelic"
-    ],
-    "params": [
-      {
-        "id": "swirlStrength",
-        "name": "Swirl Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "radiusScale",
-        "name": "Radius Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "polarDistort",
-        "name": "Polar Distortion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorWarp",
-        "name": "Color Warp",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "vortex-distortion",
-    "name": "Vortex Distortion",
-    "url": "shaders/vortex-distortion.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "description": "A swirling vortex centered on the mouse that twists the image and adds chromatic aberration.",
-    "params": [
-      {
-        "id": "twistStrength",
-        "name": "Twist Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "darkness",
-        "name": "Center Darkness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
       "warp",
-      "distort",
-      "transform",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "julia-warp",
-    "name": "Julia Warp",
-    "url": "shaders/julia-warp.wgsl",
-    "category": "distortion",
-    "description": "Julia fractal-based warping with orbit traps for psychedelic coloring.",
+      "multi-pass",
+      "audio-reactive"
+    ],
     "features": [
+      "multi-pass-2",
       "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
+      "audio-reactive"
     ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform",
-      "audio",
-      "music",
-      "reactive"
-    ],
+    "multipass": {
+      "pass": 2,
+      "totalPasses": 2
+    },
     "params": [
       {
         "id": "param1",
@@ -2145,207 +2075,6 @@
         "max": 1,
         "step": 0.01
       }
-    ]
-  },
-  {
-    "id": "predator-camouflage",
-    "name": "Predator Camouflage",
-    "url": "shaders/predator-camouflage.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Simulates an optical camouflage cloaking device around the mouse cursor, with refraction, chromatic aberration, and shimmer.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Cloak Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Radius of the camouflage cloaking field"
-      },
-      {
-        "id": "distortion",
-        "name": "Refraction Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Strength of refraction distortion"
-      },
-      {
-        "id": "shimmer",
-        "name": "Shimmer Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Speed of the shimmer animation"
-      },
-      {
-        "id": "noise_scale",
-        "name": "Noise Scale",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Scale of the camouflage noise pattern"
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "luminescent-glass-tiles",
-    "url": "shaders/luminescent-glass-tiles.wgsl",
-    "category": "distortion",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Grid Density",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Mouse Radius",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "turbulence",
-        "name": "Mouse Chaos",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "description": "Glass tiles that refract based on video brightness and mouse interaction.",
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ],
-    "name": "Luminescent Glass"
-  },
-  {
-    "id": "luma-glass",
-    "name": "Luma Glass",
-    "category": "distortion",
-    "url": "shaders/luma-glass.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Dynamic refraction shader where the image luminance creates a glass-like surface, lit by the mouse.",
-    "params": [
-      {
-        "id": "refract-str",
-        "name": "Refraction Depth",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smoothness",
-        "name": "Surface Smoothness",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "specular",
-        "name": "Specular Shine",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "light-height",
-        "name": "Light Distance",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
-    ]
-  },
-  {
-    "id": "fractal-glass-distort",
-    "name": "Fractal Glass Distort",
-    "url": "shaders/fractal-glass-distort.wgsl",
-    "category": "distortion",
-    "description": "Recursive refraction effect that creates a fractal-like kaleidoscope. Mouse position controls the distortion center.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "rotation",
-        "name": "Rotation Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scale",
-        "name": "Fractal Scale",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "warp",
-      "distort",
-      "transform"
     ]
   },
   {
@@ -2408,6 +2137,219 @@
     "target_rating": 4.7
   },
   {
+    "id": "hybrid-chromatic-liquid",
+    "name": "Hybrid Chromatic Liquid",
+    "url": "shaders/hybrid-chromatic-liquid.wgsl",
+    "category": "distortion",
+    "description": "Fluid-like distortion with RGB channel separation flowing along a noise-generated flow field. Audio reactivity pulses dot size and ink density with the music.",
+    "features": [
+      "mouse-driven",
+      "hybrid",
+      "liquid-distortion",
+      "chromatic-aberration",
+      "flow-field",
+      "fresnel",
+      "randomization-safe",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "flow_scale",
+        "name": "Flow Field Scale",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Scale of the flow field pattern"
+      },
+      {
+        "id": "distortion",
+        "name": "Liquid Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Amount of liquid displacement"
+      },
+      {
+        "id": "chromatic",
+        "name": "RGB Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Chromatic aberration strength"
+      },
+      {
+        "id": "flow_speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Animation speed of flow field"
+      }
+    ],
+    "tags": [
+      "interactive",
+      "cursor",
+      "audio",
+      "music"
+    ],
+    "chunks_used": [
+      "fbm2 (gen_grid.wgsl)",
+      "fresnelSchlick (crystal-facets.wgsl)",
+      "flow-field pattern (luma-flow-field.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "hybrid-spectral-sorting",
+    "name": "Hybrid Spectral Sorting",
+    "url": "shaders/hybrid-spectral-sorting.wgsl",
+    "category": "distortion",
+    "description": "Audio-reactive pixel sorting with frequency-based color shifts and displacement based on spectral analysis",
+    "features": [
+      "mouse-driven",
+      "hybrid",
+      "pixel-sorting",
+      "spectral-analysis",
+      "audio-reactive",
+      "hue-shift",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "sort_threshold",
+        "name": "Sort Sensitivity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Luminance threshold for pixel sorting"
+      },
+      {
+        "id": "spectral_bands",
+        "name": "Spectral Bands",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Number of frequency bands"
+      },
+      {
+        "id": "displacement",
+        "name": "Spectral Displacement",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Displacement based on spectral energy"
+      },
+      {
+        "id": "hue_shift",
+        "name": "Hue Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color shift based on frequency band"
+      }
+    ],
+    "tags": [
+      "interactive",
+      "cursor"
+    ],
+    "chunks_used": [
+      "pixel sorting pattern (bitonic-sort)",
+      "spectral analysis (spectrogram-displace)",
+      "audio-reactive pattern",
+      "fbm2 (gen_grid.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)",
+      "hueShift (stellar-plasma.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "hybrid-voronoi-glass",
+    "name": "Hybrid Voronoi Glass",
+    "url": "shaders/hybrid-voronoi-glass.wgsl",
+    "category": "distortion",
+    "description": "Voronoi diagram rendered as glass blocks with chromatic dispersion and physically-inspired refraction",
+    "features": [
+      "mouse-driven",
+      "hybrid",
+      "voronoi",
+      "glass-refraction",
+      "chromatic-dispersion",
+      "fresnel",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "cell_density",
+        "name": "Cell Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Number of Voronoi cells"
+      },
+      {
+        "id": "ior",
+        "name": "Refraction Index",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Index of refraction (glass to diamond)"
+      },
+      {
+        "id": "dispersion",
+        "name": "Chromatic Dispersion",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "RGB channel separation on refraction"
+      },
+      {
+        "id": "thickness",
+        "name": "Glass Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Virtual thickness of glass blocks"
+      }
+    ],
+    "tags": [
+      "interactive",
+      "cursor"
+    ],
+    "chunks_used": [
+      "hash22 (voronoi-glass.wgsl)",
+      "fresnelSchlick (crystal-facets.wgsl)",
+      "dispersion pattern (hyperbolic-dreamweaver.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
     "id": "digital-lens",
     "name": "Digital Lens",
     "url": "shaders/digital-lens.wgsl",
@@ -2418,29 +2360,29 @@
         "id": "distortion",
         "name": "Distortion",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "dispersion",
         "name": "Dispersion",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "vignette",
         "name": "Vignette",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "focus",
         "name": "Focus Point",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -2460,6 +2402,239 @@
     ]
   },
   {
+    "id": "chroma-shift-grid",
+    "name": "Chroma Shift Grid",
+    "url": "shaders/chroma-shift-grid.wgsl",
+    "category": "distortion",
+    "description": "Grid-based multi-mode chromatic aberration with temporal animation, per-cell lens distortion, and depth awareness.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "mode",
+        "name": "Chroma Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "animationSpeed",
+        "name": "Animation Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "distortionStrength",
+        "name": "Lens Distortion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "chromaStrength",
+        "name": "Chroma Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "chromatic",
+      "lens",
+      "grid",
+      "distortion"
+    ]
+  },
+  {
+    "id": "chromatic-mosaic-projector",
+    "name": "Chromatic Mosaic Projector",
+    "url": "shaders/chromatic-mosaic-projector.wgsl",
+    "category": "distortion",
+    "description": "Animated Voronoi cell mosaic with per-cell chromatic aberration, mouse gravity wells, and audio-reactive cell pulsing.",
+    "params": [
+      {
+        "id": "cellSize",
+        "name": "Cell Size",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chromatic",
+        "name": "Chromatic Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "voronoi",
+        "name": "Voronoi Distort",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Projection Angle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "upgraded-rgba",
+      "voronoi",
+      "chromatic-dispersion"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "mosaic",
+      "chromatic",
+      "voronoi",
+      "audio-reactive",
+      "interactive"
+    ]
+  },
+  {
+    "id": "temporal_echo",
+    "name": "Temporal Echo",
+    "url": "shaders/temporal_echo.wgsl",
+    "category": "distortion",
+    "description": "Time-warp effect with multi-frame temporal accumulation, RGB channel time offsets, ghost trails, motion-based displacement, and audio-reactive feedback pulses",
+    "tags": [
+      "temporal",
+      "echo",
+      "time",
+      "ghost",
+      "trail",
+      "warp",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "rgba",
+      "temporal",
+      "echo",
+      "motion",
+      "feedback",
+      "time-warp",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Echo Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Time Offset",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Decay",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Displacement",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "sim-heat-haze-field",
+    "name": "Heat Haze Field",
+    "url": "shaders/sim-heat-haze-field.wgsl",
+    "category": "distortion",
+    "description": "Temperature simulation with convection currents. Desert mirage effect with rising heat patterns.",
+    "features": [
+      "simulation",
+      "temperature-field",
+      "convection",
+      "refraction",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "temperature",
+        "name": "Temperature Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Temperature intensity"
+      },
+      {
+        "id": "convection_speed",
+        "name": "Convection Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Speed of convection currents"
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Refraction distortion strength"
+      },
+      {
+        "id": "heat_sources",
+        "name": "Heat Source Count",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Number of heat sources"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "Temperature diffusion",
+      "Convection simulation",
+      "Refraction mapping"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
+  },
+  {
     "id": "elastic-chromatic",
     "name": "Elastic Chromatic",
     "url": "shaders/elastic-chromatic.wgsl",
@@ -2476,8 +2651,8 @@
         "id": "elasticity",
         "name": "Elasticity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Elastic spring constant for chromatic lag"
@@ -2486,8 +2661,8 @@
         "id": "chromatic_scale",
         "name": "Chromatic Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Scale of chromatic separation"
@@ -2496,8 +2671,8 @@
         "id": "lissajous_ratio",
         "name": "Lissajous Ratio",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Frequency ratio for Lissajous oscillation"
@@ -2506,8 +2681,8 @@
         "id": "damping",
         "name": "Damping",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Damping factor for elastic lag"
@@ -2521,180 +2696,5 @@
       "lissajous",
       "mouse-driven"
     ]
-  },
-  {
-    "id": "mosaic-reveal",
-    "name": "Mosaic Reveal",
-    "url": "shaders/mosaic-reveal.wgsl",
-    "category": "distortion",
-    "description": "Mosaic reveal with hexagonal/square grid options, flood-fill reveal animation from mouse, edge glow, and audio-reactive pulse.",
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "mosaic",
-      "interactive-reveal",
-      "mouse-driven",
-      "hex-grid",
-      "flood-fill-reveal",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "cellSize",
-        "name": "Cell Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "revealSpeed",
-        "name": "Reveal Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edgeGlow",
-        "name": "Edge Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gridType",
-        "name": "Grid Type",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "mosaic",
-      "reveal",
-      "interactive",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "glass_refraction_alpha",
-    "name": "Glass Refraction RGBA",
-    "url": "shaders/glass_refraction_alpha.wgsl",
-    "category": "distortion",
-    "description": "Ray-marched glass blobs with Snell's law refraction, Fresnel reflectivity, chromatic dispersion. Alpha = transparency based on thickness and angle.",
-    "tags": [
-      "interactive",
-      "cursor",
-      "glass",
-      "refraction",
-      "dispersion",
-      "fresnel",
-      "raymarch",
-      "transparent",
-      "alpha",
-      "physical-transmittance"
-    ],
-    "features": [
-      "mouse-driven",
-      "rgba",
-      "ray-marching",
-      "refraction",
-      "fresnel",
-      "chromatic",
-      "glass",
-      "advanced-alpha"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Transparency",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Dispersion",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Thickness",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Roughness",
-        "default": 0.1,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "distortion_gravitational_lens",
-    "name": "Gravitational Lens",
-    "url": "shaders/distortion_gravitational_lens.wgsl",
-    "category": "distortion",
-    "description": "Einstein ring gravitational lensing with Schwarzschild metric deflection, accretion disk blackbody radiation, and chromatic aberration",
-    "tags": [
-      "gravity",
-      "lens",
-      "einstein",
-      "relativity",
-      "space",
-      "accretion"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "relativistic",
-      "hdr"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Lens Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Mass Count",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Disk Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Chromatic Aberration",
-        "default": 0.2,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.7
   }
 ]

--- a/public/shader-lists/generative.json
+++ b/public/shader-lists/generative.json
@@ -1,391 +1,147 @@
 [
   {
-    "id": "hybrid-fractal-feedback",
-    "name": "Hybrid Fractal Feedback",
-    "url": "shaders/hybrid-fractal-feedback.wgsl",
+    "id": "cellular-automata-3d",
+    "name": "Cellular Automata 3D",
+    "url": "shaders/cellular-automata-3d.wgsl",
     "category": "generative",
-    "description": "Julia set fractal with feedback trails and per-channel temporal delay creating RGB separation trails",
+    "description": "3D Game of Life rendered with volume raymarching. Glowing 3D structures that evolve frame-by-frame.",
     "features": [
-      "hybrid",
-      "julia-set",
-      "temporal-feedback",
-      "rgb-delay",
-      "fractal",
-      "randomization-safe"
+      "advanced-hybrid",
+      "3d-ca",
+      "volume-raymarching",
+      "transfer-function",
+      "randomization-safe",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
       {
-        "id": "zoom",
-        "name": "Zoom Level",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "evolution_speed",
+        "name": "Evolution Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Fractal zoom level"
+        "description": "Speed of CA evolution"
       },
       {
-        "id": "feedback",
-        "name": "Feedback Strength",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "initial_density",
+        "name": "Initial Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Strength of temporal feedback trails"
+        "description": "Initial cell density"
       },
       {
-        "id": "rgb_delay",
-        "name": "RGB Channel Delay",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Temporal offset between RGB channels"
-      },
-      {
-        "id": "color_cycle",
+        "id": "color_cycling",
         "name": "Color Cycling",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Speed of palette color cycling"
-      }
-    ],
-    "chunks_used": [
-      "juliaIterate (julia-warp.wgsl)",
-      "fbm2 flow field (gen_grid.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-noise-kaleidoscope",
-    "name": "Hybrid Noise Kaleidoscope",
-    "url": "shaders/hybrid-noise-kaleidoscope.wgsl",
-    "category": "generative",
-    "description": "Domain-warped FBM noise fed through kaleidoscope symmetry with dynamic hue shifting and RGB channel splits",
-    "features": [
-      "hybrid",
-      "fbm-noise",
-      "kaleidoscope",
-      "chromatic-aberration",
-      "hue-shift",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "noise_scale",
-        "name": "Noise Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Scale of the FBM noise pattern"
-      },
-      {
-        "id": "segments",
-        "name": "Kaleidoscope Segments",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Number of mirror segments in kaleidoscope"
-      },
-      {
-        "id": "chromatic",
-        "name": "Chromatic Aberration",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
-        "description": "RGB channel separation amount"
-      },
-      {
-        "id": "hue_speed",
-        "name": "Hue Shift Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
         "description": "Speed of color cycling"
+      },
+      {
+        "id": "camera_rotation",
+        "name": "Camera Rotation",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Camera rotation speed"
       }
     ],
     "chunks_used": [
-      "fbm2 (gen_grid.wgsl)",
-      "kaleidoscope (kaleidoscope.wgsl)",
-      "hueShift (stellar-plasma.wgsl)"
+      "hash12 (gen_grid.wgsl)",
+      "hash3 (gen-xeno-botanical-synth-flora.wgsl)",
+      "3D CA rules (26 neighbors)",
+      "Volume raymarching",
+      "Transfer function coloring"
     ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-cyber-organic",
-    "name": "Hybrid Cyber-Organic",
-    "url": "shaders/hybrid-cyber-organic.wgsl",
-    "category": "generative",
-    "description": "Digital circuit traces that grow organically with neon glow, combining hexagonal grid structures with cellular growth patterns",
-    "features": [
-      "hybrid",
-      "circuit-patterns",
-      "organic-growth",
-      "neon-glow",
-      "hex-grid",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "circuit_density",
-        "name": "Circuit Density",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of hexagonal circuit grid"
-      },
-      {
-        "id": "growth",
-        "name": "Organic Growth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Amount of organic growth over circuits"
-      },
-      {
-        "id": "glow",
-        "name": "Neon Glow",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Glow intensity of active circuits"
-      },
-      {
-        "id": "chaos",
-        "name": "Randomness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Chaos/randomness in growth patterns"
-      }
-    ],
-    "chunks_used": [
-      "hexEdgeDist (hex-circuit.wgsl)",
-      "fbm2 growth pattern (digital-moss.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-sdf-plasma",
-    "name": "Hybrid SDF Plasma Field",
-    "url": "shaders/hybrid-sdf-plasma.wgsl",
-    "category": "generative",
-    "description": "Raymarched SDF scene with plasma noise displacement and dynamic palette-based coloring",
-    "features": [
-      "hybrid",
-      "raymarching",
-      "sdf",
-      "plasma-noise",
-      "palette-cycling",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "plasma_detail",
-        "name": "Plasma Detail",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Detail level of plasma noise displacement"
-      },
-      {
-        "id": "color_speed",
-        "name": "Color Cycle Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Speed of palette color cycling"
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Plasma glow strength"
-      },
-      {
-        "id": "quality",
-        "name": "Raymarch Quality",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Raymarching step count (affects performance)"
-      }
-    ],
-    "chunks_used": [
-      "sdSphere (gen-xeno-botanical-synth-flora.wgsl)",
-      "sdSmoothUnion (gen-xeno-botanical-synth-flora.wgsl)",
-      "fbm3 (gen-xeno-botanical-synth-flora.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-magnetic-field",
-    "name": "Hybrid Magnetic Field",
-    "url": "shaders/hybrid-magnetic-field.wgsl",
-    "category": "generative",
-    "description": "Magnetic field line visualization with flowing particles and FBM-varied field distortion. Audio reactivity makes field lines pulse and glow with the beat.",
-    "features": [
-      "hybrid",
-      "vector-field",
-      "particle-trails",
-      "magnetic-distortion",
-      "glow",
-      "randomization-safe",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "field_strength",
-        "name": "Field Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Strength of magnetic dipole field"
-      },
-      {
-        "id": "line_density",
-        "name": "Line Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Number of field lines displayed"
-      },
-      {
-        "id": "trails",
-        "name": "Trail Persistence",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "How long particle trails persist"
-      },
-      {
-        "id": "distortion",
-        "name": "Field Distortion",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "FBM noise influence on field"
-      }
-    ],
+    "performance_target": "30-45 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22",
     "tags": [
       "audio",
       "music",
-      "magnetic",
-      "field",
-      "particles",
-      "trails",
-      "glow"
-    ],
-    "chunks_used": [
-      "magnetic field calculation",
-      "fbm2 variation (gen_grid.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)",
-      "rot2 (kaleidoscope.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
+      "reactive"
+    ]
   },
   {
-    "id": "aurora_borealis",
-    "name": "Aurora Borealis",
-    "url": "shaders/aurora_borealis.wgsl",
+    "id": "holographic-interferometry",
+    "name": "Holographic Interferometry",
+    "url": "shaders/holographic-interferometry.wgsl",
     "category": "generative",
-    "description": "Northern lights with flowing ribbon curves, curl noise turbulence, altitude-based coloring (green to red), and starfield background",
-    "tags": [
-      "aurora",
-      "northern-lights",
-      "atmospheric",
-      "nature",
-      "sky"
-    ],
+    "description": "Simulated hologram with interference fringe patterns. Rainbow interference fringes with speckled laser light.",
     "features": [
-      "rgba",
-      "aurora",
-      "curl-noise",
-      "ribbons",
-      "atmospheric"
+      "advanced-hybrid",
+      "interference-patterns",
+      "holography",
+      "phase-coloring",
+      "randomization-safe",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Ribbons",
-        "default": 0.4,
+        "id": "fringe_density",
+        "name": "Fringe Density",
+        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of interference fringes"
       },
       {
-        "id": "param2",
-        "name": "Flow Speed",
-        "default": 0.4,
+        "id": "coherence",
+        "name": "Coherence Length",
+        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Laser coherence (affects speckle size)"
       },
       {
-        "id": "param3",
-        "name": "Ribbon Width",
-        "default": 0.3,
+        "id": "reconstruction_angle",
+        "name": "Reconstruction Angle",
+        "default": 0,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Hologram reconstruction angle"
       },
       {
-        "id": "param4",
-        "name": "Glow",
-        "default": 0.7,
+        "id": "saturation",
+        "name": "Color Saturation",
+        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Saturation of holographic colors"
       }
     ],
-    "target_rating": 4.8
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "Interference pattern math",
+      "Speckle noise generation"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22",
+    "tags": [
+      "audio",
+      "music",
+      "reactive"
+    ]
   },
   {
     "id": "multi-fractal-compositor-lens",
@@ -409,8 +165,8 @@
         "id": "lens_mass",
         "name": "Lens Mass",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Mouse gravitational mass and zoom level"
@@ -419,8 +175,8 @@
         "id": "ring_glow",
         "name": "Ring Glow",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Einstein ring glow strength and iteration count"
@@ -429,8 +185,8 @@
         "id": "ripple_mass",
         "name": "Ripple Mass",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Temporary mass from clicks and domain warp"
@@ -438,9 +194,9 @@
       {
         "id": "chroma_boost",
         "name": "Chroma Boost",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Lens-driven chromatic aberration and fractal blend"
@@ -489,8 +245,8 @@
         "id": "zoom",
         "name": "Zoom Level",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Zoom level into fractal"
@@ -499,8 +255,8 @@
         "id": "iterations",
         "name": "Iteration Count",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Maximum iterations"
@@ -508,9 +264,9 @@
       {
         "id": "domain_warp",
         "name": "Domain Warp",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Amount of domain warping"
@@ -518,9 +274,9 @@
       {
         "id": "fractal_blend",
         "name": "Fractal Blend",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Blend between fractal types"
@@ -535,150 +291,6 @@
       "Newton fractal"
     ],
     "performance_target": "45-60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22",
-    "tags": [
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "cellular-automata-3d",
-    "name": "Cellular Automata 3D",
-    "url": "shaders/cellular-automata-3d.wgsl",
-    "category": "generative",
-    "description": "3D Game of Life rendered with volume raymarching. Glowing 3D structures that evolve frame-by-frame.",
-    "features": [
-      "advanced-hybrid",
-      "3d-ca",
-      "volume-raymarching",
-      "transfer-function",
-      "randomization-safe",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "evolution_speed",
-        "name": "Evolution Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Speed of CA evolution"
-      },
-      {
-        "id": "initial_density",
-        "name": "Initial Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Initial cell density"
-      },
-      {
-        "id": "color_cycling",
-        "name": "Color Cycling",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Speed of color cycling"
-      },
-      {
-        "id": "camera_rotation",
-        "name": "Camera Rotation",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Camera rotation speed"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "hash3 (gen-xeno-botanical-synth-flora.wgsl)",
-      "3D CA rules (26 neighbors)",
-      "Volume raymarching",
-      "Transfer function coloring"
-    ],
-    "performance_target": "30-45 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22",
-    "tags": [
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "holographic-interferometry",
-    "name": "Holographic Interferometry",
-    "url": "shaders/holographic-interferometry.wgsl",
-    "category": "generative",
-    "description": "Simulated hologram with interference fringe patterns. Rainbow interference fringes with speckled laser light.",
-    "features": [
-      "advanced-hybrid",
-      "interference-patterns",
-      "holography",
-      "phase-coloring",
-      "randomization-safe",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "fringe_density",
-        "name": "Fringe Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of interference fringes"
-      },
-      {
-        "id": "coherence",
-        "name": "Coherence Length",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Laser coherence (affects speckle size)"
-      },
-      {
-        "id": "reconstruction_angle",
-        "name": "Reconstruction Angle",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Hologram reconstruction angle"
-      },
-      {
-        "id": "saturation",
-        "name": "Color Saturation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Saturation of holographic colors"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "Interference pattern math",
-      "Speckle noise generation"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
     "created_by": "Agent 3B - Advanced Hybrid Creator",
     "created_date": "2026-03-22",
     "tags": [
@@ -707,8 +319,8 @@
         "id": "network_depth",
         "name": "Network Depth",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Number of neural network layers"
@@ -717,8 +329,8 @@
         "id": "activation_vis",
         "name": "Activation Visualization",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Visibility of activation patterns"
@@ -727,8 +339,8 @@
         "id": "glow",
         "name": "Glow Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Volumetric glow intensity"
@@ -736,9 +348,9 @@
       {
         "id": "camera_rotation",
         "name": "Camera Rotation",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Camera orbit position"
@@ -760,278 +372,188 @@
     ]
   },
   {
-    "id": "predator-prey",
-    "name": "Pixel Ecology",
-    "url": "shaders/predator-prey.wgsl",
+    "id": "galaxy-sim",
+    "name": "Galaxy Simulation",
+    "url": "shaders/galaxy.wgsl",
     "category": "generative",
-    "description": "Cellular automata ecosystem with plants, herbivores, and carnivores - watch the food chain unfold.",
-    "params": [
-      {
-        "id": "eatProbability",
-        "name": "Eat Probability",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "deathRate",
-        "name": "Death Rate",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "mutationRate",
-        "name": "Mutation Rate",
-        "default": 0.2,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "breedThreshold",
-        "name": "Breed Threshold",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      }
-    ],
+    "description": "Audio-reactive spiral galaxy with breathing arms, diffraction-spike stars, mouse-parallax center, and silence-driven reverse flow.",
     "features": [
-      "temporal-persistence",
-      "interactive",
-      "ecology",
+      "depth-aware",
+      "upgraded-rgba",
+      "animated",
+      "audio-reactive",
       "mouse-driven"
     ],
     "tags": [
       "procedural",
-      "generative"
-    ]
-  },
-  {
-    "id": "cymatic-sand",
-    "name": "Cymatic Sand",
-    "description": "Simulates Chladni plate patterns where sand accumulates on nodal lines of standing waves. Mouse X/Y controls the frequency modes.",
-    "url": "shaders/cymatic-sand.wgsl",
-    "category": "generative",
-    "features": [
-      "mouse-driven",
-      "simulation",
+      "generative",
+      "galaxy",
+      "space",
+      "stars",
+      "spiral",
       "audio-reactive",
-      "audio-driven"
+      "vj"
     ],
     "params": [
       {
-        "id": "amount",
-        "name": "Sand Amount",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0
+        "id": "param1",
+        "name": "Opacity",
+        "default": 0.85,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "width",
-        "name": "Line Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param2",
+        "name": "Arm Count",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "grain",
-        "name": "Grain Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param3",
+        "name": "Rotation Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param4",
+        "name": "Arm Spread",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "particle_dreams_alpha",
+    "name": "Particle Dreams RGBA",
+    "url": "shaders/particle_dreams_alpha.wgsl",
+    "category": "generative",
+    "description": "80+ particles with alpha-based lifetime, trail accumulation, birth/death fades. Alpha channel stores particle density for blending.",
+    "tags": [
+      "particles",
+      "alpha",
+      "trails",
+      "dreamy",
+      "generative"
+    ],
+    "features": [
+      "rgba",
+      "alpha-trails",
+      "temporal-feedback",
+      "mouse-attraction",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Particle Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Trail Persistence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Chaos",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       }
     ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "plasma",
+    "name": "Plasma Ball",
+    "url": "shaders/plasma.wgsl",
+    "category": "generative",
+    "description": "",
     "tags": [
       "procedural",
       "generative",
       "audio",
       "music",
       "reactive"
-    ]
-  },
-  {
-    "id": "lichtenberg-fractal",
-    "name": "Lichtenberg Fractal",
-    "description": "Simulates high-voltage electrical branching patterns (Lichtenberg figures) that grow from the mouse cursor.",
-    "url": "shaders/lichtenberg-fractal.wgsl",
-    "category": "generative",
-    "features": [
-      "mouse-driven",
-      "simulation"
-    ],
-    "params": [
-      {
-        "id": "speed",
-        "name": "Growth Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "branching",
-        "name": "Branching Factor",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Burn Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "clear",
-        "name": "Clear Canvas",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "procedural",
-      "generative"
-    ]
-  },
-  {
-    "id": "gen-crystalline-chrono-dyson",
-    "name": "Crystalline Chrono-Dyson",
-    "url": "shaders/gen-crystalline-chrono-dyson.wgsl",
-    "category": "generative",
-    "description": "A colossal, self-assembling Dyson sphere constructed of hyper-refractive crystal panels and flowing plasma conduits that orbit and extract energy from a dying, audio-reactive micro-quasar.",
-    "tags": [
-      "cosmic",
-      "mechanical",
-      "refraction",
-      "plasma",
-      "raymarching"
     ],
     "features": [
-      "mouse-driven",
+      "audio-reactive",
       "audio-driven",
-      "audio-reactive"
+      "mouse-driven"
     ],
-    "params": [
-      {
-        "id": "panelDensity",
-        "name": "Panel Density",
-        "default": 4.0,
-        "min": 1.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "id": "quasarGlow",
-        "name": "Quasar Glow",
-        "default": 1.5,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.05
-      },
-      {
-        "id": "fluxSpeed",
-        "name": "Flux Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 3.0,
-        "step": 0.01
-      },
-      {
-        "id": "swarmCount",
-        "name": "Swarm Count",
-        "default": 50.0,
-        "min": 10.0,
-        "max": 100.0,
-        "step": 1.0
-      }
-    ]
-  },
-  {
-    "id": "wolfram-data-demo",
-    "name": "Wolfram Data Demo",
-    "url": "shaders/wolfram-data-demo.wgsl",
-    "category": "generative",
-    "description": "Demonstrates scientific constants and mathematical functions from Wolfram Alpha. Features phyllotaxis patterns, Airy disk diffraction, Fibonacci spirals, and atmospheric scattering using real physical data.",
-    "tags": [
-      "wolfram",
-      "scientific",
-      "mathematical",
-      "procedural",
-      "physics",
-      "golden-ratio",
-      "atmospheric",
-      "diffraction"
-    ],
-    "features": [
-      "procedural"
-    ],
-    "complexity": "high",
     "params": [
       {
         "id": "param1",
-        "name": "Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.25,
-        "labels": [
-          "Phyllotaxis",
-          "Airy Disk",
-          "Fibonacci",
-          "Atmosphere"
-        ]
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
         "id": "param2",
-        "name": "Scale / Size",
+        "name": "Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "param3",
-        "name": "Density / Detail",
+        "name": "Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "param4",
-        "name": "Temperature / Blend",
+        "name": "Detail",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "gen-holographic-data-core",
-    "name": "Holographic Data Core",
-    "url": "shaders/gen-holographic-data-core.wgsl",
+    "id": "gen-bioluminescent-abyss",
+    "name": "Bioluminescent Abyss",
+    "url": "shaders/gen-bioluminescent-abyss.wgsl",
     "category": "generative",
-    "description": "An infinite journey through a quantum lattice of glowing data nodes and pulsing circuits.",
+    "description": "An infinite deep underwater landscape with swaying tube worms and thermal vents, featuring bioluminescence and deep sea atmosphere.",
     "tags": [
+      "underwater",
+      "generative",
       "3d",
+      "bioluminescence",
       "raymarching",
-      "cyberpunk",
-      "hologram",
-      "data",
-      "neon",
-      "procedural",
-      "infinite",
+      "volumetric",
       "audio",
-      "music"
+      "music",
+      "reactive"
     ],
     "features": [
       "mouse-driven",
@@ -1041,46 +563,47 @@
     "params": [
       {
         "id": "param1",
-        "name": "Node Density",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 2.0,
+        "name": "Worm Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.1
       },
       {
         "id": "param2",
-        "name": "Travel Speed",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.5
+        "name": "Current Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
       },
       {
         "id": "param3",
-        "name": "Data Pulse Rate",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
+        "name": "Glow Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
         "step": 0.1
       },
       {
         "id": "param4",
-        "name": "Glitch Intensity",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
+        "name": "Water Clarity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.05
       }
     ]
   },
   {
-    "id": "gen-hyper-warp",
-    "name": "Hyper Warp",
-    "url": "shaders/gen_hyper_warp.wgsl",
+    "id": "bubble-chamber",
+    "name": "Bubble Chamber",
+    "url": "shaders/bubble-chamber.wgsl",
     "category": "generative",
-    "description": "Advanced domain warping with fractal noise and reaction-diffusion feedback.",
+    "description": "Simulates subatomic particle trails in a magnetic field using a feedback loop.",
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "feedback"
     ],
     "tags": [
       "procedural",
@@ -1122,128 +645,569 @@
     ]
   },
   {
-    "id": "gen-voronoi-crystal",
-    "name": "Voronoi Crystal",
-    "url": "shaders/gen-voronoi-crystal.wgsl",
+    "id": "cosmic-jellyfish",
+    "name": "Cosmic Jellyfish",
+    "url": "shaders/cosmic-jellyfish.wgsl",
     "category": "generative",
-    "description": "Animated crystal growth using Voronoi diagrams with time-evolving seeds, featuring icy facets and rainbow iridescence",
+    "description": "A majestic, translucent jellyfish floating in a cosmic void, with bioluminescent glow and rhythmic pulsation.",
     "tags": [
-      "generative",
-      "voronoi",
-      "crystal",
-      "procedural",
-      "animated",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "growthSpeed",
-        "name": "Growth Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "crystalCount",
-        "name": "Crystal Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "irregularity",
-        "name": "Irregularity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-string-theory",
-    "name": "String Theory",
-    "url": "shaders/gen-string-theory.wgsl",
-    "category": "generative",
-    "description": "Vibrating string visualizations with interference patterns and harmonics based on the 1D wave equation",
-    "tags": [
-      "generative",
-      "physics",
-      "waves",
-      "harmonics",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "audio-reactive",
-      "animated",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "fundamental",
-        "name": "Fundamental Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "harmonicRichness",
-        "name": "Harmonic Richness",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.85,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "excitement",
-        "name": "Pluck Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-mycelium-network",
-    "name": "Mycelium Network",
-    "url": "shaders/gen-mycelium-network.wgsl",
-    "category": "generative",
-    "description": "Growing network patterns resembling fungal mycelium with diffusion-limited aggregation branching and bioluminescent tips",
-    "tags": [
-      "generative",
-      "organic",
-      "nature",
+      "3d",
+      "raymarching",
       "bioluminescent",
+      "space",
+      "organic",
+      "calm",
+      "procedural",
+      "generative"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Tentacle Activity",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Hue Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Glow Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "cosmic-web",
+    "name": "Cosmic Web Filament",
+    "url": "shaders/cosmic-web.wgsl",
+    "category": "generative",
+    "description": "Simulates the large-scale structure of the universe with dark matter filaments and voids. Mouse acts as a gravity well.",
+    "tags": [
+      "space",
+      "procedural",
+      "organic",
+      "scifi",
+      "dark-matter",
+      "generative"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Filament Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Flow Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-abyssal-chrono-coral",
+    "name": "Abyssal Chrono-Coral",
+    "url": "shaders/gen-abyssal-chrono-coral.wgsl",
+    "category": "generative",
+    "description": "A hyper-dimensional, endlessly growing bioluminescent reef suspended in a cosmic void, where time-dilation forces crystalline coral branches to blossom and shatter in sync with quantum audio frequencies.",
+    "tags": [
+      "organic",
+      "fractal",
+      "bioluminescence",
+      "raymarching",
+      "audio-reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "coralDensity",
+        "name": "Coral Density",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "branchComplexity",
+        "name": "Branch Complexity",
+        "default": 4,
+        "min": 1,
+        "max": 8,
+        "step": 1,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "bioluminescenceGlow",
+        "name": "Bioluminescence Glow",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "timeDilationField",
+        "name": "Time Dilation Field",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "coordinate": 856
+  },
+  {
+    "id": "gen-abyssal-leviathan-scales",
+    "name": "Abyssal Leviathan-Scales",
+    "url": "shaders/gen-abyssal-leviathan-scales.wgsl",
+    "category": "generative",
+    "description": "A mesmerizing, infinite expanse of massive, interlocking biomechanical armor scales that undulate like a breathing cosmic leviathan, parting to reveal a blazing, audio-reactive quantum fusion core beneath.",
+    "tags": [
+      "organic",
+      "mechanical",
+      "quantum",
+      "raymarching",
+      "bioluminescence"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "scaleDensity",
+        "name": "Scale Density",
+        "default": 5,
+        "min": 1,
+        "max": 15,
+        "step": 0.1
+      },
+      {
+        "id": "plasmaIntensity",
+        "name": "Plasma Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "breathingSpeed",
+        "name": "Breathing Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "coreHeat",
+        "name": "Core Heat",
+        "default": 2,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-alien-flora",
+    "name": "Alien Flora",
+    "url": "shaders/gen-alien-flora.wgsl",
+    "category": "generative",
+    "description": "An infinite procedural forest of bioluminescent alien vegetation with swaying mushrooms and atmospheric fog.",
+    "tags": [
+      "nature",
+      "plants",
+      "bioluminescent",
+      "raymarching",
+      "3d",
+      "organic",
+      "forest",
+      "procedural",
+      "generative",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Vegetation Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Sway Speed",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Glow Intensity",
+        "default": 1.5,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-art-deco-sky",
+    "name": "Art Deco Skyscraper",
+    "url": "shaders/gen-art-deco-sky.wgsl",
+    "category": "generative",
+    "description": "Infinite vertical ascent up a monumental Art Deco tower with gold fluting and geometric patterns.",
+    "tags": [
+      "3d",
+      "raymarching",
+      "architecture",
+      "art-deco",
+      "gold",
+      "scifi",
+      "procedural",
+      "infinite",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "City Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Ascent Speed",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Gold Glow",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Fog Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-astro-kinetic-chrono-orrery",
+    "name": "Astro-Kinetic Chrono-Orrery",
+    "url": "shaders/gen-astro-kinetic-chrono-orrery.wgsl",
+    "category": "generative",
+    "description": "A hyper-intricate cosmic mechanism of nested, rotating brass and energy rings orbiting a blazing quantum singularity, merging celestial mechanics with clockwork precision.",
+    "tags": [
+      "cosmic",
+      "mechanical",
+      "clockwork",
+      "quantum",
+      "orrery",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Complexity",
+        "min": 1,
+        "max": 10,
+        "default": 4,
+        "step": 1
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "min": 0,
+        "max": 5,
+        "default": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Glow Intensity",
+        "min": 0,
+        "max": 3,
+        "default": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Audio Reactivity",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-audio-spirograph",
+    "name": "Audio Spirograph",
+    "url": "shaders/gen-audio-spirograph.wgsl",
+    "category": "generative",
+    "description": "Audio-reactive spirograph with harmonic resonance using epitrochoid and hypotrochoid curves with musical frequency ratios",
+    "tags": [
+      "generative",
+      "audio-reactive",
+      "spirograph",
+      "harmonic",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "audio-reactive",
+      "animated",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "baseFreq",
+        "name": "Base Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "audioReactivity",
+        "name": "Audio Reactivity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "trailLength",
+        "name": "Trail Length",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "lineThickness",
+        "name": "Line Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-audiovisual-mandelbulb-raymarcher",
+    "name": "Audiovisual Mandelbulb",
+    "url": "/shaders/gen-audiovisual-mandelbulb-raymarcher.wgsl",
+    "category": "generative",
+    "description": "Raymarched 3D Mandelbulb fractal with video texture mapping, audio-reactive geometry mutation, and depth output.",
+    "tags": [
+      "fractal",
+      "3d",
+      "raymarched",
+      "audio-reactive",
+      "mandelbulb",
+      "neon",
+      "abstract"
+    ],
+    "features": [
+      "raymarched",
+      "audio-reactive",
+      "mouse-driven",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "iterations",
+        "name": "Iterations",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "escape",
+        "name": "Escape Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Glow",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "texture",
+        "name": "Video Blend",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-auroral-ferrofluid-monolith",
+    "name": "Auroral Ferrofluid-Monolith",
+    "url": "shaders/gen-auroral-ferrofluid-monolith.wgsl",
+    "coordinate": 149,
+    "category": "generative",
+    "description": "A colossal, liquid-metal obelisk suspended in a void, its surface rippling with spiky, audio-reactive ferrofluid structures while crackling with volumetric auroral energy.",
+    "tags": [
+      "ferrofluid",
+      "monolith",
+      "aurora",
+      "liquid-metal",
+      "audio-reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "spikeLength",
+        "name": "Spike Length",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "auroraIntensity",
+        "name": "Aurora Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "magneticTwist",
+        "name": "Magnetic Twist",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "fluidMetallic",
+        "name": "Fluid Metallic",
+        "default": 0.9,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-bifurcation-diagram",
+    "name": "Bifurcation Diagram",
+    "url": "shaders/gen-bifurcation-diagram.wgsl",
+    "category": "generative",
+    "description": "Logistic map bifurcation diagram visualizing the transition from order to chaos with density-based coloring and Lyapunov exponent highlighting",
+    "tags": [
+      "generative",
+      "chaos",
+      "mathematical",
+      "fractal",
       "procedural",
       "audio",
       "music",
@@ -1256,36 +1220,151 @@
     ],
     "params": [
       {
-        "id": "growthRate",
-        "name": "Growth Rate",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "branching",
-        "name": "Branching Factor",
+        "id": "rPosition",
+        "name": "R Parameter Position",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "nutrientDensity",
-        "name": "Nutrient Density",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "zoom",
+        "name": "Zoom Level",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "biolumIntensity",
-        "name": "Bioluminescence",
+        "id": "iterations",
+        "name": "Iteration Count",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorScheme",
+        "name": "Color Scheme",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-bioluminescent-aether-pulsar",
+    "name": "Bioluminescent Aether-Pulsar",
+    "type": "shader",
+    "category": "generative",
+    "url": "shaders/gen-bioluminescent-aether-pulsar.wgsl",
+    "coordinate": 861,
+    "params": [
+      {
+        "id": "spin_rate",
+        "name": "Pulsar Spin Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1,
+        "mapping": "zoom_params.x",
+        "description": "Rotation speed of the pulsar core"
+      },
+      {
+        "id": "beam_intensity",
+        "name": "Beam Intensity",
         "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "mapping": "zoom_params.y",
+        "description": "Intensity of the volumetric beams"
+      },
+      {
+        "id": "accretion_density",
+        "name": "Accretion Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "mapping": "zoom_params.z",
+        "description": "Density and detail of the accretion disk"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "mapping": "zoom_params.w",
+        "description": "Shifts the color palette of the pulsar"
+      }
+    ]
+  },
+  {
+    "id": "gen-bioluminescent-reaction-diffusion",
+    "name": "Bioluminescent Reaction-Diffusion",
+    "coordinate": 871,
+    "type": "wgsl",
+    "category": "generative",
+    "url": "shaders/gen-bioluminescent-reaction-diffusion.wgsl"
+  },
+  {
+    "id": "gen-biomechanical-hive",
+    "name": "Biomechanical Hive",
+    "url": "shaders/gen-biomechanical-hive.wgsl",
+    "category": "generative",
+    "description": "An infinite, claustrophobic structure of hexagonal cells blending industrial machinery with organic tissue. Features pulsating lights, rhythmic breathing, and slimy metallic textures.",
+    "tags": [
+      "scifi",
+      "biomechanical",
+      "giger",
+      "alien",
+      "raymarching",
+      "horror",
+      "generative",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Cell Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Biomass",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Hue Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
       }
     ]
   },
@@ -1321,8 +1400,8 @@
       {
         "id": "param1",
         "name": "Terrace Step Size",
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "default": 0.5,
         "step": 0.01,
         "description": "Size of stepped terraces characteristic of bismuth crystals"
@@ -1330,8 +1409,8 @@
       {
         "id": "param2",
         "name": "Ascension Speed",
-        "min": 0.0,
-        "max": 2.0,
+        "min": 0,
+        "max": 2,
         "default": 0.5,
         "step": 0.01,
         "description": "Camera movement speed through the crystal citadel"
@@ -1339,8 +1418,8 @@
       {
         "id": "param3",
         "name": "Metallic Shine",
-        "min": 0.0,
-        "max": 2.0,
+        "min": 0,
+        "max": 2,
         "default": 0.8,
         "step": 0.01,
         "description": "Specular highlight intensity on metallic surfaces"
@@ -1348,66 +1427,11 @@
       {
         "id": "param4",
         "name": "Iridescence Shift",
-        "min": 0.0,
-        "max": 5.0,
-        "default": 1.0,
+        "min": 0,
+        "max": 5,
+        "default": 1,
         "step": 0.1,
         "description": "Thin-film interference color shift on crystal surfaces"
-      }
-    ]
-  },
-  {
-    "id": "gen-topology-flow",
-    "name": "Topology Flow",
-    "url": "shaders/gen-topology-flow.wgsl",
-    "category": "generative",
-    "description": "Topological surface flow visualization inspired by Morse theory, showing gradient flows converging and diverging at critical points",
-    "tags": [
-      "generative",
-      "topology",
-      "flow",
-      "mathematical",
-      "procedural",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "flowSpeed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "complexity",
-        "name": "Height Complexity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "particleDensity",
-        "name": "Particle Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "trailPersistence",
-        "name": "Trail Persistence",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
       }
     ]
   },
@@ -1436,47 +1460,47 @@
         "id": "sun_angle",
         "name": "Sun Angle",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "fog_density",
         "name": "Fog Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "artifact_scale",
         "name": "Artifact Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "complexity",
         "name": "Structure Complexity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ]
   },
   {
-    "id": "gen-art-deco-sky",
-    "name": "Art Deco Skyscraper",
-    "url": "shaders/gen-art-deco-sky.wgsl",
+    "id": "gen-celestial-forge",
+    "name": "Celestial Forge",
+    "url": "shaders/gen-celestial-forge.wgsl",
     "category": "generative",
-    "description": "Infinite vertical ascent up a monumental Art Deco tower with gold fluting and geometric patterns.",
+    "description": "A massive sci-fi megastructure enclosing a miniature star, featuring contra-rotating rings, plasma arcs, and glowing panels.",
     "tags": [
-      "3d",
+      "space",
+      "megastructure",
+      "dyson sphere",
+      "plasma",
+      "rings",
+      "sci-fi",
       "raymarching",
-      "architecture",
-      "art-deco",
-      "gold",
-      "scifi",
-      "procedural",
-      "infinite",
+      "3d",
       "audio",
       "music"
     ],
@@ -1485,38 +1509,576 @@
       "audio-reactive",
       "audio-driven"
     ],
+    "author": "AI",
     "params": [
       {
         "id": "param1",
-        "name": "City Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1
+        "name": "Rotation Speed",
+        "min": 0,
+        "max": 2,
+        "default": 1,
+        "step": 0.01,
+        "description": "Speed of the contra-rotating ring structure."
       },
       {
         "id": "param2",
-        "name": "Ascent Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
+        "name": "Complexity",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Number of rings and surface detail density."
       },
       {
         "id": "param3",
-        "name": "Gold Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
+        "name": "Ring Scale",
+        "min": 0.5,
+        "max": 2,
+        "default": 1,
+        "step": 0.01,
+        "description": "Overall size of the ring structure."
       },
       {
         "id": "param4",
+        "name": "Core Intensity",
+        "min": 0,
+        "max": 5,
+        "default": 1,
+        "step": 0.01,
+        "description": "Brightness of the central star and emitted light."
+      }
+    ]
+  },
+  {
+    "id": "gen-celestial-glass-tornado",
+    "name": "Celestial Glass Tornado",
+    "url": "shaders/gen-celestial-glass-tornado.wgsl",
+    "category": "generative",
+    "coordinate": 859,
+    "type": "shader",
+    "params": [
+      {
+        "id": "vortex_twist",
+        "name": "Vortex Twist",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1,
+        "mapping": "zoom_params.x",
+        "description": "Twist of the vortex"
+      },
+      {
+        "id": "debris_density",
+        "name": "Debris Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "mapping": "zoom_params.y",
+        "description": "Density of debris particles"
+      },
+      {
+        "id": "chromatic_split",
+        "name": "Chromatic Split",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Chromatic aberration split"
+      },
+      {
+        "id": "audio_reactivity",
+        "name": "Audio Reactivity",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "mapping": "zoom_params.w",
+        "description": "Audio reactivity multiplier"
+      }
+    ]
+  },
+  {
+    "id": "gen-celestial-prism-orchid",
+    "name": "Celestial Prism-Orchid",
+    "url": "shaders/gen-celestial-prism-orchid.wgsl",
+    "category": "generative",
+    "description": "A mesmerizing, infinite expanse of refractive, crystalline petals that fold, bloom, and scatter starlight into vivid chromatic spectrums, dynamically responding to cosmic winds and audio vibrations.",
+    "tags": [
+      "organic",
+      "cosmic",
+      "refractive",
+      "audio-reactive",
+      "raymarching",
+      "fractal"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "bloomComplexity",
+        "name": "Bloom Complexity",
+        "default": 1.5,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "refractiveIndex",
+        "name": "Refractive Index",
+        "default": 1.2,
+        "min": 1,
+        "max": 2.5,
+        "step": 0.01
+      },
+      {
+        "id": "coreIntensity",
+        "name": "Core Intensity",
+        "default": 2,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "cosmicWindSpeed",
+        "name": "Cosmic Wind Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-celestial-yggdrasil-matrix",
+    "name": "Celestial Yggdrasil-Matrix",
+    "coordinate": 869,
+    "type": "wgsl",
+    "category": "generative",
+    "url": "shaders/gen-celestial-yggdrasil-matrix.wgsl",
+    "description": "An infinitely branching, cosmic tree constructed from intertwining ribbons of stellar plasma and quantum circuitry that pulses with the heartbeat of the universe, fusing organic arboreal forms with intricate cosmic geometry.",
+    "tags": [
+      "organic",
+      "cosmic",
+      "fractal",
+      "kifs",
+      "plasma"
+    ],
+    "author": "Jules",
+    "sliders": [
+      {
+        "name": "Branch Complexity",
+        "param": "zoom_params.x",
+        "min": 1,
+        "max": 10,
+        "step": 1,
+        "default": 5
+      },
+      {
+        "name": "Plasma Flow",
+        "param": "zoom_params.y",
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1,
+        "default": 1
+      },
+      {
+        "name": "Gravity Warp",
+        "param": "zoom_params.z",
+        "min": 0,
+        "max": 2,
+        "step": 0.05,
+        "default": 0.5
+      },
+      {
+        "name": "Glow Intensity",
+        "param": "zoom_params.w",
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "default": 1.2
+      }
+    ]
+  },
+  {
+    "id": "gen-cellular-automata-tapestry",
+    "name": "Cellular Automata Tapestry",
+    "author": "Jules",
+    "description": "Convert the video feed into a living reaction-diffusion tapestry.",
+    "category": "generative",
+    "type": "wgsl",
+    "coordinate": 870,
+    "url": "shaders/gen-cellular-automata-tapestry.wgsl",
+    "tags": [
+      "reaction-diffusion",
+      "cellular-automata",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "gen-chromatic-metamorphosis",
+    "name": "Chromatic Metamorphosis",
+    "url": "shaders/gen-chromatic-metamorphosis.wgsl",
+    "category": "generative",
+    "description": "Metaballs morph continuously between sphere, torus, box, and capsule shapes via smooth-min SDF blending. Surface color evolves independently from geometry in flowing waves.",
+    "tags": [
+      "metamorphosis",
+      "morphing",
+      "sdf",
+      "raymarching",
+      "color",
+      "organic",
+      "generative",
+      "3d",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Morph Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Speed of shape transformation cycle."
+      },
+      {
+        "id": "param2",
+        "name": "Color Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Speed at which surface color evolves independently of geometry."
+      },
+      {
+        "id": "param3",
+        "name": "Blend Radius",
+        "min": 0,
+        "max": 1,
+        "default": 0.35,
+        "step": 0.01,
+        "description": "Smooth-min radius for SDF blending between shapes."
+      },
+      {
+        "id": "param4",
+        "name": "Light Intensity",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Intensity of the key light illuminating the morphing form."
+      }
+    ]
+  },
+  {
+    "id": "gen-chromodynamic-plasma-collider",
+    "name": "Chromodynamic Plasma-Collider",
+    "coordinate": 853,
+    "type": "wgsl",
+    "url": "shaders/gen-chromodynamic-plasma-collider.wgsl",
+    "category": "generative",
+    "description": "A hyper-speed journey down an infinite magnetic containment tunnel where sub-atomic particles collide and shatter into vibrant, audio-reactive showers of exotic matter.",
+    "tags": [
+      "cosmic",
+      "mechanical",
+      "particle",
+      "plasma",
+      "audio-reactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "ringDensity",
+        "name": "Ring Density",
+        "default": 15,
+        "min": 5,
+        "max": 30,
+        "step": 1
+      },
+      {
+        "id": "collisionRate",
+        "name": "Collision Rate",
+        "default": 5,
+        "min": 0.5,
+        "max": 20,
+        "step": 0.5
+      },
+      {
+        "id": "anomalyPull",
+        "name": "Anomaly Pull",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "tunnelWarp",
+        "name": "Tunnel Warp",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-chronos-labyrinth",
+    "name": "Chronos Labyrinth",
+    "url": "shaders/gen-chronos-labyrinth.wgsl",
+    "category": "generative",
+    "description": "An infinite, Escher-esque maze of shifting geometric staircases and corridors suspended over a void, with glowing temporal anomalies.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "3d",
+      "raymarching",
+      "geometry",
+      "escher",
+      "maze",
+      "impossible",
+      "abstract",
+      "infinite",
+      "generative",
+      "procedural",
+      "audio",
+      "music"
+    ],
+    "params": [
+      {
+        "id": "complexity",
+        "name": "Labyrinth Complexity",
+        "default": 1,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "shift_speed",
+        "name": "Shift Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "id": "rifts",
+        "name": "Temporal Rifts",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "atm_perspective",
+        "name": "Atmospheric Perspective",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "description": "Distance fade intensity"
+      }
+    ]
+  },
+  {
+    "id": "gen-cosmic-web-filament",
+    "name": "Cosmic Web Filament",
+    "url": "shaders/gen-cosmic-web-filament.wgsl",
+    "category": "generative",
+    "description": "Dark matter web with Voronoi filaments, FBM warping, and mouse gravity wells. Hypnotic cosmic structure with purple-to-cyan gradients.",
+    "tags": [
+      "generative",
+      "cosmic",
+      "voronoi",
+      "filament",
+      "organic",
+      "dark-matter",
+      "web",
+      "gravity",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "ford442",
+    "params": [
+      {
+        "id": "warp",
+        "name": "Warp Strength",
+        "default": 0.33,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "density",
+        "name": "Filament Density",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "default": 0.25,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-crystal-caverns",
+    "name": "Crystal Caverns",
+    "url": "shaders/gen-crystal-caverns.wgsl",
+    "category": "generative",
+    "description": "Infinite procedural cave system with glowing crystals featuring physical light transmission. Crystals have IOR-based Fresnel reflection and variable purity affecting their glow transparency.",
+    "tags": [
+      "crystal",
+      "cave",
+      "3d",
+      "raymarching",
+      "fantasy",
+      "glowing",
+      "stalactites",
+      "procedural",
+      "generative",
+      "alpha-transmission",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "physical-transmission",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "ford442",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Cave Scale",
+        "default": 0.25,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Size of cave structures"
+      },
+      {
+        "id": "density",
+        "name": "Crystal Purity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Crystal clarity affecting transmission and glow"
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Brightness of crystal glow"
+      },
+      {
+        "id": "fogDensity",
         "name": "Fog Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 2,
+        "step": 0.01,
+        "description": "Volumetric fog density"
+      }
+    ]
+  },
+  {
+    "id": "gen-crystalline-chrono-dyson",
+    "name": "Crystalline Chrono-Dyson",
+    "url": "shaders/gen-crystalline-chrono-dyson.wgsl",
+    "category": "generative",
+    "description": "A colossal, self-assembling Dyson sphere constructed of hyper-refractive crystal panels and flowing plasma conduits that orbit and extract energy from a dying, audio-reactive micro-quasar.",
+    "tags": [
+      "cosmic",
+      "mechanical",
+      "refraction",
+      "plasma",
+      "raymarching"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "panelDensity",
+        "name": "Panel Density",
+        "default": 4,
+        "min": 1,
+        "max": 10,
         "step": 0.1
+      },
+      {
+        "id": "quasarGlow",
+        "name": "Quasar Glow",
+        "default": 1.5,
+        "min": 0,
+        "max": 5,
+        "step": 0.05
+      },
+      {
+        "id": "fluxSpeed",
+        "name": "Flux Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 3,
+        "step": 0.01
+      },
+      {
+        "id": "swarmCount",
+        "name": "Swarm Count",
+        "default": 50,
+        "min": 10,
+        "max": 100,
+        "step": 1
       }
     ]
   },
@@ -1546,34 +2108,3415 @@
       {
         "id": "gridDensity",
         "name": "Grid Density",
-        "default": 1.0,
+        "default": 1,
         "min": 0.1,
-        "max": 5.0,
+        "max": 5,
         "step": 0.1
       },
       {
         "id": "glyphSharpness",
         "name": "Glyph Sharpness",
         "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.05
       },
       {
         "id": "charBrightness",
         "name": "Character Brightness",
-        "default": 1.0,
+        "default": 1,
         "min": 0.5,
-        "max": 2.0,
+        "max": 2,
         "step": 0.1
       },
       {
         "id": "scanlineBloom",
         "name": "Scanline Bloom",
         "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
+        "min": 0,
+        "max": 2,
         "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-cybernetic-ferro-coral",
+    "name": "Cybernetic Ferro-Coral",
+    "url": "shaders/gen-cybernetic-ferro-coral.wgsl",
+    "category": "generative",
+    "description": "A biomechanical reef of magnetic, liquid-metal coral that dynamically shapes itself in response to acoustic vibrations, revealing a glowing quantum-plasma core beneath a dark metallic exterior.",
+    "tags": [
+      "biomechanical",
+      "ferrofluid",
+      "coral",
+      "magnetic",
+      "audio-reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "spikeIntensity",
+        "name": "Spike Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "coreGlow",
+        "name": "Core Glow",
+        "default": 1.5,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "iridescence",
+        "name": "Iridescence",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-cybernetic-liquid-chrome-engine",
+    "name": "Cybernetic Liquid-Chrome Engine",
+    "coordinate": 864,
+    "type": "shader",
+    "category": "generative",
+    "url": "shaders/gen-cybernetic-liquid-chrome-engine.wgsl",
+    "description": "A colossal, endlessly shifting mechanical engine constructed of hyper-reflective liquid chrome, pumping iridescent plasma through infinitely complex fractal pistons that react to the heavy bass of audio frequencies.",
+    "tags": [
+      "mechanical",
+      "liquid-metal",
+      "audio-reactive",
+      "raymarching",
+      "fractal"
+    ],
+    "sliders": [
+      {
+        "name": "Engine Speed",
+        "param": "zoom_params.x",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "name": "Chrome Reflectivity",
+        "param": "zoom_params.y",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      },
+      {
+        "name": "Plasma Glow",
+        "param": "zoom_params.z",
+        "default": 2,
+        "min": 0,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "name": "Complexity",
+        "param": "zoom_params.w",
+        "default": 3,
+        "min": 1,
+        "max": 8,
+        "step": 1
+      }
+    ]
+  },
+  {
+    "id": "gen-cymatic-plasma-mandalas",
+    "name": "Cymatic Plasma-Mandalas",
+    "url": "shaders/gen-cymatic-plasma-mandalas.wgsl",
+    "category": "generative",
+    "description": "A hyper-intricate, unfolding kaleidoscope of glowing liquid geometry that dances and weaves complex, sacred-geometry-inspired mandalas in direct response to audio frequencies.",
+    "tags": [
+      "generative",
+      "mandala",
+      "cymatics",
+      "plasma",
+      "kaleidoscope",
+      "audio-reactive",
+      "liquid",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "symmetryOrder",
+        "name": "Symmetry Order",
+        "default": 6,
+        "min": 1,
+        "max": 12,
+        "step": 1
+      },
+      {
+        "id": "plasmaDensity",
+        "name": "Plasma Density",
+        "default": 2,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "cymaticFrequency",
+        "name": "Cymatic Frequency",
+        "default": 10,
+        "min": 0.5,
+        "max": 30,
+        "step": 0.1
+      },
+      {
+        "id": "swirlChaos",
+        "name": "Swirl Chaos",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-depth-refracted-liquid-stained-glass",
+    "coordinate": 858,
+    "type": "wgsl",
+    "url": "shaders/gen-depth-refracted-liquid-stained-glass.wgsl",
+    "category": "generative",
+    "name": "Depth-Refracted Liquid Stained Glass",
+    "description": "Transform the input video into a shattering, ornate cathedral window that feels tactile, refractive, and symmetrically kaleidoscopic.",
+    "tags": [
+      "kaleidoscope",
+      "refraction",
+      "audio-reactive",
+      "mouse-driven"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-input"
+    ],
+    "sliders": [
+      {
+        "id": "facetCount",
+        "name": "Facet Count",
+        "default": 6,
+        "min": 3,
+        "max": 24,
+        "step": 1,
+        "param": "zoom_params.x"
+      },
+      {
+        "id": "bevelWidth",
+        "name": "Bevel Width",
+        "default": 2,
+        "min": 0.1,
+        "max": 10,
+        "step": 0.1,
+        "param": "zoom_params.y"
+      }
+    ]
+  },
+  {
+    "id": "gen-eldritch-tesseract-hive-mind",
+    "name": "Eldritch Tesseract-Hive Mind",
+    "author": "Jules",
+    "description": "An impossible, non-Euclidean hypercube hive populated by swarms of luminescent algorithmic sentinels, constantly unfolding and fracturing into new geometric dimensions driven by quantum noise and acoustic energy.",
+    "category": "generative",
+    "type": "wgsl",
+    "coordinate": 881,
+    "url": "shaders/gen-eldritch-tesseract-hive-mind.wgsl",
+    "tags": [
+      "tesseract",
+      "fractal",
+      "quantum",
+      "mechanical",
+      "audio-reactive",
+      "swarm"
+    ],
+    "parameters": [
+      {
+        "name": "Tesseract Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "name": "Swarm Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "name": "Voxel Tearing Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "name": "Iridescence Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-ethereal-anemone-bloom",
+    "name": "Ethereal Anemone Bloom",
+    "url": "shaders/gen-ethereal-anemone-bloom.wgsl",
+    "category": "generative",
+    "description": "A pulsating, infinite underwater expanse of translucent, bioluminescent anemone-like structures that gently sway in an invisible current, reaching out to feed on the audio frequencies.",
+    "features": [
+      "mouse-driven",
+      "raymarched",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "organic",
+      "bioluminescent",
+      "underwater",
+      "fluid",
+      "audio-reactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "current_speed",
+        "name": "Current Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "tentacle_density",
+        "name": "Tentacle Density",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.05
+      },
+      {
+        "id": "bioluminescence_glow",
+        "name": "Bioluminescence Glow",
+        "default": 2,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "water_murkiness",
+        "name": "Water Murkiness",
+        "default": 0.8,
+        "min": 0,
+        "max": 1.5,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-ethereal-quantum-medusa",
+    "name": "Ethereal Quantum Medusa",
+    "url": "shaders/gen-ethereal-quantum-medusa.wgsl",
+    "category": "generative",
+    "coordinate": 857,
+    "type": "shader",
+    "params": [
+      {
+        "id": "swimming_speed",
+        "name": "Swimming Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1,
+        "mapping": "zoom_params.x",
+        "description": "Speed of medusa movement"
+      },
+      {
+        "id": "tentacle_curl",
+        "name": "Tentacle Curl",
+        "default": 2,
+        "min": 0,
+        "max": 5,
+        "step": 0.1,
+        "mapping": "zoom_params.y",
+        "description": "Curliness of tentacles"
+      },
+      {
+        "id": "quantum_glow",
+        "name": "Quantum Glow",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "mapping": "zoom_params.z",
+        "description": "Glow intensity"
+      },
+      {
+        "id": "repulsion_strength",
+        "name": "Repulsion Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "mapping": "zoom_params.w",
+        "description": "Mouse repulsion strength"
+      }
+    ]
+  },
+  {
+    "id": "gen-fractal-clockwork",
+    "name": "Fractal Clockwork",
+    "url": "shaders/gen-fractal-clockwork.wgsl",
+    "category": "generative",
+    "description": "Infinite interlocking brass gears rotating in perfect mechanical sync. Steampunk raymarched masterpiece with metallic PBR shading and mouse orbit control.",
+    "tags": [
+      "steampunk",
+      "mechanical",
+      "3d",
+      "raymarching",
+      "gears",
+      "metallic",
+      "brass",
+      "clockwork",
+      "procedural",
+      "generative",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "ford442",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Gear Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "teeth",
+        "name": "Teeth Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Rotation Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "material",
+        "name": "Material",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "labels": [
+          "Brass",
+          "Steel",
+          "Gold"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "gen-fractured-monolith",
+    "name": "Fractured Monolith",
+    "url": "shaders/gen-fractured-monolith.wgsl",
+    "category": "generative",
+    "description": "A massive, ancient monolith floating above a dark liquid sea, fractured into segmented pieces that pulse with an inner, ethereal light.",
+    "tags": [
+      "monolith",
+      "floating",
+      "fractured",
+      "glowing",
+      "ambient",
+      "generative",
+      "scifi",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Fracture Spread",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.05
+      },
+      {
+        "id": "param2",
+        "name": "Levitation Speed",
+        "min": 0,
+        "max": 3,
+        "default": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Glow Intensity",
+        "min": 0,
+        "max": 2,
+        "default": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Rotation Speed",
+        "min": 0,
+        "max": 2,
+        "default": 0.5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-gravitational-strain",
+    "name": "Gravitational Strain Field",
+    "url": "shaders/gen-gravitational-strain.wgsl",
+    "category": "generative",
+    "description": "Orbiting gravity wells warp a procedural star field via geodesic ray integration. Tidal emission glows brightest where gravitational gradients collide — dark matter visualization as art.",
+    "tags": [
+      "gravity",
+      "lensing",
+      "space",
+      "physics",
+      "stars",
+      "dark-matter",
+      "generative",
+      "simulation",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Well Count",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Number of gravity wells (maps to 1–6)."
+      },
+      {
+        "id": "param2",
+        "name": "Well Mass",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Mass of each gravity well — controls bending strength."
+      },
+      {
+        "id": "param3",
+        "name": "Bend Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Overall geodesic deflection amplitude."
+      },
+      {
+        "id": "param4",
+        "name": "Emission Scale",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Brightness of tidal emission at field gradient maxima."
+      }
+    ]
+  },
+  {
+    "id": "gen-graviton-plasma-lotus",
+    "name": "Graviton Plasma Lotus",
+    "url": "shaders/gen-graviton-plasma-lotus.wgsl",
+    "category": "generative",
+    "type": "shader",
+    "coordinate": 860,
+    "params": [
+      {
+        "id": "rotation_speed",
+        "name": "Rotation Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1,
+        "mapping": "zoom_params.x",
+        "description": "Speed of rotation"
+      },
+      {
+        "id": "complexity",
+        "name": "Complexity",
+        "default": 1,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1,
+        "mapping": "zoom_params.y",
+        "description": "Form complexity"
+      },
+      {
+        "id": "bloom_intensity",
+        "name": "Bloom Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1,
+        "mapping": "zoom_params.z",
+        "description": "Bloom glow intensity"
+      },
+      {
+        "id": "gravity_well",
+        "name": "Gravity Well Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "mapping": "zoom_params.w",
+        "description": "Gravity well pull strength"
+      }
+    ]
+  },
+  {
+    "id": "gen-holographic-data-core",
+    "name": "Holographic Data Core",
+    "url": "shaders/gen-holographic-data-core.wgsl",
+    "category": "generative",
+    "description": "An infinite journey through a quantum lattice of glowing data nodes and pulsing circuits.",
+    "tags": [
+      "3d",
+      "raymarching",
+      "cyberpunk",
+      "hologram",
+      "data",
+      "neon",
+      "procedural",
+      "infinite",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Node Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Travel Speed",
+        "default": 2,
+        "min": 0,
+        "max": 10,
+        "step": 0.5
+      },
+      {
+        "id": "param3",
+        "name": "Data Pulse Rate",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Glitch Intensity",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-holographic-plasma-geode",
+    "name": "Holographic Plasma-Geode",
+    "url": "shaders/gen-holographic-plasma-geode.wgsl",
+    "category": "generative",
+    "description": "A hyper-dimensional geode cracked open to reveal a swirling, audio-reactive core of liquid plasma and holographic fractal crystals.",
+    "tags": [
+      "crystal",
+      "plasma",
+      "audio-reactive",
+      "holographic",
+      "raymarching"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "plasmaIntensity",
+        "name": "Plasma Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "crystalDensity",
+        "name": "Crystal Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "holographicHue",
+        "name": "Holographic Hue",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "coreRotationSpeed",
+        "name": "Core Rotation Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-hyper-dimensional-tesseract-labyrinth",
+    "name": "Hyper-Dimensional Tesseract-Labyrinth",
+    "url": "shaders/gen-hyper-dimensional-tesseract-labyrinth.wgsl",
+    "category": "generative",
+    "description": "A dizzying, gravity-defying maze of glowing hyper-cubes that unfold and rotate through 4D space, creating impossible, Escher-like geometries driven by sound.",
+    "tags": [
+      "geometric",
+      "4d",
+      "optical-illusion",
+      "audio-reactive",
+      "raymarching"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "tesseractComplexity",
+        "name": "Tesseract Complexity",
+        "default": 1,
+        "min": 0.1,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "edgeGlow",
+        "name": "Edge Glow",
+        "default": 2,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "warpField",
+        "name": "Warp Field",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "flySpeed",
+        "name": "Fly Speed",
+        "default": 2,
+        "min": 0,
+        "max": 10,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-hyper-labyrinth",
+    "name": "Hyper Labyrinth",
+    "url": "shaders/gen-hyper-labyrinth.wgsl",
+    "category": "generative",
+    "description": "A 4D maze visualization with neon aesthetics and evolving geometry. Use mouse to orbit the hyper-structure.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "neon",
+      "cyber",
+      "maze",
+      "4d",
+      "generative",
+      "abstract",
+      "geometric",
+      "procedural",
+      "audio",
+      "music"
+    ],
+    "params": [
+      {
+        "id": "scale",
+        "name": "Labyrinth Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "morph",
+        "name": "Morph Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Neon Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "thickness",
+        "name": "Wall Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "gen-hyper-refractive-rain-matrix",
+    "name": "Hyper-Refractive Rain-Matrix",
+    "type": "shader",
+    "category": "generative",
+    "url": "shaders/gen-hyper-refractive-rain-matrix.wgsl",
+    "coordinate": 862,
+    "sliders": [
+      {
+        "id": "rain_density",
+        "name": "Rain Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1,
+        "param": "zoom_params.x",
+        "description": "Density of the rain matrix"
+      },
+      {
+        "id": "drop_speed",
+        "name": "Drop Speed",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "param": "zoom_params.y",
+        "description": "Falling speed of the drops"
+      },
+      {
+        "id": "fluid_viscosity",
+        "name": "Fluid Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "param": "zoom_params.z",
+        "description": "Viscosity of the fluid merging effect"
+      },
+      {
+        "id": "storm_intensity",
+        "name": "Storm Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
+        "step": 0.05,
+        "param": "zoom_params.w",
+        "description": "Intensity of the background storm"
+      }
+    ]
+  },
+  {
+    "id": "gen-hyperbolic-tessellation",
+    "name": "Hyperbolic Tessellation Engine",
+    "url": "shaders/gen-hyperbolic-tessellation.wgsl",
+    "category": "generative",
+    "description": "Non-Euclidean Poincaré-disk tessellation in real-time. Hyperbolic tiles subdivide infinitely toward the boundary disk, colored by recursive depth — M.C. Escher meets fractals.",
+    "tags": [
+      "hyperbolic",
+      "tessellation",
+      "fractal",
+      "non-euclidean",
+      "escher",
+      "geometric",
+      "generative",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Tile Symmetry",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Number of sides in the fundamental tile (maps to p=3–8)."
+      },
+      {
+        "id": "param2",
+        "name": "Depth Color",
+        "min": 0,
+        "max": 1,
+        "default": 0.2,
+        "step": 0.01,
+        "description": "Hue offset for depth-based coloring."
+      },
+      {
+        "id": "param3",
+        "name": "Rotation Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Speed and direction of the global hyperbolic rotation."
+      },
+      {
+        "id": "param4",
+        "name": "Boundary Glow",
+        "min": 0,
+        "max": 1,
+        "default": 0.7,
+        "step": 0.01,
+        "description": "Brightness of the glow near the Poincaré disk boundary."
+      }
+    ]
+  },
+  {
+    "id": "gen-inverse-mandelbrot",
+    "name": "Inverse Mandelbrot Realm",
+    "url": "shaders/gen-inverse-mandelbrot.wgsl",
+    "category": "generative",
+    "description": "Instead of iterating coordinates, we iterate color-space vectors through the Mandelbrot map. Each pixel's RGB becomes a complex number that orbits and escapes, creating alien fractal color fields.",
+    "tags": [
+      "mandelbrot",
+      "fractal",
+      "color-space",
+      "iteration",
+      "alien",
+      "abstract",
+      "generative",
+      "complex",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Iterations",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Maximum iteration count (maps to 20–80)."
+      },
+      {
+        "id": "param2",
+        "name": "Color Zoom",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Zoom level into the color-space fractal."
+      },
+      {
+        "id": "param3",
+        "name": "Colormap Rotate",
+        "min": 0,
+        "max": 1,
+        "default": 0,
+        "step": 0.01,
+        "description": "Global hue rotation of the colormap."
+      },
+      {
+        "id": "param4",
+        "name": "Bailout Radius",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Escape radius — lower values create more intricate boundaries."
+      }
+    ]
+  },
+  {
+    "id": "gen-isometric-city",
+    "name": "Isometric Cyber-City",
+    "url": "shaders/gen-isometric-city.wgsl",
+    "category": "generative",
+    "description": "An infinite procedural isometric city with neon lights and traffic.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Building density and height variance"
+      },
+      {
+        "id": "speed",
+        "name": "Traffic Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Speed of traffic and flyover"
+      },
+      {
+        "id": "glow",
+        "name": "Neon Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Intensity of neon window glow"
+      },
+      {
+        "id": "height_scale",
+        "name": "Building Height Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Scale of building heights"
+      }
+    ],
+    "tags": [
+      "procedural",
+      "generative",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "gen-kinetic-neo-brutalist-megastructure",
+    "name": "Kinetic Neo-Brutalist Megastructure",
+    "url": "shaders/gen-kinetic-neo-brutalist-megastructure.wgsl",
+    "category": "generative",
+    "description": "An endlessly shifting, gravity-defying neo-brutalist megastructure of colossal floating concrete blocks that grind and interlock, revealing glowing, audio-reactive server cores hidden within.",
+    "tags": [
+      "architecture",
+      "cyberpunk",
+      "mechanical",
+      "audio-reactive",
+      "raymarching"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "blockDensity",
+        "name": "Block Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "repulsionRadius",
+        "name": "Repulsion Radius",
+        "default": 3,
+        "min": 0,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "neonIntensity",
+        "name": "Neon Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "travelSpeed",
+        "name": "Travel Speed",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-lenia-2",
+    "name": "Lenia 2.0 - Multi-Species",
+    "url": "shaders/gen-lenia-2.wgsl",
+    "category": "generative",
+    "description": "Advanced 4-species Lenia with 4 distinct kernels (Ring, Disk, Gaussian, Sharp Cross). Creatures evolve, compete, and merge. Mouse feeds different species. Truly alive.",
+    "tags": [
+      "lenia",
+      "multi-species",
+      "4-kernels",
+      "organic",
+      "creature",
+      "cellular-automata",
+      "evolution",
+      "advanced",
+      "procedural",
+      "generative",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "ford442",
+    "params": [
+      {
+        "id": "growth",
+        "name": "Global Growth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "kernel",
+        "name": "Kernel Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Evolution Speed",
+        "default": 0.33,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "mix",
+        "name": "Cross-Species Mix",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-liquid-crystal-hive-mind",
+    "name": "Liquid-Crystal Hive-Mind",
+    "url": "shaders/gen-liquid-crystal-hive-mind.wgsl",
+    "category": "generative",
+    "description": "A vast, breathing network of hexagonal bio-synthetic cells containing turbulent, iridescent liquid crystals that synchronize and glow with a pulsing collective consciousness.",
+    "tags": [
+      "cellular",
+      "liquid-crystal",
+      "fluid-dynamics",
+      "honeycomb",
+      "audio-reactive",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "cellDensity",
+        "name": "Cell Density",
+        "default": 1,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "fluidTurbulence",
+        "name": "Fluid Turbulence",
+        "default": 2.5,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "syncPulse",
+        "name": "Sync Pulse",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "disruptionRadius",
+        "name": "Disruption Radius",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 2,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-liquid-neon-cyber-metropolis",
+    "name": "Liquid-Neon Cyber-Metropolis",
+    "author": "Jules",
+    "description": "An infinite, gravity-defying cyberpunk cityscape constructed from rivers of hyper-luminescent liquid neon and dark matter concrete, where architectural monoliths dynamically extrude, twist, and warp their geometry to the rhythm of heavy audio frequencies.",
+    "category": "generative",
+    "type": "wgsl",
+    "coordinate": 866,
+    "url": "shaders/gen-liquid-neon-cyber-metropolis.wgsl",
+    "tags": [
+      "cyberpunk",
+      "neon",
+      "cityscape",
+      "audio-reactive",
+      "raymarching",
+      "kifs"
+    ],
+    "sliders": [
+      {
+        "name": "Neon Intensity",
+        "param": "zoom_params.x",
+        "default": 1.5,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "name": "City Density",
+        "param": "zoom_params.y",
+        "default": 10,
+        "min": 5,
+        "max": 20,
+        "step": 1
+      },
+      {
+        "name": "Audio Reactivity",
+        "param": "zoom_params.z",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "name": "Gravity Warp Strength",
+        "param": "zoom_params.w",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-lorenz-attractor-flow",
+    "name": "Lorenz Attractor Flow",
+    "url": "shaders/lorenz-attractor-flow.wgsl",
+    "category": "generative",
+    "description": "Real-time visualization of the Lorenz strange attractor using GPU-accelerated ODE integration. Features chaotic butterfly-wing patterns, mouse perturbation, and temporal color evolution.",
+    "features": [
+      "generative",
+      "mouse-driven",
+      "temporal"
+    ],
+    "tags": [
+      "chaotic",
+      "attractor",
+      "lorenz",
+      "generative",
+      "scientific",
+      "flow",
+      "butterfly"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Integration Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-luminous-fluid-chladni-resonator",
+    "name": "Luminous-Fluid Chladni-Resonator",
+    "category": "generative",
+    "url": "/shaders/gen-luminous-fluid-chladni-resonator.wgsl",
+    "tags": [
+      "chladni",
+      "cymatics",
+      "fluid",
+      "resonance",
+      "audio-reactive",
+      "bioluminescent"
+    ],
+    "features": [
+      "audio-reactive"
+    ],
+    "description": "A mesmerizing, bioluminescent liquid surface that physically organizes itself into hyper-complex, evolving Chladni resonant figures driven by low-frequency audio interference patterns.",
+    "coordinate": 880,
+    "params": [
+      {
+        "id": "modeN",
+        "name": "Mode N",
+        "default": 3,
+        "min": 1,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "modeM",
+        "name": "Mode M",
+        "default": 5,
+        "min": 1,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "fluidity",
+        "name": "Fluidity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 1.5,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-magnetic-ferrofluid",
+    "name": "Magnetic Ferrofluid",
+    "url": "shaders/gen-magnetic-ferrofluid.wgsl",
+    "category": "generative",
+    "description": "A pulsating, dark metallic liquid with sharp spikes that respond to an oscillating magnetic field.",
+    "tags": [
+      "abstract",
+      "liquid",
+      "metal",
+      "spiky",
+      "fluid",
+      "generative",
+      "ferrofluid",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Magnetic Strength (Spikes)",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Controls the height and intensity of the fluid spikes."
+      },
+      {
+        "id": "param2",
+        "name": "Fluid Density",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Controls how many small spikes and structures form."
+      },
+      {
+        "id": "param3",
+        "name": "Oscillation Speed",
+        "min": 0.1,
+        "max": 3,
+        "default": 1,
+        "step": 0.01,
+        "description": "Speed at which the fluid pulsates and shifts."
+      },
+      {
+        "id": "param4",
+        "name": "Iridescence Shift",
+        "min": 0,
+        "max": 1,
+        "default": 0.2,
+        "step": 0.01,
+        "description": "Shifts the thin-film interference colors on the metallic surface."
+      }
+    ]
+  },
+  {
+    "id": "gen-magnetic-field-lines",
+    "name": "Magnetic Field Lines",
+    "url": "shaders/gen-magnetic-field-lines.wgsl",
+    "category": "generative",
+    "description": "Magnetic dipole field visualization with field lines and charged particles following the field, featuring North (blue) and South (red) poles",
+    "tags": [
+      "generative",
+      "physics",
+      "magnetic",
+      "field-lines",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "fieldStrength",
+        "name": "Field Strength",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "particleSpeed",
+        "name": "Particle Speed",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "numDipoles",
+        "name": "Number of Dipoles",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "trailLength",
+        "name": "Trail Length",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-magnetic-field-warp",
+    "name": "Magnetic Field Warp",
+    "author": "Jules",
+    "description": "Treat the image as charged particles warped by a magnetic field.",
+    "category": "generative",
+    "type": "wgsl",
+    "coordinate": 876,
+    "url": "shaders/gen-magnetic-field-warp.wgsl",
+    "tags": [
+      "magnetic",
+      "warp",
+      "audio-reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware"
+    ],
+    "params": [
+      {
+        "id": "warp_strength",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "plasma_mix",
+        "name": "Plasma Mix",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-micro-cosmos",
+    "name": "Micro-Cosmos",
+    "url": "shaders/gen-micro-cosmos.wgsl",
+    "category": "generative",
+    "description": "A microscopic view of a teeming liquid universe, filled with procedural microorganisms, drifting particles, and organic structures.",
+    "tags": [
+      "biological",
+      "organic",
+      "microscopic",
+      "liquid",
+      "life",
+      "floating",
+      "generative",
+      "procedural",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Population Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Fluid Activity",
+        "default": 0.3,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Membrane Glow",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-mycelium-network",
+    "name": "Mycelium Network",
+    "url": "shaders/gen-mycelium-network.wgsl",
+    "category": "generative",
+    "description": "Growing network patterns resembling fungal mycelium with diffusion-limited aggregation branching and bioluminescent tips",
+    "tags": [
+      "generative",
+      "organic",
+      "nature",
+      "bioluminescent",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "growthRate",
+        "name": "Growth Rate",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "branching",
+        "name": "Branching Factor",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "nutrientDensity",
+        "name": "Nutrient Density",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "biolumIntensity",
+        "name": "Bioluminescence",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-nebula-light-trail-swarm",
+    "name": "Nebula Light-Trail Swarm",
+    "url": "shaders/gen-nebula-light-trail-swarm.wgsl",
+    "category": "generative",
+    "description": "Photon-like particles race through the scene leaving glowing, fading trails that pulse with audio. Creates a constantly reforming nebula.",
+    "features": [
+      "audio-reactive",
+      "mouse-driven",
+      "generative"
+    ],
+    "tags": [
+      "nebula",
+      "particles",
+      "trails",
+      "glow",
+      "audio",
+      "generative",
+      "space"
+    ],
+    "params": [
+      {
+        "id": "speed",
+        "name": "Particle Speed",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "trailDecay",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "curlStrength",
+        "name": "Curl Strength",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glowRadius",
+        "name": "Glow Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-nebular-chrono-astrolabe",
+    "name": "Nebular Chrono Astrolabe",
+    "url": "shaders/gen-nebular-chrono-astrolabe.wgsl",
+    "category": "generative",
+    "type": "shader",
+    "coordinate": 858,
+    "params": [
+      {
+        "id": "rotation_speed",
+        "name": "Rotation Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1,
+        "mapping": "zoom_params.x",
+        "description": "Rotation speed of the astrolabe"
+      },
+      {
+        "id": "complexity",
+        "name": "Complexity",
+        "default": 2,
+        "min": 1,
+        "max": 5,
+        "step": 1,
+        "mapping": "zoom_params.y",
+        "description": "Number of ring layers"
+      },
+      {
+        "id": "glow_intensity",
+        "name": "Glow Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "mapping": "zoom_params.z",
+        "description": "Glow intensity"
+      },
+      {
+        "id": "gravity_well",
+        "name": "Gravity Well Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1,
+        "mapping": "zoom_params.w",
+        "description": "Mouse gravity attraction"
+      }
+    ]
+  },
+  {
+    "id": "gen-neural-bioluminescence-matrix",
+    "name": "Neural Bioluminescence Matrix",
+    "url": "shaders/gen-neural-bioluminescence-matrix.wgsl",
+    "category": "generative",
+    "description": "A pulsing, infinite organic matrix of glowing synthetic neurons firing quantum light impulses across a void, merging biological growth with cybernetic circuitry.",
+    "tags": [
+      "organic",
+      "quantum",
+      "matrix",
+      "bioluminescence",
+      "neural"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Node Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Pulse Speed",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Audio Reactivity",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Bio-Glow Intensity",
+        "default": 2,
+        "min": 0,
+        "max": 10,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-neural-fractal",
+    "name": "Neural Fractal",
+    "url": "shaders/gen-neural-fractal.wgsl",
+    "category": "generative",
+    "description": "Neural network weight visualization style fractals using sigmoid, tanh, and swish activation functions instead of standard z²+c iterations",
+    "tags": [
+      "generative",
+      "fractal",
+      "neural",
+      "mathematical",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Zoom Level",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorSpeed",
+        "name": "Color Cycling",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "iterations",
+        "name": "Iteration Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "mutation",
+        "name": "Mutation Factor",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-neural-network-glow-synaptic-pulse",
+    "name": "Neural Network Glow",
+    "url": "/shaders/gen-neural-network-glow-synaptic-pulse.wgsl",
+    "category": "generative",
+    "coordinate": 873,
+    "description": "Render a glowing neural mesh and drive action-potential pulses with audio, creating a living synapse network that lights up in layers.",
+    "tags": [
+      "neural",
+      "glow",
+      "audio-reactive",
+      "network",
+      "mesh"
+    ],
+    "features": [
+      "audio-reactive",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "pulse_speed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "id": "glow_intensity",
+        "name": "Glow Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-neuro-cosmos",
+    "name": "Neuro-Cosmos",
+    "url": "shaders/gen-neuro-cosmos.wgsl",
+    "category": "generative",
+    "description": "A mesmerizing 3D generative visualization of a structure that visually bridges the gap between a biological neural network and the cosmic web of the universe.",
+    "tags": [
+      "network",
+      "neural",
+      "cosmic",
+      "web",
+      "3d",
+      "raymarching",
+      "voronoi",
+      "glowing",
+      "cyber",
+      "procedural",
+      "generative"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Network Density",
+        "default": 1,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Pulse Speed",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Connection Thickness",
+        "default": 0.1,
+        "min": 0.01,
+        "max": 0.5,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-neuro-kinetic-bloom",
+    "name": "Neuro-Kinetic Bloom",
+    "url": "shaders/gen-neuro-kinetic-bloom.wgsl",
+    "category": "generative",
+    "description": "A vast, deep-sea garden of biomechanical, neon-veined flora that dynamically uncoils and pulses with quantum energy, its tendrils whipping and synchronizing to the rhythm of sound.",
+    "tags": [
+      "organic",
+      "biomechanical",
+      "audio-reactive",
+      "flora",
+      "raymarching",
+      "volumetric"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "bloomExtension",
+        "name": "Bloom Extension",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "repulsionRadius",
+        "name": "Repulsion Radius",
+        "default": 3,
+        "min": 0,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "veinGlow",
+        "name": "Vein Glow",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "cameraZoom",
+        "name": "Camera Zoom",
+        "default": 0,
+        "min": -10,
+        "max": 10,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-obsidian-echo-chamber",
+    "name": "Obsidian Echo-Chamber",
+    "author": "Jules",
+    "description": "An infinite, abyssal expanse of highly polished, brutalist obsidian monoliths that react to audio by emitting and reflecting brilliant, luminescent echolocation ripples across their glassy surfaces.",
+    "category": "generative",
+    "type": "wgsl",
+    "coordinate": 863,
+    "url": "shaders/gen-obsidian-echo-chamber.wgsl",
+    "tags": [
+      "brutalist",
+      "obsidian",
+      "audio-reactive",
+      "reflection",
+      "dark"
+    ],
+    "sliders": [
+      {
+        "name": "Monolith Spacing",
+        "param": "zoom_params.x",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Audio Ripple Intensity",
+        "param": "zoom_params.y",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Specular Glossiness",
+        "param": "zoom_params.z",
+        "default": 0.9,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Forward Speed",
+        "param": "zoom_params.w",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-photonic-crystal-brain",
+    "name": "Photonic Crystal-Brain",
+    "author": "Jules",
+    "description": "An infinite, glowing network of hyper-refractive crystal neurons that fire iridescent plasma pulses in sync with audio frequencies, generating volumetric glowing synapses within a dark cosmic void.",
+    "category": "generative",
+    "type": "wgsl",
+    "coordinate": 868,
+    "url": "shaders/gen-photonic-crystal-brain.wgsl",
+    "tags": [
+      "neural",
+      "crystal",
+      "plasma",
+      "organic",
+      "audio-reactive",
+      "raymarching"
+    ],
+    "sliders": [
+      {
+        "name": "Synapse Density",
+        "param": "zoom_params.x",
+        "default": 1,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "name": "Pulse Speed",
+        "param": "zoom_params.y",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "name": "Crystal Distortion",
+        "param": "zoom_params.z",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "name": "Glow Intensity",
+        "param": "zoom_params.w",
+        "default": 1.5,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-physarum-sacred-geometry",
+    "coordinate": 857,
+    "type": "wgsl",
+    "url": "shaders/gen-physarum-sacred-geometry.wgsl",
+    "category": "generative",
+    "name": "Physarum (Slime Mold) Sacred Geometry",
+    "description": "A psychedelic organic simulation where millions of microscopic agents feed on video input, leaving vibrant, glowing, fractal trails that pulse with audio.",
+    "tags": [
+      "organic",
+      "simulation",
+      "audio-reactive",
+      "mouse-driven",
+      "psychedelic"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "sliders": [
+      {
+        "id": "sensorAngle",
+        "name": "Sensor Angle",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1.5,
+        "step": 0.05,
+        "param": "zoom_params.x"
+      },
+      {
+        "id": "sensorDistance",
+        "name": "Sensor Distance",
+        "default": 10,
+        "min": 1,
+        "max": 50,
+        "step": 1,
+        "param": "zoom_params.y"
+      },
+      {
+        "id": "decayRate",
+        "name": "Decay Rate",
+        "default": 0.95,
+        "min": 0.8,
+        "max": 0.99,
+        "step": 0.01,
+        "param": "zoom_params.z"
+      },
+      {
+        "id": "diffusionStrength",
+        "name": "Diffusion Strength",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1,
+        "param": "zoom_params.w"
+      }
+    ]
+  },
+  {
+    "id": "gen-prismatic-aether-loom",
+    "name": "Prismatic Aether-Loom",
+    "url": "shaders/gen-prismatic-aether-loom.wgsl",
+    "coordinate": 851,
+    "category": "generative",
+    "type": "compute",
+    "description": "A hyper-dimensional weaving machine where threads of liquid light are spun into iridescent fabrics of space-time, dynamically reacting to audio frequencies and cosmic winds.",
+    "tags": [
+      "cosmic",
+      "mechanical",
+      "strings",
+      "iridescent",
+      "audio-reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "threadDensity",
+        "name": "Thread Density",
+        "default": 10,
+        "min": 1,
+        "max": 50,
+        "step": 1
+      },
+      {
+        "id": "braidComplexity",
+        "name": "Braid Complexity",
+        "default": 3,
+        "min": 1,
+        "max": 10,
+        "step": 1
+      },
+      {
+        "id": "cosmicWind",
+        "name": "Cosmic Wind",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "chromaticShift",
+        "name": "Chromatic Shift",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-prismatic-bismuth-lattice",
+    "name": "Prismatic Bismuth Lattice",
+    "url": "shaders/gen-prismatic-bismuth-lattice.wgsl",
+    "category": "generative",
+    "description": "Endlessly folding hyper-geometric expanse of iridescent bismuth crystals with physical light transmission. Features thin-film interference, metallic Fresnel reflection, and oxide layer transmission.",
+    "tags": [
+      "crystalline",
+      "iridescent",
+      "fractal",
+      "geometric",
+      "audio-reactive",
+      "alpha-transmission",
+      "physical",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "audio-reactive",
+      "mouse-driven",
+      "physical-transmission",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Complexity",
+        "default": 3,
+        "min": 1,
+        "max": 6,
+        "step": 1,
+        "description": "Recursion depth of hopper crystal formation"
+      },
+      {
+        "id": "param2",
+        "name": "Iridescence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Thin-film interference color intensity"
+      },
+      {
+        "id": "param3",
+        "name": "Crystal Scale",
+        "default": 1,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1,
+        "description": "Size of crystal lattice cells"
+      },
+      {
+        "id": "param4",
+        "name": "Fog Density",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Atmospheric fog density"
+      }
+    ]
+  },
+  {
+    "id": "gen-prismatic-fractal-dunes",
+    "name": "Prismatic Fractal-Dunes",
+    "url": "shaders/gen-prismatic-fractal-dunes.wgsl",
+    "type": "generative",
+    "category": "generative",
+    "coordinate": 850,
+    "description": "An infinite, shifting desert where the sand grains are micro-prisms, rippling and flowing like liquid glass under cosmic winds and erupting into chromatic geysers of light to the rhythm of sound.",
+    "tags": [
+      "landscape",
+      "refraction",
+      "audio-reactive",
+      "raymarching",
+      "fractal"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "duneComplexity",
+        "name": "Dune Complexity",
+        "default": 5,
+        "min": 1,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "prismDispersion",
+        "name": "Prism Dispersion",
+        "default": 1.5,
+        "min": 0,
+        "max": 5,
+        "step": 0.05
+      },
+      {
+        "id": "geyserHeight",
+        "name": "Geyser Height",
+        "default": 2,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "windSpeed",
+        "name": "Wind Speed",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-psychedelic-time-warp-kaleidoscope",
+    "name": "Psychedelic Time-Warp Kaleidoscope",
+    "type": "compute",
+    "category": "generative",
+    "coordinate": 872,
+    "url": "shaders/gen-psychedelic-time-warp-kaleidoscope.wgsl",
+    "description": "Mirror the image around a dynamic axis with a time-varying mirror count. Reflection vectors are distorted by a 3D noise field for a shimmering kaleidoscope.",
+    "tags": [
+      "psychedelic",
+      "kaleidoscope",
+      "time-warp",
+      "noise",
+      "audio-reactive"
+    ],
+    "author": "Jules",
+    "parameters": []
+  },
+  {
+    "id": "gen-quantum-aether-origami",
+    "name": "Quantum Aether-Origami",
+    "url": "shaders/gen-quantum-aether-origami.wgsl",
+    "category": "generative",
+    "description": "A hyper-dimensional expanse of iridescent, self-folding light-sheets that crease, snap, and unfold like cosmic origami, collapsing into singularities to the beat of sound.",
+    "tags": [
+      "origami",
+      "quantum",
+      "geometry",
+      "interference",
+      "audio-reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "foldComplexity",
+        "name": "Fold Complexity",
+        "default": 5,
+        "min": 1,
+        "max": 10,
+        "step": 1
+      },
+      {
+        "id": "creaseGlow",
+        "name": "Crease Glow",
+        "default": 1.5,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "audioReactivity",
+        "name": "Audio Reactivity",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "interferenceShift",
+        "name": "Interference Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-quantum-mycelium",
+    "name": "Quantum Mycelium",
+    "url": "shaders/gen-quantum-mycelium.wgsl",
+    "category": "generative",
+    "description": "A hyper-organic, microscopic journey through an infinitely growing, glowing fungal network that pulses with data-like energy and branches dynamically based on spatial noise.",
+    "tags": [
+      "organic",
+      "microscopic",
+      "fungal",
+      "network",
+      "audio-reactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "networkDensity",
+        "name": "Network Density",
+        "default": 1.5,
+        "min": 0.5,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "growthChaos",
+        "name": "Growth Chaos",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "id": "pulseSpeed",
+        "name": "Pulse Speed",
+        "default": 2,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "edgeSoftness",
+        "name": "Edge Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-quantum-neural-lace",
+    "name": "Quantum Neural Lace",
+    "url": "shaders/gen-quantum-neural-lace.wgsl",
+    "category": "generative",
+    "tags": [
+      "cyber",
+      "network",
+      "3d",
+      "raymarching",
+      "scifi",
+      "glowing",
+      "lattice",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "raymarched",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Lattice Density",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Fiber Chaos",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "glow",
+        "name": "Energy Level",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "gen-quantum-superposition",
+    "name": "Quantum Superposition Lattice",
+    "url": "shaders/gen-quantum-superposition.wgsl",
+    "category": "generative",
+    "description": "Particles exist in quantum superposition — visible at multiple Lissajous-orbit positions simultaneously as Gaussian probability clouds. Mouse clicks collapse the wave function locally.",
+    "tags": [
+      "quantum",
+      "superposition",
+      "particles",
+      "wavefunction",
+      "probability",
+      "physics",
+      "generative",
+      "abstract",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Particle Count",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Number of quantum particles (maps to 1–8)."
+      },
+      {
+        "id": "param2",
+        "name": "Decoherence",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Wave-function spread (decoherence / Gaussian sigma)."
+      },
+      {
+        "id": "param3",
+        "name": "Wave Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.35,
+        "step": 0.01,
+        "description": "Oscillation frequency of the quantum wave functions."
+      },
+      {
+        "id": "param4",
+        "name": "Wavefunction Opacity",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01,
+        "description": "Probability cloud opacity scale."
+      }
+    ]
+  },
+  {
+    "id": "gen-quasicrystal",
+    "name": "Quasicrystal",
+    "url": "shaders/gen-quasicrystal.wgsl",
+    "category": "generative",
+    "description": "Penrose tiling-inspired quasicrystal patterns with n-fold symmetry using the projection method from higher-dimensional lattices",
+    "tags": [
+      "generative",
+      "quasicrystal",
+      "symmetry",
+      "mathematical",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "symmetry",
+        "name": "Symmetry Order",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "density",
+        "name": "Pattern Density",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorCycle",
+        "name": "Color Cycling",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "projAngle",
+        "name": "Projection Angle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-raptor-mini",
+    "name": "Raptor Mini",
+    "url": "shaders/gen-raptor-mini.wgsl",
+    "category": "generative",
+    "description": "Fast predatory mini raptor agents chase the mouse and strike with claws. Audio rage mode boosts speed and attacks.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "agent",
+      "chase",
+      "audio",
+      "music",
+      "procedural",
+      "generative",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "turnSpeed",
+        "name": "Turn Speed",
+        "default": 0.8,
+        "min": 0.2,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "maxSpeed",
+        "name": "Max Speed",
+        "default": 3,
+        "min": 1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "rageDuration",
+        "name": "Rage Duration",
+        "default": 1.2,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "glowRadius",
+        "name": "Glow Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-silica-tsunami",
+    "name": "Silica Tsunami",
+    "description": "A slow-motion wave of refractive glass-like particles that crests and shatters, dynamically reshaping around the mouse and reacting to audio amplitude.",
+    "type": "generative",
+    "category": "generative",
+    "coordinate": 855,
+    "url": "shaders/gen-silica-tsunami.wgsl",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Wave Height",
+        "default": 2,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Glass Refraction",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Particle Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "id": "param4",
+        "name": "Audio Reactivity",
+        "default": 1.5,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-singularity-forge",
+    "name": "Singularity Forge",
+    "url": "shaders/gen-singularity-forge.wgsl",
+    "category": "generative",
+    "description": "A hyper-dense, gravity-warped crucible of collapsing stars and chaotic plasma rings, endlessly generating and consuming geometric artifacts.",
+    "tags": [
+      "cosmic",
+      "black-hole",
+      "gravity",
+      "plasma",
+      "audio-reactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "diskDensity",
+        "name": "Disk Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "jetIntensity",
+        "name": "Jet Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "id": "gravityWarp",
+        "name": "Gravity Warp",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "timeDilation",
+        "name": "Time Dilation",
+        "default": 1,
+        "min": 0.1,
+        "max": 2,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-stellar-plasma-ouroboros",
+    "coordinate": 852,
+    "type": "wgsl",
+    "url": "shaders/gen-stellar-plasma-ouroboros.wgsl",
+    "category": "generative",
+    "name": "Stellar Plasma-Ouroboros",
+    "description": "An infinite, self-consuming mechanical serpent made of fractured glass scales and stellar plasma.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Scale Density",
+        "default": 10,
+        "min": 1,
+        "max": 50,
+        "step": 1
+      },
+      {
+        "id": "param2",
+        "name": "Plasma Intensity",
+        "default": 2,
+        "min": 0.1,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Anomaly Gravity",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "id": "param4",
+        "name": "Time Warp",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-stellar-web-loom",
+    "name": "Stellar Web-Loom",
+    "url": "shaders/gen-stellar-web-loom.wgsl",
+    "category": "generative",
+    "description": "A hyper-dimensional cosmic loom weaving infinite tendrils of starlight and plasma silk across a dark void, blending organic neuro-network vibes with vast, mechanical astrophysics.",
+    "tags": [
+      "cosmic",
+      "neuro",
+      "plasma",
+      "volumetric",
+      "audio-reactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "threadDensity",
+        "name": "Thread Density",
+        "default": 2,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "weaveSpeed",
+        "name": "Weave Speed",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "plasmaGlow",
+        "name": "Plasma Glow",
+        "default": 3,
+        "min": 1,
+        "max": 8,
+        "step": 0.1
+      },
+      {
+        "id": "threadOpacityExp",
+        "name": "Thread Opacity Exponent",
+        "default": 1,
+        "min": 0.25,
+        "max": 3,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-string-theory",
+    "name": "String Theory",
+    "url": "shaders/gen-string-theory.wgsl",
+    "category": "generative",
+    "description": "Vibrating string visualizations with interference patterns and harmonics based on the 1D wave equation",
+    "tags": [
+      "generative",
+      "physics",
+      "waves",
+      "harmonics",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "audio-reactive",
+      "animated",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "fundamental",
+        "name": "Fundamental Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "harmonicRichness",
+        "name": "Harmonic Richness",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.85,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "excitement",
+        "name": "Pluck Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-superfluid-quantum-foam",
+    "name": "Superfluid Quantum-Foam",
+    "url": "shaders/gen-superfluid-quantum-foam.wgsl",
+    "category": "generative",
+    "description": "A mesmerizing, hyper-turbulent ocean of boiling quantum probability foam, where iridescent hyper-bubbles merge and burst in sync with audio frequencies, releasing flashes of raw cosmic energy.",
+    "tags": [
+      "organic",
+      "quantum",
+      "fluid",
+      "audio-reactive",
+      "raymarching",
+      "volumetric"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "boilingVolatility",
+        "name": "Boiling Volatility",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "id": "vortexRadius",
+        "name": "Vortex Radius",
+        "default": 4,
+        "min": 0,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "radiationGlow",
+        "name": "Radiation Glow",
+        "default": 1,
+        "min": 0,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "currentSpeed",
+        "name": "Current Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-supernova-remnant",
+    "name": "Supernova Remnant",
+    "url": "shaders/gen-supernova-remnant.wgsl",
+    "category": "generative",
+    "description": "Expanding shell structures with shockwave physics and Rayleigh-Taylor instability patterns, inspired by Hubble nebula images",
+    "tags": [
+      "generative",
+      "nebula",
+      "physics",
+      "space",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "explosionEnergy",
+        "name": "Explosion Energy",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "shellDensity",
+        "name": "Shell Density",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chaos",
+        "name": "Turbulence/Chaos",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "gasOpacity",
+        "name": "Gas Opacity",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "step": 0.05
+      }
+    ]
+  },
+  {
+    "id": "gen-topology-flow",
+    "name": "Topology Flow",
+    "url": "shaders/gen-topology-flow.wgsl",
+    "category": "generative",
+    "description": "Topological surface flow visualization inspired by Morse theory, showing gradient flows converging and diverging at critical points",
+    "tags": [
+      "generative",
+      "topology",
+      "flow",
+      "mathematical",
+      "procedural",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "flowSpeed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "complexity",
+        "name": "Height Complexity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "particleDensity",
+        "name": "Particle Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "trailPersistence",
+        "name": "Trail Persistence",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-vitreous-chrono-chandelier",
+    "name": "Vitreous Chrono-Chandelier",
+    "url": "shaders/gen-vitreous-chrono-chandelier.wgsl",
+    "category": "generative",
+    "description": "An infinite, abyssal cavern illuminated by a colossal, self-assembling chandelier of hyper-refractive glass chimes and glowing quantum pendulums that shatter and reform to the rhythm of time and sound.",
+    "tags": [
+      "crystal",
+      "mechanical",
+      "audio-reactive",
+      "raymarching",
+      "glass",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "shatterThreshold",
+        "name": "Shatter Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chimeDensity",
+        "name": "Chime Density",
+        "default": 4,
+        "min": 1,
+        "max": 10,
+        "step": 0.1
+      },
+      {
+        "id": "refractionIndex",
+        "name": "Refraction Index",
+        "default": 1.3,
+        "min": 1,
+        "max": 2.5,
+        "step": 0.01
+      },
+      {
+        "id": "transmission",
+        "name": "Transmission",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-voronoi-crystal",
+    "name": "Voronoi Crystal",
+    "url": "shaders/gen-voronoi-crystal.wgsl",
+    "category": "generative",
+    "description": "Animated crystal growth using Voronoi diagrams with time-evolving seeds, featuring icy facets and rainbow iridescence",
+    "tags": [
+      "generative",
+      "voronoi",
+      "crystal",
+      "procedural",
+      "animated",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "animated",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "growthSpeed",
+        "name": "Growth Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "crystalCount",
+        "name": "Crystal Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "irregularity",
+        "name": "Irregularity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-xeno-botanical-synth-flora",
+    "name": "Xeno-Botanical Synth-Flora",
+    "url": "shaders/gen-xeno-botanical-synth-flora.wgsl",
+    "category": "generative",
+    "description": "A dense, alien jungle of luminescent, synthetic flora that blooms and breathes with the rhythm of sound, blending organic curves with crystalline cybernetic materials.",
+    "tags": [
+      "organic",
+      "botanical",
+      "cybernetic",
+      "bioluminescent",
+      "audio-reactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "floraDensity",
+        "name": "Flora Density",
+        "default": 2,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "id": "bloomIntensity",
+        "name": "Bloom Intensity",
+        "default": 1.5,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      },
+      {
+        "id": "cyberCircuitGlow",
+        "name": "Cyber-Circuit Glow",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
+        "step": 0.1
+      },
+      {
+        "id": "glowSpread",
+        "name": "Glow Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-xeno-mycelial-resonance-web",
+    "name": "Xeno-Mycelial Resonance-Web",
+    "coordinate": 867,
+    "type": "compute",
+    "category": "generative",
+    "url": "shaders/gen-xeno-mycelial-resonance-web.wgsl",
+    "description": "An infinite, subterranean expanse of bioluminescent, hyper-dimensional mycelium that rhythmically pulses, grows, and interconnects its glowing neural networks in response to audio frequencies.",
+    "tags": [
+      "organic",
+      "mycelium",
+      "fractal",
+      "bioluminescent",
+      "audio-reactive",
+      "raymarching"
+    ],
+    "sliders": [
+      {
+        "name": "Network Density",
+        "param": "zoom_params.x",
+        "default": 2,
+        "min": 0.5,
+        "max": 5,
+        "step": 0.1
+      },
+      {
+        "name": "Branch Thickness",
+        "param": "zoom_params.y",
+        "default": 0.15,
+        "min": 0.05,
+        "max": 0.5,
+        "step": 0.01
+      },
+      {
+        "name": "Bioluminescence Hue",
+        "param": "zoom_params.z",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Pulse Speed",
+        "param": "zoom_params.w",
+        "default": 1,
+        "min": 0.1,
+        "max": 5,
+        "step": 0.1
+      }
+    ]
+  },
+  {
+    "id": "gen-capabilities",
+    "name": "System Monitor",
+    "url": "shaders/gen_capabilities.wgsl",
+    "category": "generative",
+    "description": "Cyberpunk system monitor demonstrating mouse inputs, time, and frame feedback.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "procedural",
+      "generative"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
     ]
   },
@@ -1626,160 +5569,11 @@
     ]
   },
   {
-    "id": "spec-distance-field-text",
-    "name": "Distance Field Text",
-    "url": "shaders/spec-distance-field-text.wgsl",
+    "id": "gen-fluffy-raincloud",
+    "name": "Fluffy Raincloud",
+    "url": "shaders/gen_fluffy_raincloud.wgsl",
     "category": "generative",
-    "description": "SDF-based procedural glyph overlay. Generates abstract runes and symbols as signed distance fields with infinitely smooth scaling, glowing edges, drop shadows, and chromatic cycling.",
-    "tags": [
-      "SDF",
-      "distance-field",
-      "procedural-text",
-      "glyph",
-      "overlay",
-      "runes"
-    ],
-    "features": [
-      "SDF",
-      "procedural-text",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "glyph_scale",
-        "name": "Glyph Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glyph_width",
-        "name": "Glyph Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Glow Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "overlay",
-        "name": "Overlay Mix",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.5
-  },
-  {
-    "id": "gen-stellar-web-loom",
-    "name": "Stellar Web-Loom",
-    "url": "shaders/gen-stellar-web-loom.wgsl",
-    "category": "generative",
-    "description": "A hyper-dimensional cosmic loom weaving infinite tendrils of starlight and plasma silk across a dark void, blending organic neuro-network vibes with vast, mechanical astrophysics.",
-    "tags": [
-      "cosmic",
-      "neuro",
-      "plasma",
-      "volumetric",
-      "audio-reactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "threadDensity",
-        "name": "Thread Density",
-        "default": 2.0,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "weaveSpeed",
-        "name": "Weave Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "plasmaGlow",
-        "name": "Plasma Glow",
-        "default": 3.0,
-        "min": 1.0,
-        "max": 8.0,
-        "step": 0.1
-      },
-      {
-        "id": "threadOpacityExp",
-        "name": "Thread Opacity Exponent",
-        "default": 1.0,
-        "min": 0.25,
-        "max": 3.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-magnetic-field-warp",
-    "name": "Magnetic Field Warp",
-    "author": "Jules",
-    "description": "Treat the image as charged particles warped by a magnetic field.",
-    "category": "generative",
-    "type": "wgsl",
-    "coordinate": 876,
-    "url": "shaders/gen-magnetic-field-warp.wgsl",
-    "tags": [
-      "magnetic",
-      "warp",
-      "audio-reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware"
-    ],
-    "params": [
-      {
-        "id": "warp_strength",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "plasma_mix",
-        "name": "Plasma Mix",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-rainbow-smoke",
-    "name": "Rainbow Smoke",
-    "url": "shaders/gen_rainbow_smoke.wgsl",
-    "category": "generative",
-    "description": "Turbulent fluid simulation with colorful, explosive interactions.",
+    "description": "Move the cloud with your mouse and watch it rain (try clicking!).",
     "features": [
       "mouse-driven"
     ],
@@ -1823,932 +5617,41 @@
     ]
   },
   {
-    "id": "gen-kimi-nebula",
-    "name": "Kimi Nebula",
-    "url": "shaders/gen_kimi_nebula.wgsl",
+    "id": "gen-grid",
+    "name": "Domain-Warped FBM Grid",
+    "url": "shaders/gen_grid.wgsl",
     "category": "generative",
-    "description": "Cosmic nebula cloud swirls with ethereal gas formations, twinkling stars, and mouse-driven stellar winds.",
+    "description": "Audio-reactive domain-warped FBM grid with mouse gravity well, recursive moiré sub-grids, chromatic dispersion edges, and temporal motion blur.",
     "features": [
       "mouse-driven",
-      "generative",
-      "procedural",
-      "cosmic"
-    ],
-    "tags": [
-      "procedural",
-      "generative"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-raptor-mini",
-    "name": "Raptor Mini",
-    "url": "shaders/gen-raptor-mini.wgsl",
-    "category": "generative",
-    "description": "Fast predatory mini raptor agents chase the mouse and strike with claws. Audio rage mode boosts speed and attacks.",
-    "features": [
-      "mouse-driven",
+      "depth-aware",
+      "upgraded-rgba",
+      "domain-warping",
       "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "agent",
-      "chase",
-      "audio",
-      "music",
-      "procedural",
-      "generative",
-      "reactive"
-    ],
-    "params": [
-      {
-        "id": "turnSpeed",
-        "name": "Turn Speed",
-        "default": 0.8,
-        "min": 0.2,
-        "max": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "maxSpeed",
-        "name": "Max Speed",
-        "default": 3.0,
-        "min": 1.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "rageDuration",
-        "name": "Rage Duration",
-        "default": 1.2,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "glowRadius",
-        "name": "Glow Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-celestial-yggdrasil-matrix",
-    "name": "Celestial Yggdrasil-Matrix",
-    "coordinate": 869,
-    "type": "wgsl",
-    "category": "generative",
-    "url": "shaders/gen-celestial-yggdrasil-matrix.wgsl",
-    "description": "An infinitely branching, cosmic tree constructed from intertwining ribbons of stellar plasma and quantum circuitry that pulses with the heartbeat of the universe, fusing organic arboreal forms with intricate cosmic geometry.",
-    "tags": [
-      "organic",
-      "cosmic",
-      "fractal",
-      "kifs",
-      "plasma"
-    ],
-    "author": "Jules",
-    "sliders": [
-      {
-        "name": "Branch Complexity",
-        "param": "zoom_params.x",
-        "min": 1.0,
-        "max": 10.0,
-        "step": 1.0,
-        "default": 5.0
-      },
-      {
-        "name": "Plasma Flow",
-        "param": "zoom_params.y",
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1,
-        "default": 1.0
-      },
-      {
-        "name": "Gravity Warp",
-        "param": "zoom_params.z",
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05,
-        "default": 0.5
-      },
-      {
-        "name": "Glow Intensity",
-        "param": "zoom_params.w",
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1,
-        "default": 1.2
-      }
-    ]
-  },
-  {
-    "id": "gen-kinetic-neo-brutalist-megastructure",
-    "name": "Kinetic Neo-Brutalist Megastructure",
-    "url": "shaders/gen-kinetic-neo-brutalist-megastructure.wgsl",
-    "category": "generative",
-    "description": "An endlessly shifting, gravity-defying neo-brutalist megastructure of colossal floating concrete blocks that grind and interlock, revealing glowing, audio-reactive server cores hidden within.",
-    "tags": [
-      "architecture",
-      "cyberpunk",
-      "mechanical",
-      "audio-reactive",
-      "raymarching"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "blockDensity",
-        "name": "Block Density",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "repulsionRadius",
-        "name": "Repulsion Radius",
-        "default": 3.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "id": "neonIntensity",
-        "name": "Neon Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "travelSpeed",
-        "name": "Travel Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-ethereal-anemone-bloom",
-    "name": "Ethereal Anemone Bloom",
-    "url": "shaders/gen-ethereal-anemone-bloom.wgsl",
-    "category": "generative",
-    "description": "A pulsating, infinite underwater expanse of translucent, bioluminescent anemone-like structures that gently sway in an invisible current, reaching out to feed on the audio frequencies.",
-    "features": [
-      "mouse-driven",
-      "raymarched",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "organic",
-      "bioluminescent",
-      "underwater",
-      "fluid",
-      "audio-reactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "params": [
-      {
-        "id": "current_speed",
-        "name": "Current Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "tentacle_density",
-        "name": "Tentacle Density",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0,
-        "step": 0.05
-      },
-      {
-        "id": "bioluminescence_glow",
-        "name": "Bioluminescence Glow",
-        "default": 2.0,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "water_murkiness",
-        "name": "Water Murkiness",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.5,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "generative-turing-veins",
-    "name": "Turing Veins Generative",
-    "url": "shaders/generative-turing-veins.wgsl",
-    "category": "generative",
-    "description": "Generative multiscale reaction-diffusion Turing patterns forming organic vein networks.",
-    "features": [
-      "mouse-driven",
-      "generative",
-      "reaction-diffusion",
-      "biological"
+      "temporal"
     ],
     "tags": [
       "procedural",
-      "generative"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-chromatic-metamorphosis",
-    "name": "Chromatic Metamorphosis",
-    "url": "shaders/gen-chromatic-metamorphosis.wgsl",
-    "category": "generative",
-    "description": "Metaballs morph continuously between sphere, torus, box, and capsule shapes via smooth-min SDF blending. Surface color evolves independently from geometry in flowing waves.",
-    "tags": [
-      "metamorphosis",
-      "morphing",
-      "sdf",
-      "raymarching",
-      "color",
-      "organic",
       "generative",
-      "3d",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Morph Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Speed of shape transformation cycle."
-      },
-      {
-        "id": "param2",
-        "name": "Color Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Speed at which surface color evolves independently of geometry."
-      },
-      {
-        "id": "param3",
-        "name": "Blend Radius",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.35,
-        "step": 0.01,
-        "description": "Smooth-min radius for SDF blending between shapes."
-      },
-      {
-        "id": "param4",
-        "name": "Light Intensity",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Intensity of the key light illuminating the morphing form."
-      }
-    ]
-  },
-  {
-    "id": "gen-psychedelic-time-warp-kaleidoscope",
-    "name": "Psychedelic Time-Warp Kaleidoscope",
-    "type": "compute",
-    "category": "generative",
-    "coordinate": 872,
-    "url": "shaders/gen-psychedelic-time-warp-kaleidoscope.wgsl",
-    "description": "Mirror the image around a dynamic axis with a time-varying mirror count. Reflection vectors are distorted by a 3D noise field for a shimmering kaleidoscope.",
-    "tags": [
-      "psychedelic",
-      "kaleidoscope",
-      "time-warp",
       "noise",
-      "audio-reactive"
-    ],
-    "author": "Jules",
-    "parameters": []
-  },
-  {
-    "id": "gen-depth-refracted-liquid-stained-glass",
-    "coordinate": 858,
-    "type": "wgsl",
-    "url": "shaders/gen-depth-refracted-liquid-stained-glass.wgsl",
-    "category": "generative",
-    "name": "Depth-Refracted Liquid Stained Glass",
-    "description": "Transform the input video into a shattering, ornate cathedral window that feels tactile, refractive, and symmetrically kaleidoscopic.",
-    "tags": [
-      "kaleidoscope",
-      "refraction",
+      "grid",
+      "domain-warp",
+      "moire",
       "audio-reactive",
-      "mouse-driven"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "depth-input"
-    ],
-    "sliders": [
-      {
-        "id": "facetCount",
-        "name": "Facet Count",
-        "default": 6.0,
-        "min": 3.0,
-        "max": 24.0,
-        "step": 1.0,
-        "param": "zoom_params.x"
-      },
-      {
-        "id": "bevelWidth",
-        "name": "Bevel Width",
-        "default": 2.0,
-        "min": 0.1,
-        "max": 10.0,
-        "step": 0.1,
-        "param": "zoom_params.y"
-      }
-    ]
-  },
-  {
-    "id": "gen-fractal-clockwork",
-    "name": "Fractal Clockwork",
-    "url": "shaders/gen-fractal-clockwork.wgsl",
-    "category": "generative",
-    "description": "Infinite interlocking brass gears rotating in perfect mechanical sync. Steampunk raymarched masterpiece with metallic PBR shading and mouse orbit control.",
-    "tags": [
-      "steampunk",
-      "mechanical",
-      "3d",
-      "raymarching",
-      "gears",
-      "metallic",
-      "brass",
-      "clockwork",
-      "procedural",
-      "generative",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "ford442",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Gear Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "teeth",
-        "name": "Teeth Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Rotation Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "material",
-        "name": "Material",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "labels": [
-          "Brass",
-          "Steel",
-          "Gold"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "gen-astro-kinetic-chrono-orrery",
-    "name": "Astro-Kinetic Chrono-Orrery",
-    "url": "shaders/gen-astro-kinetic-chrono-orrery.wgsl",
-    "category": "generative",
-    "description": "A hyper-intricate cosmic mechanism of nested, rotating brass and energy rings orbiting a blazing quantum singularity, merging celestial mechanics with clockwork precision.",
-    "tags": [
-      "cosmic",
-      "mechanical",
-      "clockwork",
-      "quantum",
-      "orrery",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
+      "vj"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Complexity",
-        "min": 1.0,
-        "max": 10.0,
-        "default": 4.0,
-        "step": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "min": 0.0,
-        "max": 5.0,
-        "default": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "min": 0.0,
-        "max": 3.0,
-        "default": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Audio Reactivity",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-physarum-sacred-geometry",
-    "coordinate": 857,
-    "type": "wgsl",
-    "url": "shaders/gen-physarum-sacred-geometry.wgsl",
-    "category": "generative",
-    "name": "Physarum (Slime Mold) Sacred Geometry",
-    "description": "A psychedelic organic simulation where millions of microscopic agents feed on video input, leaving vibrant, glowing, fractal trails that pulse with audio.",
-    "tags": [
-      "organic",
-      "simulation",
-      "audio-reactive",
-      "mouse-driven",
-      "psychedelic"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "sliders": [
-      {
-        "id": "sensorAngle",
-        "name": "Sensor Angle",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.5,
-        "step": 0.05,
-        "param": "zoom_params.x"
-      },
-      {
-        "id": "sensorDistance",
-        "name": "Sensor Distance",
-        "default": 10.0,
-        "min": 1.0,
-        "max": 50.0,
-        "step": 1.0,
-        "param": "zoom_params.y"
-      },
-      {
-        "id": "decayRate",
-        "name": "Decay Rate",
-        "default": 0.95,
-        "min": 0.8,
-        "max": 0.99,
-        "step": 0.01,
-        "param": "zoom_params.z"
-      },
-      {
-        "id": "diffusionStrength",
-        "name": "Diffusion Strength",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1,
-        "param": "zoom_params.w"
-      }
-    ]
-  },
-  {
-    "id": "gen-holographic-plasma-geode",
-    "name": "Holographic Plasma-Geode",
-    "url": "shaders/gen-holographic-plasma-geode.wgsl",
-    "category": "generative",
-    "description": "A hyper-dimensional geode cracked open to reveal a swirling, audio-reactive core of liquid plasma and holographic fractal crystals.",
-    "tags": [
-      "crystal",
-      "plasma",
-      "audio-reactive",
-      "holographic",
-      "raymarching"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "plasmaIntensity",
-        "name": "Plasma Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "crystalDensity",
-        "name": "Crystal Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "holographicHue",
-        "name": "Holographic Hue",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "coreRotationSpeed",
-        "name": "Core Rotation Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-supernova-remnant",
-    "name": "Supernova Remnant",
-    "url": "shaders/gen-supernova-remnant.wgsl",
-    "category": "generative",
-    "description": "Expanding shell structures with shockwave physics and Rayleigh-Taylor instability patterns, inspired by Hubble nebula images",
-    "tags": [
-      "generative",
-      "nebula",
-      "physics",
-      "space",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "explosionEnergy",
-        "name": "Explosion Energy",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "shellDensity",
-        "name": "Shell Density",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chaos",
-        "name": "Turbulence/Chaos",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "gasOpacity",
-        "name": "Gas Opacity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-hyper-labyrinth",
-    "name": "Hyper Labyrinth",
-    "url": "shaders/gen-hyper-labyrinth.wgsl",
-    "category": "generative",
-    "description": "A 4D maze visualization with neon aesthetics and evolving geometry. Use mouse to orbit the hyper-structure.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "neon",
-      "cyber",
-      "maze",
-      "4d",
-      "generative",
-      "abstract",
-      "geometric",
-      "procedural",
-      "audio",
-      "music"
-    ],
-    "params": [
-      {
-        "id": "scale",
-        "name": "Labyrinth Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "morph",
-        "name": "Morph Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glow",
-        "name": "Neon Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "thickness",
-        "name": "Wall Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ]
-  },
-  {
-    "id": "gen-inverse-mandelbrot",
-    "name": "Inverse Mandelbrot Realm",
-    "url": "shaders/gen-inverse-mandelbrot.wgsl",
-    "category": "generative",
-    "description": "Instead of iterating coordinates, we iterate color-space vectors through the Mandelbrot map. Each pixel's RGB becomes a complex number that orbits and escapes, creating alien fractal color fields.",
-    "tags": [
-      "mandelbrot",
-      "fractal",
-      "color-space",
-      "iteration",
-      "alien",
-      "abstract",
-      "generative",
-      "complex",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Iterations",
-        "min": 0.0,
-        "max": 1.0,
+        "name": "Warp Amount",
         "default": 0.4,
-        "step": 0.01,
-        "description": "Maximum iteration count (maps to 20\u201380)."
-      },
-      {
-        "id": "param2",
-        "name": "Color Zoom",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Zoom level into the color-space fractal."
-      },
-      {
-        "id": "param3",
-        "name": "Colormap Rotate",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0,
-        "step": 0.01,
-        "description": "Global hue rotation of the colormap."
-      },
-      {
-        "id": "param4",
-        "name": "Bailout Radius",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Escape radius \u2014 lower values create more intricate boundaries."
-      }
-    ]
-  },
-  {
-    "id": "gen-neural-fractal",
-    "name": "Neural Fractal",
-    "url": "shaders/gen-neural-fractal.wgsl",
-    "category": "generative",
-    "description": "Neural network weight visualization style fractals using sigmoid, tanh, and swish activation functions instead of standard z\u00b2+c iterations",
-    "tags": [
-      "generative",
-      "fractal",
-      "neural",
-      "mathematical",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "zoom",
-        "name": "Zoom Level",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorSpeed",
-        "name": "Color Cycling",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "iterations",
-        "name": "Iteration Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "mutation",
-        "name": "Mutation Factor",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-grok4-life",
-    "name": "Grok4 Cellular Life",
-    "url": "shaders/gen_grok4_life.wgsl",
-    "category": "generative",
-    "description": "Conway's Game of Life simulation with mouse drawing and random seeding.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "procedural",
-      "generative"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param2",
-        "name": "Speed",
+        "name": "Grid Density",
         "default": 0.5,
         "min": 0,
         "max": 1,
@@ -2756,203 +5659,19 @@
       },
       {
         "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-magnetic-ferrofluid",
-    "name": "Magnetic Ferrofluid",
-    "url": "shaders/gen-magnetic-ferrofluid.wgsl",
-    "category": "generative",
-    "description": "A pulsating, dark metallic liquid with sharp spikes that respond to an oscillating magnetic field.",
-    "tags": [
-      "abstract",
-      "liquid",
-      "metal",
-      "spiky",
-      "fluid",
-      "generative",
-      "ferrofluid",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Magnetic Strength (Spikes)",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Controls the height and intensity of the fluid spikes."
-      },
-      {
-        "id": "param2",
-        "name": "Fluid Density",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Controls how many small spikes and structures form."
-      },
-      {
-        "id": "param3",
-        "name": "Oscillation Speed",
-        "min": 0.1,
-        "max": 3.0,
-        "default": 1.0,
-        "step": 0.01,
-        "description": "Speed at which the fluid pulsates and shifts."
-      },
-      {
-        "id": "param4",
-        "name": "Iridescence Shift",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.2,
-        "step": 0.01,
-        "description": "Shifts the thin-film interference colors on the metallic surface."
-      }
-    ]
-  },
-  {
-    "id": "gen-cosmic-web-filament",
-    "name": "Cosmic Web Filament",
-    "url": "shaders/gen-cosmic-web-filament.wgsl",
-    "category": "generative",
-    "description": "Dark matter web with Voronoi filaments, FBM warping, and mouse gravity wells. Hypnotic cosmic structure with purple-to-cyan gradients.",
-    "tags": [
-      "generative",
-      "cosmic",
-      "voronoi",
-      "filament",
-      "organic",
-      "dark-matter",
-      "web",
-      "gravity",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "ford442",
-    "params": [
-      {
-        "id": "warp",
-        "name": "Warp Strength",
-        "default": 0.33,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "density",
-        "name": "Filament Density",
+        "name": "Line Thickness",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "default": 0.25,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-hyperbolic-tessellation",
-    "name": "Hyperbolic Tessellation Engine",
-    "url": "shaders/gen-hyperbolic-tessellation.wgsl",
-    "category": "generative",
-    "description": "Non-Euclidean Poincar\u00e9-disk tessellation in real-time. Hyperbolic tiles subdivide infinitely toward the boundary disk, colored by recursive depth \u2014 M.C. Escher meets fractals.",
-    "tags": [
-      "hyperbolic",
-      "tessellation",
-      "fractal",
-      "non-euclidean",
-      "escher",
-      "geometric",
-      "generative",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Tile Symmetry",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Number of sides in the fundamental tile (maps to p=3\u20138)."
-      },
-      {
-        "id": "param2",
-        "name": "Depth Color",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.2,
-        "step": 0.01,
-        "description": "Hue offset for depth-based coloring."
-      },
-      {
-        "id": "param3",
-        "name": "Rotation Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Speed and direction of the global hyperbolic rotation."
       },
       {
         "id": "param4",
-        "name": "Boundary Glow",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.7,
-        "step": 0.01,
-        "description": "Brightness of the glow near the Poincar\u00e9 disk boundary."
+        "name": "Palette Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
     ]
   },
@@ -3016,33 +5735,42 @@
     ]
   },
   {
-    "id": "kimi-nebula-depth",
-    "name": "Kimi Nebula Depth",
-    "url": "shaders/kimi_nebula_depth.wgsl",
+    "id": "gen-grok41-plasma",
+    "name": "Spherical Harmonics Plasma",
+    "url": "shaders/gen_grok41_plasma.wgsl",
     "category": "generative",
-    "description": "Volumetric nebula with 3D noise, ray marching, and depth-based color grading.",
+    "description": "Audio-reactive 3D gas giant using Y(l,m) spherical harmonics with HDR ACES tone mapping, Rayleigh limb scattering, mouse-driven light, and treble-triggered lightning tendrils.",
     "features": [
       "mouse-driven",
-      "generative",
-      "volumetric",
-      "3d"
+      "depth-aware",
+      "upgraded-rgba",
+      "3d",
+      "audio-reactive",
+      "spherical-harmonics",
+      "animated"
     ],
     "tags": [
       "procedural",
-      "generative"
+      "generative",
+      "sphere",
+      "atmosphere",
+      "spherical-harmonics",
+      "gas-giant",
+      "audio-reactive",
+      "vj"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
+        "name": "L1 Coefficient",
+        "default": 0.55,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param2",
-        "name": "Speed",
+        "name": "L2 Coefficient",
         "default": 0.5,
         "min": 0,
         "max": 1,
@@ -3050,16 +5778,16 @@
       },
       {
         "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
+        "name": "L3 Coefficient",
+        "default": 0.4,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
+        "name": "Hue Shift",
+        "default": 0,
         "min": 0,
         "max": 1,
         "step": 0.01
@@ -3067,11 +5795,11 @@
     ]
   },
   {
-    "id": "gen-capabilities",
-    "name": "System Monitor",
-    "url": "shaders/gen_capabilities.wgsl",
+    "id": "gen-grok4-life",
+    "name": "Grok4 Cellular Life",
+    "url": "shaders/gen_grok4_life.wgsl",
     "category": "generative",
-    "description": "Cyberpunk system monitor demonstrating mouse inputs, time, and frame feedback.",
+    "description": "Conway's Game of Life simulation with mouse drawing and random seeding.",
     "features": [
       "mouse-driven"
     ],
@@ -3115,1287 +5843,188 @@
     ]
   },
   {
-    "id": "gen-biomechanical-hive",
-    "name": "Biomechanical Hive",
-    "url": "shaders/gen-biomechanical-hive.wgsl",
+    "id": "gen-grok4-perlin",
+    "name": "Grok4 Perlin Terrain",
+    "url": "shaders/gen_grok4_perlin.wgsl",
     "category": "generative",
-    "description": "An infinite, claustrophobic structure of hexagonal cells blending industrial machinery with organic tissue. Features pulsating lights, rhythmic breathing, and slimy metallic textures.",
-    "tags": [
-      "scifi",
-      "biomechanical",
-      "giger",
-      "alien",
-      "raymarching",
-      "horror",
-      "generative",
-      "audio",
-      "music"
+    "description": "Multi-octave Perlin noise generating animated terrain with mouse offset.",
+    "features": [
+      "upgraded-rgba",
+      "depth-aware",
+      "procedural",
+      "mouse-driven"
     ],
+    "tags": [
+      "procedural",
+      "generative"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-grokcf-interference",
+    "name": "Chladni Plate Cymatics",
+    "url": "shaders/gen_grokcf_interference.wgsl",
+    "category": "generative",
+    "description": "Audio-reactive Chladni cymatics with modal synthesis, iridescent oil-slick interference, and Fibonacci spiral self-organization at high audio energy.",
     "features": [
       "mouse-driven",
+      "depth-aware",
+      "upgraded-rgba",
       "audio-reactive",
-      "audio-driven"
+      "procedural",
+      "organic",
+      "animated"
+    ],
+    "tags": [
+      "procedural",
+      "generative",
+      "cymatics",
+      "interference",
+      "audio-reactive",
+      "stained-glass",
+      "vibration",
+      "vj"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Sweep Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Mode Count",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Pattern Sharpness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Sand Density",
+        "default": 0.55,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-grokcf-voronoi",
+    "name": "Worley Cellular",
+    "url": "shaders/gen_grokcf_voronoi.wgsl",
+    "category": "generative",
+    "description": "Audio-reactive Worley cellular fields with thin-film interference edge glow and micro-cosmic starfields hidden inside each cell.",
+    "features": [
+      "mouse-driven",
+      "depth-aware",
+      "upgraded-rgba",
+      "animated",
+      "audio-reactive",
+      "procedural",
+      "organic-cellular"
+    ],
+    "tags": [
+      "procedural",
+      "generative",
+      "voronoi",
+      "cellular",
+      "worley",
+      "audio-reactive",
+      "thin-film",
+      "vj"
     ],
     "params": [
       {
         "id": "param1",
         "name": "Cell Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Biomass",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Hue Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "cosmic-jellyfish",
-    "name": "Cosmic Jellyfish",
-    "url": "shaders/cosmic-jellyfish.wgsl",
-    "category": "generative",
-    "description": "A majestic, translucent jellyfish floating in a cosmic void, with bioluminescent glow and rhythmic pulsation.",
-    "tags": [
-      "3d",
-      "raymarching",
-      "bioluminescent",
-      "space",
-      "organic",
-      "calm",
-      "procedural",
-      "generative"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Tentacle Activity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Hue Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Glow Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-abyssal-leviathan-scales",
-    "name": "Abyssal Leviathan-Scales",
-    "url": "shaders/gen-abyssal-leviathan-scales.wgsl",
-    "category": "generative",
-    "description": "A mesmerizing, infinite expanse of massive, interlocking biomechanical armor scales that undulate like a breathing cosmic leviathan, parting to reveal a blazing, audio-reactive quantum fusion core beneath.",
-    "tags": [
-      "organic",
-      "mechanical",
-      "quantum",
-      "raymarching",
-      "bioluminescence"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "scaleDensity",
-        "name": "Scale Density",
-        "default": 5.0,
-        "min": 1.0,
-        "max": 15.0,
-        "step": 0.1
-      },
-      {
-        "id": "plasmaIntensity",
-        "name": "Plasma Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "breathingSpeed",
-        "name": "Breathing Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "coreHeat",
-        "name": "Core Heat",
-        "default": 2.0,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-neuro-cosmos",
-    "name": "Neuro-Cosmos",
-    "url": "shaders/gen-neuro-cosmos.wgsl",
-    "category": "generative",
-    "description": "A mesmerizing 3D generative visualization of a structure that visually bridges the gap between a biological neural network and the cosmic web of the universe.",
-    "tags": [
-      "network",
-      "neural",
-      "cosmic",
-      "web",
-      "3d",
-      "raymarching",
-      "voronoi",
-      "glowing",
-      "cyber",
-      "procedural",
-      "generative"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Network Density",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Pulse Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Connection Thickness",
-        "default": 0.1,
-        "min": 0.01,
-        "max": 0.5,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-celestial-glass-tornado",
-    "name": "Celestial Glass Tornado",
-    "url": "shaders/gen-celestial-glass-tornado.wgsl",
-    "category": "generative",
-    "coordinate": 859,
-    "type": "shader",
-    "params": [
-      {
-        "id": "vortex_twist",
-        "name": "Vortex Twist",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1,
-        "mapping": "zoom_params.x",
-        "description": "Twist of the vortex"
-      },
-      {
-        "id": "debris_density",
-        "name": "Debris Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05,
-        "mapping": "zoom_params.y",
-        "description": "Density of debris particles"
-      },
-      {
-        "id": "chromatic_split",
-        "name": "Chromatic Split",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Chromatic aberration split"
-      },
-      {
-        "id": "audio_reactivity",
-        "name": "Audio Reactivity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1,
-        "mapping": "zoom_params.w",
-        "description": "Audio reactivity multiplier"
-      }
-    ]
-  },
-  {
-    "id": "gen-xeno-botanical-synth-flora",
-    "name": "Xeno-Botanical Synth-Flora",
-    "url": "shaders/gen-xeno-botanical-synth-flora.wgsl",
-    "category": "generative",
-    "description": "A dense, alien jungle of luminescent, synthetic flora that blooms and breathes with the rhythm of sound, blending organic curves with crystalline cybernetic materials.",
-    "tags": [
-      "organic",
-      "botanical",
-      "cybernetic",
-      "bioluminescent",
-      "audio-reactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "floraDensity",
-        "name": "Flora Density",
-        "default": 2.0,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "bloomIntensity",
-        "name": "Bloom Intensity",
-        "default": 1.5,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "cyberCircuitGlow",
-        "name": "Cyber-Circuit Glow",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "glowSpread",
-        "name": "Glow Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-quantum-superposition",
-    "name": "Quantum Superposition Lattice",
-    "url": "shaders/gen-quantum-superposition.wgsl",
-    "category": "generative",
-    "description": "Particles exist in quantum superposition \u2014 visible at multiple Lissajous-orbit positions simultaneously as Gaussian probability clouds. Mouse clicks collapse the wave function locally.",
-    "tags": [
-      "quantum",
-      "superposition",
-      "particles",
-      "wavefunction",
-      "probability",
-      "physics",
-      "generative",
-      "abstract",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Particle Count",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Number of quantum particles (maps to 1\u20138)."
-      },
-      {
-        "id": "param2",
-        "name": "Decoherence",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Wave-function spread (decoherence / Gaussian sigma)."
-      },
-      {
-        "id": "param3",
-        "name": "Wave Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.35,
-        "step": 0.01,
-        "description": "Oscillation frequency of the quantum wave functions."
-      },
-      {
-        "id": "param4",
-        "name": "Wavefunction Opacity",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Probability cloud opacity scale."
-      }
-    ]
-  },
-  {
-    "id": "gen-quantum-aether-origami",
-    "name": "Quantum Aether-Origami",
-    "url": "shaders/gen-quantum-aether-origami.wgsl",
-    "category": "generative",
-    "description": "A hyper-dimensional expanse of iridescent, self-folding light-sheets that crease, snap, and unfold like cosmic origami, collapsing into singularities to the beat of sound.",
-    "tags": [
-      "origami",
-      "quantum",
-      "geometry",
-      "interference",
-      "audio-reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "foldComplexity",
-        "name": "Fold Complexity",
-        "default": 5.0,
-        "min": 1.0,
-        "max": 10.0,
-        "step": 1.0
-      },
-      {
-        "id": "creaseGlow",
-        "name": "Crease Glow",
-        "default": 1.5,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "audioReactivity",
-        "name": "Audio Reactivity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "interferenceShift",
-        "name": "Interference Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-audio-spirograph",
-    "name": "Audio Spirograph",
-    "url": "shaders/gen-audio-spirograph.wgsl",
-    "category": "generative",
-    "description": "Audio-reactive spirograph with harmonic resonance using epitrochoid and hypotrochoid curves with musical frequency ratios",
-    "tags": [
-      "generative",
-      "audio-reactive",
-      "spirograph",
-      "harmonic",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "audio-reactive",
-      "animated",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "baseFreq",
-        "name": "Base Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "audioReactivity",
-        "name": "Audio Reactivity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "trailLength",
-        "name": "Trail Length",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "lineThickness",
-        "name": "Line Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "bubble-chamber",
-    "name": "Bubble Chamber",
-    "url": "shaders/bubble-chamber.wgsl",
-    "category": "generative",
-    "description": "Simulates subatomic particle trails in a magnetic field using a feedback loop.",
-    "features": [
-      "mouse-driven",
-      "feedback"
-    ],
-    "tags": [
-      "procedural",
-      "generative"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "volumetric-cloud-nebula",
-    "name": "Volumetric Cloud Nebula",
-    "url": "shaders/volumetric-cloud-nebula.wgsl",
-    "category": "generative",
-    "description": "Raymarched volumetric clouds with nebula coloring. Features procedural cloud generation with FBM noise, dynamic color palettes, and animated camera movement through a cosmic nebula.",
-    "tags": [
-      "generative",
-      "nebula",
-      "clouds",
-      "volumetric",
-      "raymarch",
-      "space",
-      "cosmic",
-      "procedural"
-    ],
-    "features": [
-      "raymarched"
-    ],
-    "author": "Kimi",
-    "params": [
-      {
-        "id": "cloudDensity",
-        "name": "Cloud Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of the volumetric clouds"
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Shifts the nebula color palette"
-      },
-      {
-        "id": "cameraDistance",
-        "name": "Camera Distance",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Distance of camera from nebula center"
-      },
-      {
-        "id": "extinction",
-        "name": "Extinction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Light extinction coefficient in the nebula"
-      }
-    ]
-  },
-  {
-    "id": "gen-stellar-plasma-ouroboros",
-    "coordinate": 852,
-    "type": "wgsl",
-    "url": "shaders/gen-stellar-plasma-ouroboros.wgsl",
-    "category": "generative",
-    "name": "Stellar Plasma-Ouroboros",
-    "description": "An infinite, self-consuming mechanical serpent made of fractured glass scales and stellar plasma.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Scale Density",
-        "default": 10,
-        "min": 1,
-        "max": 50,
-        "step": 1
-      },
-      {
-        "id": "param2",
-        "name": "Plasma Intensity",
-        "default": 2,
-        "min": 0.1,
-        "max": 10,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Anomaly Gravity",
-        "default": 0.5,
-        "min": 0,
-        "max": 2,
-        "step": 0.05
-      },
-      {
-        "id": "param4",
-        "name": "Time Warp",
-        "default": 1,
-        "min": 0.1,
-        "max": 5,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-bioluminescent-abyss",
-    "name": "Bioluminescent Abyss",
-    "url": "shaders/gen-bioluminescent-abyss.wgsl",
-    "category": "generative",
-    "description": "An infinite deep underwater landscape with swaying tube worms and thermal vents, featuring bioluminescence and deep sea atmosphere.",
-    "tags": [
-      "underwater",
-      "generative",
-      "3d",
-      "bioluminescence",
-      "raymarching",
-      "volumetric",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Worm Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Current Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Water Clarity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-cybernetic-ferro-coral",
-    "name": "Cybernetic Ferro-Coral",
-    "url": "shaders/gen-cybernetic-ferro-coral.wgsl",
-    "category": "generative",
-    "description": "A biomechanical reef of magnetic, liquid-metal coral that dynamically shapes itself in response to acoustic vibrations, revealing a glowing quantum-plasma core beneath a dark metallic exterior.",
-    "tags": [
-      "biomechanical",
-      "ferrofluid",
-      "coral",
-      "magnetic",
-      "audio-reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "spikeIntensity",
-        "name": "Spike Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "coreGlow",
-        "name": "Core Glow",
-        "default": 1.5,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "iridescence",
-        "name": "Iridescence",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-hyper-dimensional-tesseract-labyrinth",
-    "name": "Hyper-Dimensional Tesseract-Labyrinth",
-    "url": "shaders/gen-hyper-dimensional-tesseract-labyrinth.wgsl",
-    "category": "generative",
-    "description": "A dizzying, gravity-defying maze of glowing hyper-cubes that unfold and rotate through 4D space, creating impossible, Escher-like geometries driven by sound.",
-    "tags": [
-      "geometric",
-      "4d",
-      "optical-illusion",
-      "audio-reactive",
-      "raymarching"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "tesseractComplexity",
-        "name": "Tesseract Complexity",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "edgeGlow",
         "name": "Edge Glow",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "warpField",
-        "name": "Warp Field",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "flySpeed",
-        "name": "Fly Speed",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "nebula-gyroid",
-    "name": "Nebula Gyroid",
-    "url": "shaders/nebula-gyroid.wgsl",
-    "category": "generative",
-    "description": "Ethereal, flowing organic form created with raymarched gyroid SDFs. Features iridescent lighting, multiple blended gyroid layers, and mouse-reactive domain warping for a fluid geometry effect.",
-    "tags": [
-      "generative",
-      "gyroid",
-      "raymarch",
-      "iridescent",
-      "organic",
-      "nebula",
-      "sdf",
-      "fluid",
-      "geometry",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "raymarched",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "minimax.ai",
-    "params": [
-      {
-        "id": "colorSpeed",
-        "name": "Color Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "iridescence",
-        "name": "Iridescence",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "fogDensity",
-        "name": "Fog Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "specularPower",
-        "name": "Specular Power",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen_mandelbulb_3d",
-    "name": "Mandelbulb 3D",
-    "url": "shaders/gen_mandelbulb_3d.wgsl",
-    "category": "generative",
-    "description": "3D Mandelbulb fractal with ray marching, orbit trap coloring, soft shadows, and distance-based alpha for atmospheric depth",
-    "tags": [
-      "mandelbulb",
-      "fractal",
-      "3d",
-      "raymarch",
-      "orbits"
-    ],
-    "features": [
-      "rgba",
-      "ray-marching",
-      "sdf",
-      "orbit-trap",
-      "3d-fractal"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Power",
-        "default": 0.5,
+        "default": 0.55,
         "min": 0,
         "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Zoom",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
+        "step": 0.01
       },
       {
         "id": "param3",
-        "name": "Fog Density",
-        "default": 0.2,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
         "name": "Color Shift",
-        "default": 0.5,
+        "default": 0,
         "min": 0,
         "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "gen-bifurcation-diagram",
-    "name": "Bifurcation Diagram",
-    "url": "shaders/gen-bifurcation-diagram.wgsl",
-    "category": "generative",
-    "description": "Logistic map bifurcation diagram visualizing the transition from order to chaos with density-based coloring and Lyapunov exponent highlighting",
-    "tags": [
-      "generative",
-      "chaos",
-      "mathematical",
-      "fractal",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "rPosition",
-        "name": "R Parameter Position",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
         "step": 0.01
       },
       {
-        "id": "zoom",
-        "name": "Zoom Level",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "iterations",
-        "name": "Iteration Count",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorScheme",
-        "name": "Color Scheme",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-lenia-2",
-    "name": "Lenia 2.0 - Multi-Species",
-    "url": "shaders/gen-lenia-2.wgsl",
-    "category": "generative",
-    "description": "Advanced 4-species Lenia with 4 distinct kernels (Ring, Disk, Gaussian, Sharp Cross). Creatures evolve, compete, and merge. Mouse feeds different species. Truly alive.",
-    "tags": [
-      "lenia",
-      "multi-species",
-      "4-kernels",
-      "organic",
-      "creature",
-      "cellular-automata",
-      "evolution",
-      "advanced",
-      "procedural",
-      "generative",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "ford442",
-    "params": [
-      {
-        "id": "growth",
-        "name": "Global Growth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "kernel",
-        "name": "Kernel Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Evolution Speed",
-        "default": 0.33,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "mix",
-        "name": "Cross-Species Mix",
+        "id": "param4",
+        "name": "Parallax",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "gen-ethereal-quantum-medusa",
-    "name": "Ethereal Quantum Medusa",
-    "url": "shaders/gen-ethereal-quantum-medusa.wgsl",
+    "id": "gen-hyper-warp",
+    "name": "Hyper Warp",
+    "url": "shaders/gen_hyper_warp.wgsl",
     "category": "generative",
-    "coordinate": 857,
-    "type": "shader",
-    "params": [
-      {
-        "id": "swimming_speed",
-        "name": "Swimming Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1,
-        "mapping": "zoom_params.x",
-        "description": "Speed of medusa movement"
-      },
-      {
-        "id": "tentacle_curl",
-        "name": "Tentacle Curl",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1,
-        "mapping": "zoom_params.y",
-        "description": "Curliness of tentacles"
-      },
-      {
-        "id": "quantum_glow",
-        "name": "Quantum Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1,
-        "mapping": "zoom_params.z",
-        "description": "Glow intensity"
-      },
-      {
-        "id": "repulsion_strength",
-        "name": "Repulsion Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1,
-        "mapping": "zoom_params.w",
-        "description": "Mouse repulsion strength"
-      }
-    ]
-  },
-  {
-    "id": "gen-xeno-mycelial-resonance-web",
-    "name": "Xeno-Mycelial Resonance-Web",
-    "coordinate": 867,
-    "type": "compute",
-    "category": "generative",
-    "url": "shaders/gen-xeno-mycelial-resonance-web.wgsl",
-    "description": "An infinite, subterranean expanse of bioluminescent, hyper-dimensional mycelium that rhythmically pulses, grows, and interconnects its glowing neural networks in response to audio frequencies.",
-    "tags": [
-      "organic",
-      "mycelium",
-      "fractal",
-      "bioluminescent",
-      "audio-reactive",
-      "raymarching"
-    ],
-    "sliders": [
-      {
-        "name": "Network Density",
-        "param": "zoom_params.x",
-        "default": 2.0,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "name": "Branch Thickness",
-        "param": "zoom_params.y",
-        "default": 0.15,
-        "min": 0.05,
-        "max": 0.5,
-        "step": 0.01
-      },
-      {
-        "name": "Bioluminescence Hue",
-        "param": "zoom_params.z",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "name": "Pulse Speed",
-        "param": "zoom_params.w",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-neural-bioluminescence-matrix",
-    "name": "Neural Bioluminescence Matrix",
-    "url": "shaders/gen-neural-bioluminescence-matrix.wgsl",
-    "category": "generative",
-    "description": "A pulsing, infinite organic matrix of glowing synthetic neurons firing quantum light impulses across a void, merging biological growth with cybernetic circuitry.",
-    "tags": [
-      "organic",
-      "quantum",
-      "matrix",
-      "bioluminescence",
-      "neural"
-    ],
+    "description": "Advanced domain warping with fractal noise and reaction-diffusion feedback.",
     "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Node Density",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Pulse Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Audio Reactivity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Bio-Glow Intensity",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen_quantum_foam",
-    "name": "Quantum Foam",
-    "url": "shaders/gen_quantum_foam.wgsl",
-    "category": "generative",
-    "description": "Quantum vacuum fluctuation visualization with virtual particle pairs, entanglement webs, and HDR volumetric glow",
-    "tags": [
-      "quantum",
-      "generative",
-      "entanglement",
-      "volumetric",
-      "hdr"
-    ],
-    "features": [
-      "hdr",
-      "audio-reactive",
-      "temporal-coherence",
-      "fbm-noise"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Foam Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Web Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Evolution Speed",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.6
-  },
-  {
-    "id": "gen-wave-equation",
-    "name": "Fluid Ripples",
-    "url": "shaders/gen_wave_equation.wgsl",
-    "category": "generative",
-    "description": "Audio-reactive water ripple simulation with wave interference. Bass amplifies wave energy and mouse-driven pulses. Parameters control intensity, speed, scale, and damping detail.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "upgraded-rgba",
-      "depth-aware",
-      "temporal"
+      "mouse-driven"
     ],
     "tags": [
       "procedural",
-      "generative",
-      "liquid",
-      "waves",
-      "audio-reactive",
-      "vj"
+      "generative"
     ],
     "params": [
       {
@@ -4481,532 +6110,73 @@
     ]
   },
   {
-    "id": "gen-nebular-chrono-astrolabe",
-    "name": "Nebular Chrono Astrolabe",
-    "url": "shaders/gen-nebular-chrono-astrolabe.wgsl",
+    "id": "gen-kimi-crystal",
+    "name": "Kimi Crystal",
+    "url": "shaders/gen_kimi_crystal.wgsl",
     "category": "generative",
-    "type": "shader",
-    "coordinate": 858,
-    "params": [
-      {
-        "id": "rotation_speed",
-        "name": "Rotation Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1,
-        "mapping": "zoom_params.x",
-        "description": "Rotation speed of the astrolabe"
-      },
-      {
-        "id": "complexity",
-        "name": "Complexity",
-        "default": 2.0,
-        "min": 1.0,
-        "max": 5.0,
-        "step": 1.0,
-        "mapping": "zoom_params.y",
-        "description": "Number of ring layers"
-      },
-      {
-        "id": "glow_intensity",
-        "name": "Glow Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1,
-        "mapping": "zoom_params.z",
-        "description": "Glow intensity"
-      },
-      {
-        "id": "gravity_well",
-        "name": "Gravity Well Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1,
-        "mapping": "zoom_params.w",
-        "description": "Mouse gravity attraction"
-      }
-    ]
-  },
-  {
-    "id": "gen-cellular-automata-tapestry",
-    "name": "Cellular Automata Tapestry",
-    "author": "Jules",
-    "description": "Convert the video feed into a living reaction-diffusion tapestry.",
-    "category": "generative",
-    "type": "wgsl",
-    "coordinate": 870,
-    "url": "shaders/gen-cellular-automata-tapestry.wgsl",
-    "tags": [
-      "reaction-diffusion",
-      "cellular-automata",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "gen-fluffy-raincloud",
-    "name": "Fluffy Raincloud",
-    "url": "shaders/gen_fluffy_raincloud.wgsl",
-    "category": "generative",
-    "description": "Move the cloud with your mouse and watch it rain (try clicking!).",
+    "description": "Animated crystalline structures growing on a hexagonal grid with physical light transmission. Features ice IOR-based Fresnel reflection, purity-based absorption, and variable crystal thickness.",
     "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "procedural",
-      "generative"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-liquid-neon-cyber-metropolis",
-    "name": "Liquid-Neon Cyber-Metropolis",
-    "author": "Jules",
-    "description": "An infinite, gravity-defying cyberpunk cityscape constructed from rivers of hyper-luminescent liquid neon and dark matter concrete, where architectural monoliths dynamically extrude, twist, and warp their geometry to the rhythm of heavy audio frequencies.",
-    "category": "generative",
-    "type": "wgsl",
-    "coordinate": 866,
-    "url": "shaders/gen-liquid-neon-cyber-metropolis.wgsl",
-    "tags": [
-      "cyberpunk",
-      "neon",
-      "cityscape",
-      "audio-reactive",
-      "raymarching",
-      "kifs"
-    ],
-    "sliders": [
-      {
-        "name": "Neon Intensity",
-        "param": "zoom_params.x",
-        "default": 1.5,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "name": "City Density",
-        "param": "zoom_params.y",
-        "default": 10.0,
-        "min": 5.0,
-        "max": 20.0,
-        "step": 1.0
-      },
-      {
-        "name": "Audio Reactivity",
-        "param": "zoom_params.z",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "name": "Gravity Warp Strength",
-        "param": "zoom_params.w",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-quasicrystal",
-    "name": "Quasicrystal",
-    "url": "shaders/gen-quasicrystal.wgsl",
-    "category": "generative",
-    "description": "Penrose tiling-inspired quasicrystal patterns with n-fold symmetry using the projection method from higher-dimensional lattices",
-    "tags": [
+      "mouse-driven",
       "generative",
-      "quasicrystal",
-      "symmetry",
-      "mathematical",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
+      "geometric",
+      "crystalline",
+      "alpha-transmission"
     ],
     "params": [
-      {
-        "id": "symmetry",
-        "name": "Symmetry Order",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
       {
         "id": "density",
-        "name": "Pattern Density",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorCycle",
-        "name": "Color Cycling",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "projAngle",
-        "name": "Projection Angle",
+        "name": "Grid Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1,
+        "description": "Density of hexagonal crystal grid"
+      },
+      {
+        "id": "purity",
+        "name": "Crystal Purity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "description": "Ice crystal clarity: affects transmission and absorption"
+      },
+      {
+        "id": "growth",
+        "name": "Growth Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Animation speed of crystal growth"
+      },
+      {
+        "id": "thickness",
+        "name": "Crystal Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Physical thickness affecting light path length"
       }
-    ]
-  },
-  {
-    "id": "gen-vitreous-chrono-chandelier",
-    "name": "Vitreous Chrono-Chandelier",
-    "url": "shaders/gen-vitreous-chrono-chandelier.wgsl",
-    "category": "generative",
-    "description": "An infinite, abyssal cavern illuminated by a colossal, self-assembling chandelier of hyper-refractive glass chimes and glowing quantum pendulums that shatter and reform to the rhythm of time and sound.",
+    ],
     "tags": [
+      "procedural",
+      "generative",
       "crystal",
-      "mechanical",
-      "audio-reactive",
-      "raymarching",
-      "glass",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "shatterThreshold",
-        "name": "Shatter Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chimeDensity",
-        "name": "Chime Density",
-        "default": 4.0,
-        "min": 1.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "id": "refractionIndex",
-        "name": "Refraction Index",
-        "default": 1.3,
-        "min": 1.0,
-        "max": 2.5,
-        "step": 0.01
-      },
-      {
-        "id": "transmission",
-        "name": "Transmission",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
+      "ice",
+      "hexagonal",
+      "transmission",
+      "physical"
     ]
   },
   {
-    "id": "gen-isometric-city",
-    "name": "Isometric Cyber-City",
-    "url": "shaders/gen-isometric-city.wgsl",
+    "id": "gen-kimi-nebula",
+    "name": "Kimi Nebula",
+    "url": "shaders/gen_kimi_nebula.wgsl",
     "category": "generative",
-    "description": "An infinite procedural isometric city with neon lights and traffic.",
+    "description": "Cosmic nebula cloud swirls with ethereal gas formations, twinkling stars, and mouse-driven stellar winds.",
     "features": [
       "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Building density and height variance"
-      },
-      {
-        "id": "speed",
-        "name": "Traffic Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Speed of traffic and flyover"
-      },
-      {
-        "id": "glow",
-        "name": "Neon Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Intensity of neon window glow"
-      },
-      {
-        "id": "height_scale",
-        "name": "Building Height Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Scale of building heights"
-      }
-    ],
-    "tags": [
-      "procedural",
-      "generative",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "gen-chronos-labyrinth",
-    "name": "Chronos Labyrinth",
-    "url": "shaders/gen-chronos-labyrinth.wgsl",
-    "category": "generative",
-    "description": "An infinite, Escher-esque maze of shifting geometric staircases and corridors suspended over a void, with glowing temporal anomalies.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "3d",
-      "raymarching",
-      "geometry",
-      "escher",
-      "maze",
-      "impossible",
-      "abstract",
-      "infinite",
       "generative",
       "procedural",
-      "audio",
-      "music"
-    ],
-    "params": [
-      {
-        "id": "complexity",
-        "name": "Labyrinth Complexity",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "shift_speed",
-        "name": "Shift Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      },
-      {
-        "id": "rifts",
-        "name": "Temporal Rifts",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "atm_perspective",
-        "name": "Atmospheric Perspective",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05,
-        "description": "Distance fade intensity"
-      }
-    ]
-  },
-  {
-    "id": "gen-magnetic-field-lines",
-    "name": "Magnetic Field Lines",
-    "url": "shaders/gen-magnetic-field-lines.wgsl",
-    "category": "generative",
-    "description": "Magnetic dipole field visualization with field lines and charged particles following the field, featuring North (blue) and South (red) poles",
-    "tags": [
-      "generative",
-      "physics",
-      "magnetic",
-      "field-lines",
-      "procedural",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "fieldStrength",
-        "name": "Field Strength",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "particleSpeed",
-        "name": "Particle Speed",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "numDipoles",
-        "name": "Number of Dipoles",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "trailLength",
-        "name": "Trail Length",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "stellar-plasma",
-    "name": "Stellar Plasma",
-    "url": "shaders/stellar-plasma.wgsl",
-    "category": "generative",
-    "description": "An endlessly morphing procedural cosmos powered by domain-warped fractional brownian motion. Creates swirling, liquid-like cosmic nebulae with interactive mouse gravity.",
-    "tags": [
-      "generative",
-      "procedural",
-      "nebula",
-      "cosmic",
-      "plasma",
-      "fbm",
-      "fluid",
-      "loops",
-      "domain-warping",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "Gemini 3.1 Pro Vertex",
-    "params": [
-      {
-        "id": "hueShift",
-        "name": "Hue Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "flowSpeed",
-        "name": "Flow Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "zoomScale",
-        "name": "Zoom / Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "mouseGravity",
-        "name": "Mouse Gravity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "kimi-fractal-dreams",
-    "name": "Kimi Fractal Dreams",
-    "url": "shaders/kimi_fractal_dreams.wgsl",
-    "category": "generative",
-    "description": "Multi-layer fractal with orbit traps, burning ship variant, and smooth color cycling.",
-    "features": [
-      "mouse-driven",
-      "generative",
-      "fractal",
-      "julia-set"
+      "cosmic"
     ],
     "tags": [
       "procedural",
@@ -5048,197 +6218,143 @@
     ]
   },
   {
-    "id": "spec-quaternion-julia",
-    "name": "Quaternion Julia",
-    "url": "shaders/spec-quaternion-julia.wgsl",
+    "id": "gen_mandelbulb_3d",
+    "name": "Mandelbulb 3D",
+    "url": "shaders/gen_mandelbulb_3d.wgsl",
     "category": "generative",
-    "description": "4D quaternion Julia set raymarched in real-time. The 4th dimension animates over time creating organic morphing fractal forms with orbit-trap coloring and physically-based lighting.",
+    "description": "3D Mandelbulb fractal with ray marching, orbit trap coloring, soft shadows, and distance-based alpha for atmospheric depth",
     "tags": [
-      "quaternion",
-      "julia",
+      "mandelbulb",
       "fractal",
-      "4D",
-      "raymarching",
-      "morphing"
+      "3d",
+      "raymarch",
+      "orbits"
     ],
     "features": [
-      "quaternion",
-      "4D",
-      "raymarched",
-      "mouse-driven",
-      "HDR"
+      "rgba",
+      "ray-marching",
+      "sdf",
+      "orbit-trap",
+      "3d-fractal"
     ],
     "params": [
       {
-        "id": "zoom",
-        "name": "Fractal Zoom",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "param1",
+        "name": "Power",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       },
       {
-        "id": "morph_speed",
-        "name": "Morph Speed",
+        "id": "param2",
+        "name": "Zoom",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       },
       {
-        "id": "color_cycles",
-        "name": "Color Cycles",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "param3",
+        "name": "Fog Density",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       },
       {
-        "id": "detail",
-        "name": "Detail Level",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.9
-  },
-  {
-    "id": "spec-analytic-noise-flow",
-    "name": "Analytic Noise Flow",
-    "url": "shaders/spec-analytic-noise-flow.wgsl",
-    "category": "generative",
-    "description": "Perlin noise with analytic derivatives for ultra-smooth flow fields. Gradient computed alongside noise value in single evaluation, eliminating finite-difference jitter for perfectly parallel streamlines.",
-    "tags": [
-      "analytic-derivatives",
-      "flow-field",
-      "noise",
-      "perlin",
-      "streamlines",
-      "curl"
-    ],
-    "features": [
-      "analytic-derivatives",
-      "flow-field",
-      "noise",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "flow_scale",
-        "name": "Flow Scale",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "flow_speed",
-        "name": "Flow Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "advection",
-        "name": "Advection",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "curl",
-        "name": "Curl Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.6
-  },
-  {
-    "id": "gen-bioluminescent-aether-pulsar",
-    "name": "Bioluminescent Aether-Pulsar",
-    "type": "shader",
-    "category": "generative",
-    "url": "shaders/gen-bioluminescent-aether-pulsar.wgsl",
-    "coordinate": 861,
-    "params": [
-      {
-        "id": "spin_rate",
-        "name": "Pulsar Spin Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1,
-        "mapping": "zoom_params.x",
-        "description": "Rotation speed of the pulsar core"
-      },
-      {
-        "id": "beam_intensity",
-        "name": "Beam Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05,
-        "mapping": "zoom_params.y",
-        "description": "Intensity of the volumetric beams"
-      },
-      {
-        "id": "accretion_density",
-        "name": "Accretion Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05,
-        "mapping": "zoom_params.z",
-        "description": "Density and detail of the accretion disk"
-      },
-      {
-        "id": "color_shift",
+        "id": "param4",
         "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05,
-        "mapping": "zoom_params.w",
-        "description": "Shifts the color palette of the pulsar"
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       }
-    ]
+    ],
+    "target_rating": 4.8
   },
   {
-    "id": "gen-grokcf-voronoi",
-    "name": "Worley Cellular",
-    "url": "shaders/gen_grokcf_voronoi.wgsl",
+    "id": "gen-orb",
+    "name": "Lorenz Strange Attractor",
+    "url": "shaders/gen_orb.wgsl",
     "category": "generative",
-    "description": "Audio-reactive Worley cellular fields with thin-film interference edge glow and micro-cosmic starfields hidden inside each cell.",
+    "description": "Audio-reactive Lorenz strange attractor (σ, ρ, β) with bioluminescent depth halos and persistent scent trails. Mids drive rotation, bass adds streams, treble jitters chaos.",
     "features": [
       "mouse-driven",
       "depth-aware",
       "upgraded-rgba",
-      "animated",
       "audio-reactive",
-      "procedural",
-      "organic-cellular"
+      "temporal",
+      "mathematical-art",
+      "particles"
     ],
     "tags": [
       "procedural",
       "generative",
-      "voronoi",
-      "cellular",
-      "worley",
+      "particles",
+      "mathematical-art",
+      "chaos",
+      "attractor",
       "audio-reactive",
-      "thin-film",
       "vj"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Cell Density",
+        "name": "Sigma (σ)",
+        "default": 0.45,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Rho (ρ)",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Beta (β)",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Trail Persistence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-psychedelic-spiral",
+    "name": "Psychedelic Spiral",
+    "url": "shaders/gen_psychedelic_spiral.wgsl",
+    "category": "generative",
+    "description": "Hypnotic spiral with intense feedback and mouse warping.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "procedural",
+      "generative",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
         "min": 0,
         "max": 1,
@@ -5246,24 +6362,127 @@
       },
       {
         "id": "param2",
-        "name": "Edge Glow",
-        "default": 0.55,
+        "name": "Speed",
+        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param3",
-        "name": "Color Shift",
-        "default": 0.0,
+        "name": "Scale",
+        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param4",
-        "name": "Parallax",
-        "default": 0.4,
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen_quantum_foam",
+    "name": "Quantum Foam",
+    "url": "shaders/gen_quantum_foam.wgsl",
+    "category": "generative",
+    "description": "Quantum vacuum fluctuation visualization with virtual particle pairs, entanglement webs, and HDR volumetric glow",
+    "tags": [
+      "quantum",
+      "generative",
+      "entanglement",
+      "volumetric",
+      "hdr"
+    ],
+    "features": [
+      "hdr",
+      "audio-reactive",
+      "temporal-coherence",
+      "fbm-noise"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Foam Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Web Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Evolution Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "gen-rainbow-smoke",
+    "name": "Rainbow Smoke",
+    "url": "shaders/gen_rainbow_smoke.wgsl",
+    "category": "generative",
+    "description": "Turbulent fluid simulation with colorful, explosive interactions.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "procedural",
+      "generative"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
@@ -5315,60 +6534,6 @@
         "min": 0,
         "max": 1,
         "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-prismatic-aether-loom",
-    "name": "Prismatic Aether-Loom",
-    "url": "shaders/gen-prismatic-aether-loom.wgsl",
-    "coordinate": 851,
-    "category": "generative",
-    "type": "compute",
-    "description": "A hyper-dimensional weaving machine where threads of liquid light are spun into iridescent fabrics of space-time, dynamically reacting to audio frequencies and cosmic winds.",
-    "tags": [
-      "cosmic",
-      "mechanical",
-      "strings",
-      "iridescent",
-      "audio-reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "threadDensity",
-        "name": "Thread Density",
-        "default": 10.0,
-        "min": 1.0,
-        "max": 50.0,
-        "step": 1.0
-      },
-      {
-        "id": "braidComplexity",
-        "name": "Braid Complexity",
-        "default": 3.0,
-        "min": 1.0,
-        "max": 10.0,
-        "step": 1.0
-      },
-      {
-        "id": "cosmicWind",
-        "name": "Cosmic Wind",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "chromaticShift",
-        "name": "Chromatic Shift",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
       }
     ]
   },
@@ -5433,908 +6598,25 @@
     ]
   },
   {
-    "id": "gen-photonic-crystal-brain",
-    "name": "Photonic Crystal-Brain",
-    "author": "Jules",
-    "description": "An infinite, glowing network of hyper-refractive crystal neurons that fire iridescent plasma pulses in sync with audio frequencies, generating volumetric glowing synapses within a dark cosmic void.",
+    "id": "gen-wave-equation",
+    "name": "Fluid Ripples",
+    "url": "shaders/gen_wave_equation.wgsl",
     "category": "generative",
-    "type": "wgsl",
-    "coordinate": 868,
-    "url": "shaders/gen-photonic-crystal-brain.wgsl",
-    "tags": [
-      "neural",
-      "crystal",
-      "plasma",
-      "organic",
-      "audio-reactive",
-      "raymarching"
-    ],
-    "sliders": [
-      {
-        "name": "Synapse Density",
-        "param": "zoom_params.x",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "name": "Pulse Speed",
-        "param": "zoom_params.y",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "name": "Crystal Distortion",
-        "param": "zoom_params.z",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      },
-      {
-        "name": "Glow Intensity",
-        "param": "zoom_params.w",
-        "default": 1.5,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-micro-cosmos",
-    "name": "Micro-Cosmos",
-    "url": "shaders/gen-micro-cosmos.wgsl",
-    "category": "generative",
-    "description": "A microscopic view of a teeming liquid universe, filled with procedural microorganisms, drifting particles, and organic structures.",
-    "tags": [
-      "biological",
-      "organic",
-      "microscopic",
-      "liquid",
-      "life",
-      "floating",
-      "generative",
-      "procedural",
-      "audio",
-      "music"
-    ],
+    "description": "Audio-reactive water ripple simulation with wave interference. Bass amplifies wave energy and mouse-driven pulses. Parameters control intensity, speed, scale, and damping detail.",
     "features": [
       "mouse-driven",
       "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Population Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Fluid Activity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Membrane Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-fractured-monolith",
-    "name": "Fractured Monolith",
-    "url": "shaders/gen-fractured-monolith.wgsl",
-    "category": "generative",
-    "description": "A massive, ancient monolith floating above a dark liquid sea, fractured into segmented pieces that pulse with an inner, ethereal light.",
-    "tags": [
-      "monolith",
-      "floating",
-      "fractured",
-      "glowing",
-      "ambient",
-      "generative",
-      "scifi",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Fracture Spread",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.05
-      },
-      {
-        "id": "param2",
-        "name": "Levitation Speed",
-        "min": 0.0,
-        "max": 3.0,
-        "default": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "min": 0.0,
-        "max": 2.0,
-        "default": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Rotation Speed",
-        "min": 0.0,
-        "max": 2.0,
-        "default": 0.5,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-chromodynamic-plasma-collider",
-    "name": "Chromodynamic Plasma-Collider",
-    "coordinate": 853,
-    "type": "wgsl",
-    "url": "shaders/gen-chromodynamic-plasma-collider.wgsl",
-    "category": "generative",
-    "description": "A hyper-speed journey down an infinite magnetic containment tunnel where sub-atomic particles collide and shatter into vibrant, audio-reactive showers of exotic matter.",
-    "tags": [
-      "cosmic",
-      "mechanical",
-      "particle",
-      "plasma",
-      "audio-reactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "ringDensity",
-        "name": "Ring Density",
-        "default": 15.0,
-        "min": 5.0,
-        "max": 30.0,
-        "step": 1.0
-      },
-      {
-        "id": "collisionRate",
-        "name": "Collision Rate",
-        "default": 5.0,
-        "min": 0.5,
-        "max": 20.0,
-        "step": 0.5
-      },
-      {
-        "id": "anomalyPull",
-        "name": "Anomaly Pull",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "tunnelWarp",
-        "name": "Tunnel Warp",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-quantum-neural-lace",
-    "name": "Quantum Neural Lace",
-    "url": "shaders/gen-quantum-neural-lace.wgsl",
-    "category": "generative",
-    "tags": [
-      "cyber",
-      "network",
-      "3d",
-      "raymarching",
-      "scifi",
-      "glowing",
-      "lattice",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "raymarched",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Lattice Density",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Fiber Chaos",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "glow",
-        "name": "Energy Level",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ]
-  },
-  {
-    "id": "gen-liquid-crystal-hive-mind",
-    "name": "Liquid-Crystal Hive-Mind",
-    "url": "shaders/gen-liquid-crystal-hive-mind.wgsl",
-    "category": "generative",
-    "description": "A vast, breathing network of hexagonal bio-synthetic cells containing turbulent, iridescent liquid crystals that synchronize and glow with a pulsing collective consciousness.",
-    "tags": [
-      "cellular",
-      "liquid-crystal",
-      "fluid-dynamics",
-      "honeycomb",
-      "audio-reactive",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "cellDensity",
-        "name": "Cell Density",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "fluidTurbulence",
-        "name": "Fluid Turbulence",
-        "default": 2.5,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "syncPulse",
-        "name": "Sync Pulse",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "disruptionRadius",
-        "name": "Disruption Radius",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 2.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-prismatic-fractal-dunes",
-    "name": "Prismatic Fractal-Dunes",
-    "url": "shaders/gen-prismatic-fractal-dunes.wgsl",
-    "type": "generative",
-    "category": "generative",
-    "coordinate": 850,
-    "description": "An infinite, shifting desert where the sand grains are micro-prisms, rippling and flowing like liquid glass under cosmic winds and erupting into chromatic geysers of light to the rhythm of sound.",
-    "tags": [
-      "landscape",
-      "refraction",
-      "audio-reactive",
-      "raymarching",
-      "fractal"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "duneComplexity",
-        "name": "Dune Complexity",
-        "default": 5.0,
-        "min": 1.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "id": "prismDispersion",
-        "name": "Prism Dispersion",
-        "default": 1.5,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.05
-      },
-      {
-        "id": "geyserHeight",
-        "name": "Geyser Height",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "windSpeed",
-        "name": "Wind Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-abyssal-chrono-coral",
-    "name": "Abyssal Chrono-Coral",
-    "url": "shaders/gen-abyssal-chrono-coral.wgsl",
-    "category": "generative",
-    "description": "A hyper-dimensional, endlessly growing bioluminescent reef suspended in a cosmic void, where time-dilation forces crystalline coral branches to blossom and shatter in sync with quantum audio frequencies.",
-    "tags": [
-      "organic",
-      "fractal",
-      "bioluminescence",
-      "raymarching",
-      "audio-reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "coralDensity",
-        "name": "Coral Density",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "branchComplexity",
-        "name": "Branch Complexity",
-        "default": 4.0,
-        "min": 1.0,
-        "max": 8.0,
-        "step": 1.0,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "bioluminescenceGlow",
-        "name": "Bioluminescence Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "timeDilationField",
-        "name": "Time Dilation Field",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "coordinate": 856
-  },
-  {
-    "id": "gen-kimi-crystal",
-    "name": "Kimi Crystal",
-    "url": "shaders/gen_kimi_crystal.wgsl",
-    "category": "generative",
-    "description": "Animated crystalline structures growing on a hexagonal grid with physical light transmission. Features ice IOR-based Fresnel reflection, purity-based absorption, and variable crystal thickness.",
-    "features": [
-      "mouse-driven",
-      "generative",
-      "geometric",
-      "crystalline",
-      "alpha-transmission"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Grid Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Density of hexagonal crystal grid"
-      },
-      {
-        "id": "purity",
-        "name": "Crystal Purity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Ice crystal clarity: affects transmission and absorption"
-      },
-      {
-        "id": "growth",
-        "name": "Growth Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Animation speed of crystal growth"
-      },
-      {
-        "id": "thickness",
-        "name": "Crystal Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Physical thickness affecting light path length"
-      }
-    ],
-    "tags": [
-      "procedural",
-      "generative",
-      "crystal",
-      "ice",
-      "hexagonal",
-      "transmission",
-      "physical"
-    ]
-  },
-  {
-    "id": "kimi_flock_symphony",
-    "name": "Kimi Flock Symphony",
-    "url": "shaders/kimi_flock_symphony.wgsl",
-    "category": "generative",
-    "description": "Advanced particle flocking simulation with musical visualization, featuring separation, alignment, cohesion, and mouse interaction.",
-    "tags": [
-      "boids",
-      "flocking",
-      "generative",
-      "particles",
-      "musical",
-      "interactive",
-      "procedural"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "author": "Kimi",
-    "params": [
-      {
-        "id": "trail_length",
-        "name": "Trail Length",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow_radius",
-        "name": "Glow Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "density",
-        "name": "Particle Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-cymatic-plasma-mandalas",
-    "name": "Cymatic Plasma-Mandalas",
-    "url": "shaders/gen-cymatic-plasma-mandalas.wgsl",
-    "category": "generative",
-    "description": "A hyper-intricate, unfolding kaleidoscope of glowing liquid geometry that dances and weaves complex, sacred-geometry-inspired mandalas in direct response to audio frequencies.",
-    "tags": [
-      "generative",
-      "mandala",
-      "cymatics",
-      "plasma",
-      "kaleidoscope",
-      "audio-reactive",
-      "liquid",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "symmetryOrder",
-        "name": "Symmetry Order",
-        "default": 6.0,
-        "min": 1.0,
-        "max": 12.0,
-        "step": 1.0
-      },
-      {
-        "id": "plasmaDensity",
-        "name": "Plasma Density",
-        "default": 2.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "cymaticFrequency",
-        "name": "Cymatic Frequency",
-        "default": 10.0,
-        "min": 0.5,
-        "max": 30.0,
-        "step": 0.1
-      },
-      {
-        "id": "swirlChaos",
-        "name": "Swirl Chaos",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-grid",
-    "name": "Domain-Warped FBM Grid",
-    "url": "shaders/gen_grid.wgsl",
-    "category": "generative",
-    "description": "Audio-reactive domain-warped FBM grid with mouse gravity well, recursive moir\u00e9 sub-grids, chromatic dispersion edges, and temporal motion blur.",
-    "features": [
-      "mouse-driven",
-      "depth-aware",
       "upgraded-rgba",
-      "domain-warping",
-      "audio-reactive",
+      "depth-aware",
       "temporal"
     ],
     "tags": [
       "procedural",
       "generative",
-      "noise",
-      "grid",
-      "domain-warp",
-      "moire",
-      "audio-reactive",
-      "vj"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Warp Amount",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Grid Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Line Thickness",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Palette Shift",
-        "default": 0.0,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-obsidian-echo-chamber",
-    "name": "Obsidian Echo-Chamber",
-    "author": "Jules",
-    "description": "An infinite, abyssal expanse of highly polished, brutalist obsidian monoliths that react to audio by emitting and reflecting brilliant, luminescent echolocation ripples across their glassy surfaces.",
-    "category": "generative",
-    "type": "wgsl",
-    "coordinate": 863,
-    "url": "shaders/gen-obsidian-echo-chamber.wgsl",
-    "tags": [
-      "brutalist",
-      "obsidian",
-      "audio-reactive",
-      "reflection",
-      "dark"
-    ],
-    "sliders": [
-      {
-        "name": "Monolith Spacing",
-        "param": "zoom_params.x",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "name": "Audio Ripple Intensity",
-        "param": "zoom_params.y",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "name": "Specular Glossiness",
-        "param": "zoom_params.z",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "name": "Forward Speed",
-        "param": "zoom_params.w",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-superfluid-quantum-foam",
-    "name": "Superfluid Quantum-Foam",
-    "url": "shaders/gen-superfluid-quantum-foam.wgsl",
-    "category": "generative",
-    "description": "A mesmerizing, hyper-turbulent ocean of boiling quantum probability foam, where iridescent hyper-bubbles merge and burst in sync with audio frequencies, releasing flashes of raw cosmic energy.",
-    "tags": [
-      "organic",
-      "quantum",
-      "fluid",
-      "audio-reactive",
-      "raymarching",
-      "volumetric"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "boilingVolatility",
-        "name": "Boiling Volatility",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      },
-      {
-        "id": "vortexRadius",
-        "name": "Vortex Radius",
-        "default": 4.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "id": "radiationGlow",
-        "name": "Radiation Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "currentSpeed",
-        "name": "Current Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-alien-flora",
-    "name": "Alien Flora",
-    "url": "shaders/gen-alien-flora.wgsl",
-    "category": "generative",
-    "description": "An infinite procedural forest of bioluminescent alien vegetation with swaying mushrooms and atmospheric fog.",
-    "tags": [
-      "nature",
-      "plants",
-      "bioluminescent",
-      "raymarching",
-      "3d",
-      "organic",
-      "forest",
-      "procedural",
-      "generative",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Vegetation Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Sway Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "default": 1.5,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-cybernetic-liquid-chrome-engine",
-    "name": "Cybernetic Liquid-Chrome Engine",
-    "coordinate": 864,
-    "type": "shader",
-    "category": "generative",
-    "url": "shaders/gen-cybernetic-liquid-chrome-engine.wgsl",
-    "description": "A colossal, endlessly shifting mechanical engine constructed of hyper-reflective liquid chrome, pumping iridescent plasma through infinitely complex fractal pistons that react to the heavy bass of audio frequencies.",
-    "tags": [
-      "mechanical",
-      "liquid-metal",
-      "audio-reactive",
-      "raymarching",
-      "fractal"
-    ],
-    "sliders": [
-      {
-        "name": "Engine Speed",
-        "param": "zoom_params.x",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "name": "Chrome Reflectivity",
-        "param": "zoom_params.y",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      },
-      {
-        "name": "Plasma Glow",
-        "param": "zoom_params.z",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "name": "Complexity",
-        "param": "zoom_params.w",
-        "default": 3.0,
-        "min": 1.0,
-        "max": 8.0,
-        "step": 1.0
-      }
-    ]
-  },
-  {
-    "id": "kimi-quantum-field",
-    "name": "Kimi Quantum Field",
-    "url": "shaders/kimi_quantum_field.wgsl",
-    "category": "generative",
-    "description": "Wave interference patterns with uncertainty visualization and probability densities.",
-    "features": [
-      "mouse-driven",
-      "generative",
+      "liquid",
       "waves",
-      "interference"
-    ],
-    "tags": [
-      "procedural",
-      "generative"
+      "audio-reactive",
+      "vj"
     ],
     "params": [
       {
@@ -6368,897 +6650,6 @@
         "min": 0,
         "max": 1,
         "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-silica-tsunami",
-    "name": "Silica Tsunami",
-    "description": "A slow-motion wave of refractive glass-like particles that crests and shatters, dynamically reshaping around the mouse and reacting to audio amplitude.",
-    "type": "generative",
-    "category": "generative",
-    "coordinate": 855,
-    "url": "shaders/gen-silica-tsunami.wgsl",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Wave Height",
-        "default": 2,
-        "min": 0,
-        "max": 5,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Glass Refraction",
-        "default": 0.8,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Particle Density",
-        "default": 1,
-        "min": 0.1,
-        "max": 2,
-        "step": 0.05
-      },
-      {
-        "id": "param4",
-        "name": "Audio Reactivity",
-        "default": 1.5,
-        "min": 0,
-        "max": 3,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-bioluminescent-reaction-diffusion",
-    "name": "Bioluminescent Reaction-Diffusion",
-    "coordinate": 871,
-    "type": "wgsl",
-    "category": "generative",
-    "url": "shaders/gen-bioluminescent-reaction-diffusion.wgsl"
-  },
-  {
-    "id": "gen-grok41-plasma",
-    "name": "Spherical Harmonics Plasma",
-    "url": "shaders/gen_grok41_plasma.wgsl",
-    "category": "generative",
-    "description": "Audio-reactive 3D gas giant using Y(l,m) spherical harmonics with HDR ACES tone mapping, Rayleigh limb scattering, mouse-driven light, and treble-triggered lightning tendrils.",
-    "features": [
-      "mouse-driven",
-      "depth-aware",
-      "upgraded-rgba",
-      "3d",
-      "audio-reactive",
-      "spherical-harmonics",
-      "animated"
-    ],
-    "tags": [
-      "procedural",
-      "generative",
-      "sphere",
-      "atmosphere",
-      "spherical-harmonics",
-      "gas-giant",
-      "audio-reactive",
-      "vj"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "L1 Coefficient",
-        "default": 0.55,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "L2 Coefficient",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "L3 Coefficient",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Hue Shift",
-        "default": 0.0,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-lorenz-attractor-flow",
-    "name": "Lorenz Attractor Flow",
-    "url": "shaders/lorenz-attractor-flow.wgsl",
-    "category": "generative",
-    "description": "Real-time visualization of the Lorenz strange attractor using GPU-accelerated ODE integration. Features chaotic butterfly-wing patterns, mouse perturbation, and temporal color evolution.",
-    "features": [
-      "generative",
-      "mouse-driven",
-      "temporal"
-    ],
-    "tags": [
-      "chaotic",
-      "attractor",
-      "lorenz",
-      "generative",
-      "scientific",
-      "flow",
-      "butterfly"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Integration Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-celestial-forge",
-    "name": "Celestial Forge",
-    "url": "shaders/gen-celestial-forge.wgsl",
-    "category": "generative",
-    "description": "A massive sci-fi megastructure enclosing a miniature star, featuring contra-rotating rings, plasma arcs, and glowing panels.",
-    "tags": [
-      "space",
-      "megastructure",
-      "dyson sphere",
-      "plasma",
-      "rings",
-      "sci-fi",
-      "raymarching",
-      "3d",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Rotation Speed",
-        "min": 0.0,
-        "max": 2.0,
-        "default": 1.0,
-        "step": 0.01,
-        "description": "Speed of the contra-rotating ring structure."
-      },
-      {
-        "id": "param2",
-        "name": "Complexity",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5,
-        "step": 0.01,
-        "description": "Number of rings and surface detail density."
-      },
-      {
-        "id": "param3",
-        "name": "Ring Scale",
-        "min": 0.5,
-        "max": 2.0,
-        "default": 1.0,
-        "step": 0.01,
-        "description": "Overall size of the ring structure."
-      },
-      {
-        "id": "param4",
-        "name": "Core Intensity",
-        "min": 0.0,
-        "max": 5.0,
-        "default": 1.0,
-        "step": 0.01,
-        "description": "Brightness of the central star and emitted light."
-      }
-    ]
-  },
-  {
-    "id": "gen-gravitational-strain",
-    "name": "Gravitational Strain Field",
-    "url": "shaders/gen-gravitational-strain.wgsl",
-    "category": "generative",
-    "description": "Orbiting gravity wells warp a procedural star field via geodesic ray integration. Tidal emission glows brightest where gravitational gradients collide \u2014 dark matter visualization as art.",
-    "tags": [
-      "gravity",
-      "lensing",
-      "space",
-      "physics",
-      "stars",
-      "dark-matter",
-      "generative",
-      "simulation",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Well Count",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Number of gravity wells (maps to 1\u20136)."
-      },
-      {
-        "id": "param2",
-        "name": "Well Mass",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Mass of each gravity well \u2014 controls bending strength."
-      },
-      {
-        "id": "param3",
-        "name": "Bend Strength",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Overall geodesic deflection amplitude."
-      },
-      {
-        "id": "param4",
-        "name": "Emission Scale",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Brightness of tidal emission at field gradient maxima."
-      }
-    ]
-  },
-  {
-    "id": "gen-nebula-light-trail-swarm",
-    "name": "Nebula Light-Trail Swarm",
-    "url": "shaders/gen-nebula-light-trail-swarm.wgsl",
-    "category": "generative",
-    "description": "Photon-like particles race through the scene leaving glowing, fading trails that pulse with audio. Creates a constantly reforming nebula.",
-    "features": [
-      "audio-reactive",
-      "mouse-driven",
-      "generative"
-    ],
-    "tags": [
-      "nebula",
-      "particles",
-      "trails",
-      "glow",
-      "audio",
-      "generative",
-      "space"
-    ],
-    "params": [
-      {
-        "id": "speed",
-        "name": "Particle Speed",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "trailDecay",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "curlStrength",
-        "name": "Curl Strength",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glowRadius",
-        "name": "Glow Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-grok4-perlin",
-    "name": "Grok4 Perlin Terrain",
-    "url": "shaders/gen_grok4_perlin.wgsl",
-    "category": "generative",
-    "description": "Multi-octave Perlin noise generating animated terrain with mouse offset.",
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "procedural",
-      "mouse-driven"
-    ],
-    "tags": [
-      "procedural",
-      "generative"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "cosmic-web",
-    "name": "Cosmic Web Filament",
-    "url": "shaders/cosmic-web.wgsl",
-    "category": "generative",
-    "description": "Simulates the large-scale structure of the universe with dark matter filaments and voids. Mouse acts as a gravity well.",
-    "tags": [
-      "space",
-      "procedural",
-      "organic",
-      "scifi",
-      "dark-matter",
-      "generative"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Filament Density",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Flow Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-singularity-forge",
-    "name": "Singularity Forge",
-    "url": "shaders/gen-singularity-forge.wgsl",
-    "category": "generative",
-    "description": "A hyper-dense, gravity-warped crucible of collapsing stars and chaotic plasma rings, endlessly generating and consuming geometric artifacts.",
-    "tags": [
-      "cosmic",
-      "black-hole",
-      "gravity",
-      "plasma",
-      "audio-reactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "diskDensity",
-        "name": "Disk Density",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "jetIntensity",
-        "name": "Jet Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      },
-      {
-        "id": "gravityWarp",
-        "name": "Gravity Warp",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "timeDilation",
-        "name": "Time Dilation",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 2.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-graviton-plasma-lotus",
-    "name": "Graviton Plasma Lotus",
-    "url": "shaders/gen-graviton-plasma-lotus.wgsl",
-    "category": "generative",
-    "type": "shader",
-    "coordinate": 860,
-    "params": [
-      {
-        "id": "rotation_speed",
-        "name": "Rotation Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1,
-        "mapping": "zoom_params.x",
-        "description": "Speed of rotation"
-      },
-      {
-        "id": "complexity",
-        "name": "Complexity",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1,
-        "mapping": "zoom_params.y",
-        "description": "Form complexity"
-      },
-      {
-        "id": "bloom_intensity",
-        "name": "Bloom Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1,
-        "mapping": "zoom_params.z",
-        "description": "Bloom glow intensity"
-      },
-      {
-        "id": "gravity_well",
-        "name": "Gravity Well Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.1,
-        "mapping": "zoom_params.w",
-        "description": "Gravity well pull strength"
-      }
-    ]
-  },
-  {
-    "id": "gen-hyper-refractive-rain-matrix",
-    "name": "Hyper-Refractive Rain-Matrix",
-    "type": "shader",
-    "category": "generative",
-    "url": "shaders/gen-hyper-refractive-rain-matrix.wgsl",
-    "coordinate": 862,
-    "sliders": [
-      {
-        "id": "rain_density",
-        "name": "Rain Density",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1,
-        "param": "zoom_params.x",
-        "description": "Density of the rain matrix"
-      },
-      {
-        "id": "drop_speed",
-        "name": "Drop Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 3.0,
-        "step": 0.1,
-        "param": "zoom_params.y",
-        "description": "Falling speed of the drops"
-      },
-      {
-        "id": "fluid_viscosity",
-        "name": "Fluid Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05,
-        "param": "zoom_params.z",
-        "description": "Viscosity of the fluid merging effect"
-      },
-      {
-        "id": "storm_intensity",
-        "name": "Storm Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05,
-        "param": "zoom_params.w",
-        "description": "Intensity of the background storm"
-      }
-    ]
-  },
-  {
-    "id": "gen-auroral-ferrofluid-monolith",
-    "name": "Auroral Ferrofluid-Monolith",
-    "url": "shaders/gen-auroral-ferrofluid-monolith.wgsl",
-    "coordinate": 149,
-    "category": "generative",
-    "description": "A colossal, liquid-metal obelisk suspended in a void, its surface rippling with spiky, audio-reactive ferrofluid structures while crackling with volumetric auroral energy.",
-    "tags": [
-      "ferrofluid",
-      "monolith",
-      "aurora",
-      "liquid-metal",
-      "audio-reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "spikeLength",
-        "name": "Spike Length",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "auroraIntensity",
-        "name": "Aurora Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.01
-      },
-      {
-        "id": "magneticTwist",
-        "name": "Magnetic Twist",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "fluidMetallic",
-        "name": "Fluid Metallic",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-grokcf-interference",
-    "name": "Chladni Plate Cymatics",
-    "url": "shaders/gen_grokcf_interference.wgsl",
-    "category": "generative",
-    "description": "Audio-reactive Chladni cymatics with modal synthesis, iridescent oil-slick interference, and Fibonacci spiral self-organization at high audio energy.",
-    "features": [
-      "mouse-driven",
-      "depth-aware",
-      "upgraded-rgba",
-      "audio-reactive",
-      "procedural",
-      "organic",
-      "animated"
-    ],
-    "tags": [
-      "procedural",
-      "generative",
-      "cymatics",
-      "interference",
-      "audio-reactive",
-      "stained-glass",
-      "vibration",
-      "vj"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Sweep Speed",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Mode Count",
-        "default": 0.6,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Pattern Sharpness",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Sand Density",
-        "default": 0.55,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-quantum-mycelium",
-    "name": "Quantum Mycelium",
-    "url": "shaders/gen-quantum-mycelium.wgsl",
-    "category": "generative",
-    "description": "A hyper-organic, microscopic journey through an infinitely growing, glowing fungal network that pulses with data-like energy and branches dynamically based on spatial noise.",
-    "tags": [
-      "organic",
-      "microscopic",
-      "fungal",
-      "network",
-      "audio-reactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "networkDensity",
-        "name": "Network Density",
-        "default": 1.5,
-        "min": 0.5,
-        "max": 3.0,
-        "step": 0.1
-      },
-      {
-        "id": "growthChaos",
-        "name": "Growth Chaos",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      },
-      {
-        "id": "pulseSpeed",
-        "name": "Pulse Speed",
-        "default": 2.0,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "edgeSoftness",
-        "name": "Edge Softness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-celestial-prism-orchid",
-    "name": "Celestial Prism-Orchid",
-    "url": "shaders/gen-celestial-prism-orchid.wgsl",
-    "category": "generative",
-    "description": "A mesmerizing, infinite expanse of refractive, crystalline petals that fold, bloom, and scatter starlight into vivid chromatic spectrums, dynamically responding to cosmic winds and audio vibrations.",
-    "tags": [
-      "organic",
-      "cosmic",
-      "refractive",
-      "audio-reactive",
-      "raymarching",
-      "fractal"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "bloomComplexity",
-        "name": "Bloom Complexity",
-        "default": 1.5,
-        "min": 0.1,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "refractiveIndex",
-        "name": "Refractive Index",
-        "default": 1.2,
-        "min": 1.0,
-        "max": 2.5,
-        "step": 0.01
-      },
-      {
-        "id": "coreIntensity",
-        "name": "Core Intensity",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "cosmicWindSpeed",
-        "name": "Cosmic Wind Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
-        "step": 0.05
-      }
-    ]
-  },
-  {
-    "id": "gen-prismatic-bismuth-lattice",
-    "name": "Prismatic Bismuth Lattice",
-    "url": "shaders/gen-prismatic-bismuth-lattice.wgsl",
-    "category": "generative",
-    "description": "Endlessly folding hyper-geometric expanse of iridescent bismuth crystals with physical light transmission. Features thin-film interference, metallic Fresnel reflection, and oxide layer transmission.",
-    "tags": [
-      "crystalline",
-      "iridescent",
-      "fractal",
-      "geometric",
-      "audio-reactive",
-      "alpha-transmission",
-      "physical",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "audio-reactive",
-      "mouse-driven",
-      "physical-transmission",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Complexity",
-        "default": 3.0,
-        "min": 1.0,
-        "max": 6.0,
-        "step": 1.0,
-        "description": "Recursion depth of hopper crystal formation"
-      },
-      {
-        "id": "param2",
-        "name": "Iridescence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "Thin-film interference color intensity"
-      },
-      {
-        "id": "param3",
-        "name": "Crystal Scale",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 5.0,
-        "step": 0.1,
-        "description": "Size of crystal lattice cells"
-      },
-      {
-        "id": "param4",
-        "name": "Fog Density",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "Atmospheric fog density"
       }
     ]
   },
@@ -7314,42 +6705,33 @@
     ]
   },
   {
-    "id": "gen-orb",
-    "name": "Lorenz Strange Attractor",
-    "url": "shaders/gen_orb.wgsl",
+    "id": "generative-turing-veins",
+    "name": "Turing Veins Generative",
+    "url": "shaders/generative-turing-veins.wgsl",
     "category": "generative",
-    "description": "Audio-reactive Lorenz strange attractor (\u03c3, \u03c1, \u03b2) with bioluminescent depth halos and persistent scent trails. Mids drive rotation, bass adds streams, treble jitters chaos.",
+    "description": "Generative multiscale reaction-diffusion Turing patterns forming organic vein networks.",
     "features": [
       "mouse-driven",
-      "depth-aware",
-      "upgraded-rgba",
-      "audio-reactive",
-      "temporal",
-      "mathematical-art",
-      "particles"
+      "generative",
+      "reaction-diffusion",
+      "biological"
     ],
     "tags": [
       "procedural",
-      "generative",
-      "particles",
-      "mathematical-art",
-      "chaos",
-      "attractor",
-      "audio-reactive",
-      "vj"
+      "generative"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Sigma (\u03c3)",
-        "default": 0.45,
+        "name": "Intensity",
+        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param2",
-        "name": "Rho (\u03c1)",
+        "name": "Speed",
         "default": 0.5,
         "min": 0,
         "max": 1,
@@ -7357,361 +6739,1173 @@
       },
       {
         "id": "param3",
-        "name": "Beta (\u03b2)",
-        "default": 0.4,
+        "name": "Scale",
+        "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
         "id": "param4",
-        "name": "Trail Persistence",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "kimi_flock_symphony",
+    "name": "Kimi Flock Symphony",
+    "url": "shaders/kimi_flock_symphony.wgsl",
+    "category": "generative",
+    "description": "Advanced particle flocking simulation with musical visualization, featuring separation, alignment, cohesion, and mouse interaction.",
+    "tags": [
+      "boids",
+      "flocking",
+      "generative",
+      "particles",
+      "musical",
+      "interactive",
+      "procedural"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "author": "Kimi",
+    "params": [
+      {
+        "id": "trail_length",
+        "name": "Trail Length",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow_radius",
+        "name": "Glow Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "density",
+        "name": "Particle Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "kimi-fractal-dreams",
+    "name": "Kimi Fractal Dreams",
+    "url": "shaders/kimi_fractal_dreams.wgsl",
+    "category": "generative",
+    "description": "Multi-layer fractal with orbit traps, burning ship variant, and smooth color cycling.",
+    "features": [
+      "mouse-driven",
+      "generative",
+      "fractal",
+      "julia-set"
+    ],
+    "tags": [
+      "procedural",
+      "generative"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "kimi-nebula-depth",
+    "name": "Kimi Nebula Depth",
+    "url": "shaders/kimi_nebula_depth.wgsl",
+    "category": "generative",
+    "description": "Volumetric nebula with 3D noise, ray marching, and depth-based color grading.",
+    "features": [
+      "mouse-driven",
+      "generative",
+      "volumetric",
+      "3d"
+    ],
+    "tags": [
+      "procedural",
+      "generative"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "kimi-quantum-field",
+    "name": "Kimi Quantum Field",
+    "url": "shaders/kimi_quantum_field.wgsl",
+    "category": "generative",
+    "description": "Wave interference patterns with uncertainty visualization and probability densities.",
+    "features": [
+      "mouse-driven",
+      "generative",
+      "waves",
+      "interference"
+    ],
+    "tags": [
+      "procedural",
+      "generative"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "nebula-gyroid",
+    "name": "Nebula Gyroid",
+    "url": "shaders/nebula-gyroid.wgsl",
+    "category": "generative",
+    "description": "Ethereal, flowing organic form created with raymarched gyroid SDFs. Features iridescent lighting, multiple blended gyroid layers, and mouse-reactive domain warping for a fluid geometry effect.",
+    "tags": [
+      "generative",
+      "gyroid",
+      "raymarch",
+      "iridescent",
+      "organic",
+      "nebula",
+      "sdf",
+      "fluid",
+      "geometry",
+      "procedural",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "raymarched",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "minimax.ai",
+    "params": [
+      {
+        "id": "colorSpeed",
+        "name": "Color Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "iridescence",
+        "name": "Iridescence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "fogDensity",
+        "name": "Fog Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "specularPower",
+        "name": "Specular Power",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "spec-analytic-noise-flow",
+    "name": "Analytic Noise Flow",
+    "url": "shaders/spec-analytic-noise-flow.wgsl",
+    "category": "generative",
+    "description": "Perlin noise with analytic derivatives for ultra-smooth flow fields. Gradient computed alongside noise value in single evaluation, eliminating finite-difference jitter for perfectly parallel streamlines.",
+    "tags": [
+      "analytic-derivatives",
+      "flow-field",
+      "noise",
+      "perlin",
+      "streamlines",
+      "curl"
+    ],
+    "features": [
+      "analytic-derivatives",
+      "flow-field",
+      "noise",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "flow_scale",
+        "name": "Flow Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "flow_speed",
+        "name": "Flow Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "advection",
+        "name": "Advection",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "curl",
+        "name": "Curl Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "spec-distance-field-text",
+    "name": "Distance Field Text",
+    "url": "shaders/spec-distance-field-text.wgsl",
+    "category": "generative",
+    "description": "SDF-based procedural glyph overlay. Generates abstract runes and symbols as signed distance fields with infinitely smooth scaling, glowing edges, drop shadows, and chromatic cycling.",
+    "tags": [
+      "SDF",
+      "distance-field",
+      "procedural-text",
+      "glyph",
+      "overlay",
+      "runes"
+    ],
+    "features": [
+      "SDF",
+      "procedural-text",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "glyph_scale",
+        "name": "Glyph Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glyph_width",
+        "name": "Glyph Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Glow Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "overlay",
+        "name": "Overlay Mix",
         "default": 0.7,
         "min": 0,
         "max": 1,
         "step": 0.01
       }
-    ]
+    ],
+    "target_rating": 4.5
   },
   {
-    "id": "gen-crystal-caverns",
-    "name": "Crystal Caverns",
-    "url": "shaders/gen-crystal-caverns.wgsl",
+    "id": "spec-quaternion-julia",
+    "name": "Quaternion Julia",
+    "url": "shaders/spec-quaternion-julia.wgsl",
     "category": "generative",
-    "description": "Infinite procedural cave system with glowing crystals featuring physical light transmission. Crystals have IOR-based Fresnel reflection and variable purity affecting their glow transparency.",
+    "description": "4D quaternion Julia set raymarched in real-time. The 4th dimension animates over time creating organic morphing fractal forms with orbit-trap coloring and physically-based lighting.",
     "tags": [
-      "crystal",
-      "cave",
-      "3d",
+      "quaternion",
+      "julia",
+      "fractal",
+      "4D",
       "raymarching",
-      "fantasy",
-      "glowing",
-      "stalactites",
-      "procedural",
+      "morphing"
+    ],
+    "features": [
+      "quaternion",
+      "4D",
+      "raymarched",
+      "mouse-driven",
+      "HDR"
+    ],
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Fractal Zoom",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "morph_speed",
+        "name": "Morph Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_cycles",
+        "name": "Color Cycles",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "detail",
+        "name": "Detail Level",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.9
+  },
+  {
+    "id": "stellar-plasma",
+    "name": "Stellar Plasma",
+    "url": "shaders/stellar-plasma.wgsl",
+    "category": "generative",
+    "description": "An endlessly morphing procedural cosmos powered by domain-warped fractional brownian motion. Creates swirling, liquid-like cosmic nebulae with interactive mouse gravity.",
+    "tags": [
       "generative",
-      "alpha-transmission",
+      "procedural",
+      "nebula",
+      "cosmic",
+      "plasma",
+      "fbm",
+      "fluid",
+      "loops",
+      "domain-warping",
       "audio",
       "music",
       "reactive"
     ],
     "features": [
       "mouse-driven",
-      "physical-transmission",
       "audio-reactive",
       "audio-driven"
     ],
-    "author": "ford442",
+    "author": "Gemini 3.1 Pro Vertex",
     "params": [
       {
-        "id": "scale",
-        "name": "Cave Scale",
-        "default": 0.25,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "Size of cave structures"
+        "id": "hueShift",
+        "name": "Hue Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "density",
-        "name": "Crystal Purity",
+        "id": "flowSpeed",
+        "name": "Flow Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "zoomScale",
+        "name": "Zoom / Scale",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "mouseGravity",
+        "name": "Mouse Gravity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "volumetric-cloud-nebula",
+    "name": "Volumetric Cloud Nebula",
+    "url": "shaders/volumetric-cloud-nebula.wgsl",
+    "category": "generative",
+    "description": "Raymarched volumetric clouds with nebula coloring. Features procedural cloud generation with FBM noise, dynamic color palettes, and animated camera movement through a cosmic nebula.",
+    "tags": [
+      "generative",
+      "nebula",
+      "clouds",
+      "volumetric",
+      "raymarch",
+      "space",
+      "cosmic",
+      "procedural"
+    ],
+    "features": [
+      "raymarched"
+    ],
+    "author": "Kimi",
+    "params": [
+      {
+        "id": "cloudDensity",
+        "name": "Cloud Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
-        "description": "Crystal clarity affecting transmission and glow"
+        "mapping": "zoom_params.x",
+        "description": "Density of the volumetric clouds"
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Shifts the nebula color palette"
+      },
+      {
+        "id": "cameraDistance",
+        "name": "Camera Distance",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Distance of camera from nebula center"
+      },
+      {
+        "id": "extinction",
+        "name": "Extinction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Light extinction coefficient in the nebula"
+      }
+    ]
+  },
+  {
+    "id": "wolfram-data-demo",
+    "name": "Wolfram Data Demo",
+    "url": "shaders/wolfram-data-demo.wgsl",
+    "category": "generative",
+    "description": "Demonstrates scientific constants and mathematical functions from Wolfram Alpha. Features phyllotaxis patterns, Airy disk diffraction, Fibonacci spirals, and atmospheric scattering using real physical data.",
+    "tags": [
+      "wolfram",
+      "scientific",
+      "mathematical",
+      "procedural",
+      "physics",
+      "golden-ratio",
+      "atmospheric",
+      "diffraction"
+    ],
+    "features": [
+      "procedural"
+    ],
+    "complexity": "high",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.25,
+        "labels": [
+          "Phyllotaxis",
+          "Airy Disk",
+          "Fibonacci",
+          "Atmosphere"
+        ]
+      },
+      {
+        "id": "param2",
+        "name": "Scale / Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Density / Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Temperature / Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "hybrid-cyber-organic",
+    "name": "Hybrid Cyber-Organic",
+    "url": "shaders/hybrid-cyber-organic.wgsl",
+    "category": "generative",
+    "description": "Digital circuit traces that grow organically with neon glow, combining hexagonal grid structures with cellular growth patterns",
+    "features": [
+      "hybrid",
+      "circuit-patterns",
+      "organic-growth",
+      "neon-glow",
+      "hex-grid",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "circuit_density",
+        "name": "Circuit Density",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of hexagonal circuit grid"
+      },
+      {
+        "id": "growth",
+        "name": "Organic Growth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Amount of organic growth over circuits"
       },
       {
         "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "name": "Neon Glow",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
-        "description": "Brightness of crystal glow"
+        "mapping": "zoom_params.z",
+        "description": "Glow intensity of active circuits"
       },
       {
-        "id": "fogDensity",
-        "name": "Fog Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0,
+        "id": "chaos",
+        "name": "Randomness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
-        "description": "Volumetric fog density"
+        "mapping": "zoom_params.w",
+        "description": "Chaos/randomness in growth patterns"
       }
-    ]
+    ],
+    "chunks_used": [
+      "hexEdgeDist (hex-circuit.wgsl)",
+      "fbm2 growth pattern (digital-moss.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
   },
   {
-    "id": "gen-neuro-kinetic-bloom",
-    "name": "Neuro-Kinetic Bloom",
-    "url": "shaders/gen-neuro-kinetic-bloom.wgsl",
+    "id": "hybrid-fractal-feedback",
+    "name": "Hybrid Fractal Feedback",
+    "url": "shaders/hybrid-fractal-feedback.wgsl",
     "category": "generative",
-    "description": "A vast, deep-sea garden of biomechanical, neon-veined flora that dynamically uncoils and pulses with quantum energy, its tendrils whipping and synchronizing to the rhythm of sound.",
-    "tags": [
-      "organic",
-      "biomechanical",
-      "audio-reactive",
-      "flora",
-      "raymarching",
-      "volumetric"
-    ],
+    "description": "Julia set fractal with feedback trails and per-channel temporal delay creating RGB separation trails",
     "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "bloomExtension",
-        "name": "Bloom Extension",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "repulsionRadius",
-        "name": "Repulsion Radius",
-        "default": 3.0,
-        "min": 0.0,
-        "max": 10.0,
-        "step": 0.1
-      },
-      {
-        "id": "veinGlow",
-        "name": "Vein Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0,
-        "step": 0.1
-      },
-      {
-        "id": "cameraZoom",
-        "name": "Camera Zoom",
-        "default": 0.0,
-        "min": -10.0,
-        "max": 10.0,
-        "step": 0.1
-      }
-    ]
-  },
-  {
-    "id": "gen-psychedelic-spiral",
-    "name": "Psychedelic Spiral",
-    "url": "shaders/gen_psychedelic_spiral.wgsl",
-    "category": "generative",
-    "description": "Hypnotic spiral with intense feedback and mouse warping.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "procedural",
-      "generative",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "plasma",
-    "name": "Plasma Ball",
-    "url": "shaders/plasma.wgsl",
-    "category": "generative",
-    "description": "",
-    "tags": [
-      "procedural",
-      "generative",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "audio-reactive",
-      "audio-driven",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "particle_dreams_alpha",
-    "name": "Particle Dreams RGBA",
-    "url": "shaders/particle_dreams_alpha.wgsl",
-    "category": "generative",
-    "description": "80+ particles with alpha-based lifetime, trail accumulation, birth/death fades. Alpha channel stores particle density for blending.",
-    "tags": [
-      "particles",
-      "alpha",
-      "trails",
-      "dreamy",
-      "generative"
-    ],
-    "features": [
-      "rgba",
-      "alpha-trails",
+      "hybrid",
+      "julia-set",
       "temporal-feedback",
-      "mouse-attraction",
+      "rgb-delay",
+      "fractal",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Zoom Level",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Fractal zoom level"
+      },
+      {
+        "id": "feedback",
+        "name": "Feedback Strength",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of temporal feedback trails"
+      },
+      {
+        "id": "rgb_delay",
+        "name": "RGB Channel Delay",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Temporal offset between RGB channels"
+      },
+      {
+        "id": "color_cycle",
+        "name": "Color Cycling",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Speed of palette color cycling"
+      }
+    ],
+    "chunks_used": [
+      "juliaIterate (julia-warp.wgsl)",
+      "fbm2 flow field (gen_grid.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "hybrid-magnetic-field",
+    "name": "Hybrid Magnetic Field",
+    "url": "shaders/hybrid-magnetic-field.wgsl",
+    "category": "generative",
+    "description": "Magnetic field line visualization with flowing particles and FBM-varied field distortion. Audio reactivity makes field lines pulse and glow with the beat.",
+    "features": [
+      "hybrid",
+      "vector-field",
+      "particle-trails",
+      "magnetic-distortion",
+      "glow",
+      "randomization-safe",
       "audio-reactive"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Particle Count",
+        "id": "field_strength",
+        "name": "Field Intensity",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Strength of magnetic dipole field"
       },
       {
-        "id": "param2",
+        "id": "line_density",
+        "name": "Line Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Number of field lines displayed"
+      },
+      {
+        "id": "trails",
         "name": "Trail Persistence",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "How long particle trails persist"
+      },
+      {
+        "id": "distortion",
+        "name": "Field Distortion",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "FBM noise influence on field"
+      }
+    ],
+    "tags": [
+      "audio",
+      "music",
+      "magnetic",
+      "field",
+      "particles",
+      "trails",
+      "glow"
+    ],
+    "chunks_used": [
+      "magnetic field calculation",
+      "fbm2 variation (gen_grid.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)",
+      "rot2 (kaleidoscope.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "hybrid-noise-kaleidoscope",
+    "name": "Hybrid Noise Kaleidoscope",
+    "url": "shaders/hybrid-noise-kaleidoscope.wgsl",
+    "category": "generative",
+    "description": "Domain-warped FBM noise fed through kaleidoscope symmetry with dynamic hue shifting and RGB channel splits",
+    "features": [
+      "hybrid",
+      "fbm-noise",
+      "kaleidoscope",
+      "chromatic-aberration",
+      "hue-shift",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "noise_scale",
+        "name": "Noise Scale",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Scale of the FBM noise pattern"
       },
       {
-        "id": "param3",
-        "name": "Color Shift",
+        "id": "segments",
+        "name": "Kaleidoscope Segments",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Number of mirror segments in kaleidoscope"
+      },
+      {
+        "id": "chromatic",
+        "name": "Chromatic Aberration",
         "default": 0.3,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "RGB channel separation amount"
       },
       {
-        "id": "param4",
-        "name": "Chaos",
-        "default": 0.2,
+        "id": "hue_speed",
+        "name": "Hue Shift Speed",
+        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Speed of color cycling"
       }
     ],
-    "target_rating": 4.7
+    "chunks_used": [
+      "fbm2 (gen_grid.wgsl)",
+      "kaleidoscope (kaleidoscope.wgsl)",
+      "hueShift (stellar-plasma.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
   },
   {
-    "id": "galaxy-sim",
-    "name": "Galaxy Simulation",
-    "url": "shaders/galaxy.wgsl",
+    "id": "hybrid-sdf-plasma",
+    "name": "Hybrid SDF Plasma Field",
+    "url": "shaders/hybrid-sdf-plasma.wgsl",
     "category": "generative",
-    "description": "Audio-reactive spiral galaxy with breathing arms, diffraction-spike stars, mouse-parallax center, and silence-driven reverse flow.",
+    "description": "Raymarched SDF scene with plasma noise displacement and dynamic palette-based coloring",
     "features": [
-      "depth-aware",
-      "upgraded-rgba",
-      "animated",
-      "audio-reactive",
-      "mouse-driven"
+      "hybrid",
+      "raymarching",
+      "sdf",
+      "plasma-noise",
+      "palette-cycling",
+      "randomization-safe"
     ],
+    "params": [
+      {
+        "id": "plasma_detail",
+        "name": "Plasma Detail",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Detail level of plasma noise displacement"
+      },
+      {
+        "id": "color_speed",
+        "name": "Color Cycle Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Speed of palette color cycling"
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Plasma glow strength"
+      },
+      {
+        "id": "quality",
+        "name": "Raymarch Quality",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Raymarching step count (affects performance)"
+      }
+    ],
+    "chunks_used": [
+      "sdSphere (gen-xeno-botanical-synth-flora.wgsl)",
+      "sdSmoothUnion (gen-xeno-botanical-synth-flora.wgsl)",
+      "fbm3 (gen-xeno-botanical-synth-flora.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "aurora_borealis",
+    "name": "Aurora Borealis",
+    "url": "shaders/aurora_borealis.wgsl",
+    "category": "generative",
+    "description": "Northern lights with flowing ribbon curves, curl noise turbulence, altitude-based coloring (green to red), and starfield background",
     "tags": [
-      "procedural",
-      "generative",
-      "galaxy",
-      "space",
-      "stars",
-      "spiral",
-      "audio-reactive",
-      "vj"
+      "aurora",
+      "northern-lights",
+      "atmospheric",
+      "nature",
+      "sky"
+    ],
+    "features": [
+      "rgba",
+      "aurora",
+      "curl-noise",
+      "ribbons",
+      "atmospheric"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Opacity",
-        "default": 0.85,
+        "name": "Ribbons",
+        "default": 0.4,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.1
       },
       {
         "id": "param2",
-        "name": "Arm Count",
+        "name": "Flow Speed",
         "default": 0.4,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.1
       },
       {
         "id": "param3",
-        "name": "Rotation Speed",
+        "name": "Ribbon Width",
         "default": 0.3,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.1
       },
       {
         "id": "param4",
-        "name": "Arm Spread",
-        "default": 0.4,
+        "name": "Glow",
+        "default": 0.7,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.1
       }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "cymatic-sand",
+    "name": "Cymatic Sand",
+    "description": "Simulates Chladni plate patterns where sand accumulates on nodal lines of standing waves. Mouse X/Y controls the frequency modes.",
+    "url": "shaders/cymatic-sand.wgsl",
+    "category": "generative",
+    "features": [
+      "mouse-driven",
+      "simulation",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "amount",
+        "name": "Sand Amount",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Line Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "grain",
+        "name": "Grain Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "procedural",
+      "generative",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "lichtenberg-fractal",
+    "name": "Lichtenberg Fractal",
+    "description": "Simulates high-voltage electrical branching patterns (Lichtenberg figures) that grow from the mouse cursor.",
+    "url": "shaders/lichtenberg-fractal.wgsl",
+    "category": "generative",
+    "features": [
+      "mouse-driven",
+      "simulation"
+    ],
+    "params": [
+      {
+        "id": "speed",
+        "name": "Growth Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "branching",
+        "name": "Branching Factor",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Burn Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "clear",
+        "name": "Clear Canvas",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "procedural",
+      "generative"
+    ]
+  },
+  {
+    "id": "predator-prey",
+    "name": "Pixel Ecology",
+    "url": "shaders/predator-prey.wgsl",
+    "category": "generative",
+    "description": "Cellular automata ecosystem with plants, herbivores, and carnivores - watch the food chain unfold.",
+    "params": [
+      {
+        "id": "eatProbability",
+        "name": "Eat Probability",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "deathRate",
+        "name": "Death Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mutationRate",
+        "name": "Mutation Rate",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "breedThreshold",
+        "name": "Breed Threshold",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "temporal-persistence",
+      "interactive",
+      "ecology",
+      "mouse-driven"
+    ],
+    "tags": [
+      "procedural",
+      "generative"
     ]
   }
 ]

--- a/public/shader-lists/geometric.json
+++ b/public/shader-lists/geometric.json
@@ -1,41 +1,44 @@
 [
   {
-    "id": "kaleido-scope",
-    "name": "Kaleido-Scope",
-    "url": "shaders/kaleido-scope.wgsl",
+    "id": "poincare-tile",
+    "name": "Hyperbolic Tiling",
+    "url": "shaders/poincare-tile.wgsl",
     "category": "geometric",
-    "features": [
-      "mouse-driven"
-    ],
+    "description": "Poincaré disk hyperbolic geometry with Möbius transformations and animated tilings.",
     "params": [
       {
-        "id": "segments",
-        "name": "Segments",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "id": "curvature",
+        "name": "Curvature",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "speed",
-        "name": "Rotation",
+        "id": "symmetry",
+        "name": "Symmetry",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "zoom",
-        "name": "Zoom",
+        "id": "animSpeed",
+        "name": "Animation Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "offset",
-        "name": "Ring Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "id": "tileScale",
+        "name": "Tile Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
+    ],
+    "features": [
+      "interactive",
+      "mathematical",
+      "mouse-driven"
     ],
     "tags": [
       "geometric",
@@ -43,89 +46,46 @@
     ]
   },
   {
-    "id": "kaleido-scope-grokcf1",
-    "name": "Kaleido-Scope Prism grokcf1",
-    "url": "shaders/kaleido-scope-grokcf1.wgsl",
+    "id": "voronoi-dynamics",
+    "name": "Voronoi Bubbles",
+    "url": "shaders/voronoi-dynamics.wgsl",
     "category": "geometric",
-    "description": "Enhanced kaleidoscope with prism dispersion, reflections, chromatic effects, and audio-reactive bass modulation.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
+    "description": "Dynamic Voronoi cells with bubble physics, iridescent edges, and interactive centroids.",
     "params": [
       {
-        "id": "segments",
-        "name": "Segments",
+        "id": "centroidCount",
+        "name": "Bubble Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "repulsion",
+        "name": "Repulsion",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "speed",
-        "name": "Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "attraction",
+        "name": "Attraction",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "zoom",
-        "name": "Zoom",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "offset",
-        "name": "Ring Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "id": "edgeWidth",
+        "name": "Edge Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
       }
     ],
-    "tags": [
-      "geometric",
-      "pattern",
-      "audio"
-    ]
-  },
-  {
-    "id": "neon-poly-grid",
-    "name": "Neon Poly Grid",
-    "url": "shaders/neon-poly-grid.wgsl",
-    "category": "geometric",
-    "description": "A futuristic hexagonal grid that lights up when you touch it, leaving a fading trail.",
     "features": [
+      "interactive",
+      "depth-aware",
+      "physics",
       "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "grid-scale",
-        "name": "Grid Scale",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "id": "line-width",
-        "name": "Line Width",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.2
-      },
-      {
-        "id": "glow-strength",
-        "name": "Glow Strength",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.8
-      },
-      {
-        "id": "decay-speed",
-        "name": "Trail Duration",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.8
-      }
     ],
     "tags": [
       "geometric",
@@ -133,159 +93,51 @@
     ]
   },
   {
-    "id": "spec-hypercube-projection",
-    "name": "Hypercube Projection",
-    "url": "shaders/spec-hypercube-projection.wgsl",
+    "id": "voronoi",
+    "name": "Voronoi Tessellation",
+    "url": "shaders/voronoi.wgsl",
     "category": "geometric",
-    "description": "Animated 4D tesseract projected into 2D using double rotation in XW and YZ planes. 32 edges are rendered with depth-based glow and input image texture-mapped onto faces.",
-    "tags": [
-      "hypercube",
-      "tesseract",
-      "4D",
-      "projection",
-      "geometric",
-      "rotation"
-    ],
-    "features": [
-      "4D",
-      "hypercube",
-      "mouse-driven",
-      "geometric"
-    ],
-    "params": [
-      {
-        "id": "rot_xw",
-        "name": "XW Rotation",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "rot_yz",
-        "name": "YZ Rotation",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "edge_glow",
-        "name": "Edge Glow",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "face_opacity",
-        "name": "Face Opacity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "adaptive-mosaic",
-    "url": "shaders/adaptive-mosaic.wgsl",
-    "category": "geometric",
+    "description": "Animated Voronoi reconstruction (simplified feature detection).",
     "features": [
       "mouse-driven"
-    ],
-    "description": "Dynamic pixelation that sharpens focus around your cursor while blurring the periphery into digital blocks.",
-    "params": [
-      {
-        "id": "minSize",
-        "name": "Focus Detail",
-        "type": "float",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "maxSize",
-        "name": "Bg Block Size",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Focus Radius",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gridContrast",
-        "name": "Grid Lines",
-        "type": "float",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
     ],
     "tags": [
       "geometric",
       "pattern"
     ],
-    "name": "Adaptive Mosaic"
-  },
-  {
-    "id": "quad-mirror",
-    "name": "Quad Mirror",
-    "url": "shaders/quad-mirror.wgsl",
-    "category": "geometric",
-    "description": "4-way kaleidoscope mirror with FBM domain warp at seam boundaries, animated rotation, and audio-reactive seam shimmer.",
     "params": [
       {
-        "id": "hOffset",
-        "name": "H Mirror Offset",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "vOffset",
-        "name": "V Mirror Offset",
+        "id": "param2",
+        "name": "Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "seamWarp",
-        "name": "Seam Warp",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "rotation",
-        "name": "Rotation",
+        "id": "param4",
+        "name": "Detail",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
-    ],
-    "features": [
-      "mouse-driven",
-      "geometry",
-      "upgraded-rgba",
-      "fbm-domain-warp",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "kaleidoscope",
-      "mirror",
-      "geometric",
-      "audio-reactive"
     ]
   },
   {
@@ -391,6 +243,243 @@
     "target_rating": 4.6
   },
   {
+    "id": "adaptive-mosaic",
+    "url": "shaders/adaptive-mosaic.wgsl",
+    "category": "geometric",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Dynamic pixelation that sharpens focus around your cursor while blurring the periphery into digital blocks.",
+    "params": [
+      {
+        "id": "minSize",
+        "name": "Focus Detail",
+        "type": "float",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "maxSize",
+        "name": "Bg Block Size",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Focus Radius",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gridContrast",
+        "name": "Grid Lines",
+        "type": "float",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "geometric",
+      "pattern"
+    ],
+    "name": "Adaptive Mosaic"
+  },
+  {
+    "id": "kaleido-scope-grokcf1",
+    "name": "Kaleido-Scope Prism grokcf1",
+    "url": "shaders/kaleido-scope-grokcf1.wgsl",
+    "category": "geometric",
+    "description": "Enhanced kaleidoscope with prism dispersion, reflections, chromatic effects, and audio-reactive bass modulation.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "segments",
+        "name": "Segments",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "zoom",
+        "name": "Zoom",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "offset",
+        "name": "Ring Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "geometric",
+      "pattern",
+      "audio"
+    ]
+  },
+  {
+    "id": "kaleido-scope",
+    "name": "Kaleido-Scope",
+    "url": "shaders/kaleido-scope.wgsl",
+    "category": "geometric",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "segments",
+        "name": "Segments",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "zoom",
+        "name": "Zoom",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "offset",
+        "name": "Ring Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "geometric",
+      "pattern"
+    ]
+  },
+  {
+    "id": "neon-poly-grid",
+    "name": "Neon Poly Grid",
+    "url": "shaders/neon-poly-grid.wgsl",
+    "category": "geometric",
+    "description": "A futuristic hexagonal grid that lights up when you touch it, leaving a fading trail.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "grid-scale",
+        "name": "Grid Scale",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "id": "line-width",
+        "name": "Line Width",
+        "min": 0,
+        "max": 1,
+        "default": 0.2
+      },
+      {
+        "id": "glow-strength",
+        "name": "Glow Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.8
+      },
+      {
+        "id": "decay-speed",
+        "name": "Trail Duration",
+        "min": 0,
+        "max": 1,
+        "default": 0.8
+      }
+    ],
+    "tags": [
+      "geometric",
+      "pattern"
+    ]
+  },
+  {
+    "id": "spec-hypercube-projection",
+    "name": "Hypercube Projection",
+    "url": "shaders/spec-hypercube-projection.wgsl",
+    "category": "geometric",
+    "description": "Animated 4D tesseract projected into 2D using double rotation in XW and YZ planes. 32 edges are rendered with depth-based glow and input image texture-mapped onto faces.",
+    "tags": [
+      "hypercube",
+      "tesseract",
+      "4D",
+      "projection",
+      "geometric",
+      "rotation"
+    ],
+    "features": [
+      "4D",
+      "hypercube",
+      "mouse-driven",
+      "geometric"
+    ],
+    "params": [
+      {
+        "id": "rot_xw",
+        "name": "XW Rotation",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "rot_yz",
+        "name": "YZ Rotation",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "edge_glow",
+        "name": "Edge Glow",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "face_opacity",
+        "name": "Face Opacity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
     "id": "tesseract-fold",
     "name": "Tesseract Fold",
     "url": "shaders/tesseract-fold.wgsl",
@@ -401,32 +490,32 @@
         "id": "param1",
         "name": "4D Rotation Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "param2",
         "name": "Projection Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "param3",
         "name": "Edge Glow Width",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "param4",
         "name": "Face Opacity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ],
@@ -447,144 +536,55 @@
     ]
   },
   {
-    "id": "voronoi",
-    "name": "Voronoi Tessellation",
-    "url": "shaders/voronoi.wgsl",
+    "id": "quad-mirror",
+    "name": "Quad Mirror",
+    "url": "shaders/quad-mirror.wgsl",
     "category": "geometric",
-    "description": "Animated Voronoi reconstruction (simplified feature detection).",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "geometric",
-      "pattern"
-    ],
+    "description": "4-way kaleidoscope mirror with FBM domain warp at seam boundaries, animated rotation, and audio-reactive seam shimmer.",
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "poincare-tile",
-    "name": "Hyperbolic Tiling",
-    "url": "shaders/poincare-tile.wgsl",
-    "category": "geometric",
-    "description": "Poincar\u00e9 disk hyperbolic geometry with M\u00f6bius transformations and animated tilings.",
-    "params": [
-      {
-        "id": "curvature",
-        "name": "Curvature",
-        "default": 0.7,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "symmetry",
-        "name": "Symmetry",
+        "id": "hOffset",
+        "name": "H Mirror Offset",
         "default": 0.5,
         "min": 0,
         "max": 1
       },
       {
-        "id": "animSpeed",
-        "name": "Animation Speed",
+        "id": "vOffset",
+        "name": "V Mirror Offset",
         "default": 0.5,
         "min": 0,
         "max": 1
       },
       {
-        "id": "tileScale",
-        "name": "Tile Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "interactive",
-      "mathematical",
-      "mouse-driven"
-    ],
-    "tags": [
-      "geometric",
-      "pattern"
-    ]
-  },
-  {
-    "id": "voronoi-dynamics",
-    "name": "Voronoi Bubbles",
-    "url": "shaders/voronoi-dynamics.wgsl",
-    "category": "geometric",
-    "description": "Dynamic Voronoi cells with bubble physics, iridescent edges, and interactive centroids.",
-    "params": [
-      {
-        "id": "centroidCount",
-        "name": "Bubble Count",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "repulsion",
-        "name": "Repulsion",
+        "id": "seamWarp",
+        "name": "Seam Warp",
         "default": 0.3,
         "min": 0,
         "max": 1
       },
       {
-        "id": "attraction",
-        "name": "Attraction",
-        "default": 0.2,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "edgeWidth",
-        "name": "Edge Width",
-        "default": 0.3,
+        "id": "rotation",
+        "name": "Rotation",
+        "default": 0.5,
         "min": 0,
         "max": 1
       }
     ],
     "features": [
-      "interactive",
-      "depth-aware",
-      "physics",
-      "mouse-driven"
+      "mouse-driven",
+      "geometry",
+      "upgraded-rgba",
+      "fbm-domain-warp",
+      "audio-reactive"
     ],
     "tags": [
+      "filter",
+      "image-processing",
+      "kaleidoscope",
+      "mirror",
       "geometric",
-      "pattern"
+      "audio-reactive"
     ]
   }
 ]

--- a/public/shader-lists/image.json
+++ b/public/shader-lists/image.json
@@ -1,503 +1,73 @@
 [
   {
-    "id": "neon-light",
-    "name": "Neon Light",
-    "url": "shaders/neon-light.wgsl",
+    "id": "ambient-liquid",
+    "name": "Ambient Liquid",
+    "url": "shaders/ambient-liquid.wgsl",
     "category": "image",
-    "description": "Neon glow and bloom effect.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "threshold",
-        "name": "Glow Threshold",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "saturation",
-        "name": "Color Boost",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "bloom",
-        "name": "Bloom Size",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
+    "description": "Gentle ambient liquid motion effects.",
     "features": [
-      "glow",
-      "neon",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
+      "mouse-driven"
     ],
     "tags": [
       "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "neon-pulse-edge",
-    "name": "Neon Pulse Edge",
-    "url": "shaders/neon-pulse-edge.wgsl",
-    "category": "image",
-    "description": "Edge detection with neon glow that reveals near the mouse.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
+      "image-processing"
     ],
     "params": [
       {
-        "id": "threshold",
-        "name": "Edge Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Glow Intensity",
+        "id": "viscosity",
+        "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
       },
       {
-        "id": "speed",
-        "name": "Pulse Speed",
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
       },
       {
-        "id": "shift",
+        "id": "color_shift",
         "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "dynamic-lens-flares",
-    "name": "Dynamic Lens Flares",
-    "url": "shaders/dynamic-lens-flares.wgsl",
-    "category": "image",
-    "description": "Cinematic lens flare following cursor. Generates ghost elements and chromatic artifacts.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Flare Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Brightness Filter",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spread",
-        "name": "Ghost Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ghost_count",
-        "name": "Ghost Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "optical",
-      "cinematic"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "lens-flare-brush",
-    "name": "Lens Flare Brush",
-    "url": "shaders/lens-flare-brush.wgsl",
-    "category": "image",
-    "description": "Generates anamorphic lens flares from bright pixels near the mouse.",
-    "params": [
-      {
-        "name": "Threshold",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.5,
-        "max": 1,
-        "id": "threshold"
-      },
-      {
-        "name": "Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "intensity"
-      },
-      {
-        "name": "Stretch",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "stretch"
-      },
-      {
-        "name": "Color Shift",
-        "type": "float",
-        "default": 0.2,
-        "min": 0,
-        "max": 1,
-        "id": "color_shift"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "divine-light",
-    "name": "Divine Light",
-    "url": "shaders/divine-light.wgsl",
-    "category": "image",
-    "description": "Volumetric god rays emanating from cursor position. Creates cinematic light beam effects.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Ray Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Ray Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "density",
-        "name": "Ray Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Brightness Filter",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "volumetric",
-      "atmospheric"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "flow-sort",
-    "name": "Streamline Pixel Sort",
-    "url": "shaders/flow-sort.wgsl",
-    "category": "image",
-    "description": "Pixel sorting along vector field lines derived from luminance gradients.",
-    "params": [
-      {
-        "id": "flowStrength",
-        "name": "Flow Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "sortPasses",
-        "name": "Sort Passes",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "strandPersist",
-        "name": "Trail Persistence",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "threshold",
-        "name": "Sort Threshold",
         "default": 0.3,
         "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "temporal-persistence",
-      "interactive",
-      "depth-aware",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "photonic-caustics",
-    "name": "Photonic Caustics",
-    "url": "shaders/photonic-caustics.wgsl",
-    "category": "image",
-    "description": "Light caustics simulation with chromatic dispersion, Fresnel reflections, and refractive surfaces.",
-    "params": [
-      {
-        "id": "ior",
-        "name": "Index of Refraction",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "lightSize",
-        "name": "Light Size",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "dispersion",
-        "name": "Chromatic Dispersion",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "chromatic-aberration",
-      "mouse-driven",
-      "advanced-alpha"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "alpha",
-      "luminance-key"
-    ]
-  },
-  {
-    "id": "wave-equation",
-    "name": "Wave Tank",
-    "url": "shaders/wave-equation.wgsl",
-    "category": "image",
-    "description": "2D wave equation simulation with ripple physics, refraction effects, and rainbow phase coloring.",
-    "params": [
-      {
-        "id": "waveSpeed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "sourceStrength",
-        "name": "Source Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "boundaryReflect",
-        "name": "Boundary Reflect",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "physics",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "split-flap-display",
-    "name": "Split Flap Display",
-    "url": "shaders/split-flap-display.wgsl",
-    "category": "image",
-    "features": [
-      "interactive",
-      "simulation",
-      "mouse-driven"
-    ],
-    "description": "Simulates a mechanical split-flap display where the image is made of rotating tiles.",
-    "params": [
-      {
-        "id": "rows",
-        "name": "Grid Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of the split-flap grid"
-      },
-      {
-        "id": "radius",
-        "name": "Mouse Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Radius of mouse interaction"
-      },
-      {
-        "id": "auto_speed",
-        "name": "Auto Flip Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Speed of automatic idle flipping"
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0.8,
-        "max": 0.99,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Physics damping for tile rotation"
+        "description": "Color manipulation amount"
       }
+    ]
+  },
+  {
+    "id": "astral-kaleidoscope-gemini",
+    "name": "Astral Kaleidoscope Gemini",
+    "url": "shaders/astral-kaleidoscope-gemini.wgsl",
+    "category": "image",
+    "description": "An enhanced cosmic kaleidoscope with astral color schemes, featuring dynamic, time-driven evolution and intricate, mouse-driven fractal details.",
+    "features": [
+      "mouse-driven",
+      "time-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ]
-  },
-  {
-    "id": "galaxy-compute",
-    "name": "Galaxy Compute",
-    "url": "shaders/galaxy-compute.wgsl",
-    "category": "image",
-    "description": "Volumetric spiral galaxy with logarithmic spiral SDF, procedural nebula clouds, Keplerian orbital mechanics, and stellar particle glow.",
-    "params": [
-      {
-        "id": "gravity",
-        "name": "Gravity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "particle_size",
-        "name": "Star Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pattern_opacity",
-        "name": "Pattern Opacity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "simulation",
-      "procedural",
-      "volumetric",
-      "spiral-galaxy"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-moss",
-    "name": "Digital Moss",
-    "category": "image",
-    "url": "shaders/digital-moss.wgsl",
-    "description": "Digital moss grows on dark areas. Use the mouse to clean it.",
-    "features": [
-      "mouse-driven"
     ],
     "params": [
       {
@@ -532,18 +102,63 @@
         "max": 1,
         "step": 0.01
       }
+    ]
+  },
+  {
+    "id": "astral-kaleidoscope-grokcf1",
+    "name": "Astral Kaleidoscope grokcf1",
+    "url": "shaders/astral-kaleidoscope-grokcf1.wgsl",
+    "category": "image",
+    "description": "An enhanced cosmic kaleidoscope with astral color schemes, featuring dynamic, time-driven evolution and intricate, mouse-driven fractal details.",
+    "features": [
+      "mouse-driven",
+      "time-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
     ]
   },
   {
-    "id": "ascii-glyph",
-    "name": "ASCII Glyphs",
-    "url": "shaders/ascii-glyph.wgsl",
+    "id": "astral-kaleidoscope",
+    "name": "Astral Kaleidoscope",
+    "url": "shaders/astral-kaleidoscope.wgsl",
     "category": "image",
-    "description": "ASCII / SDF glyph morphing and atlas-based rendering.",
+    "description": "Cosmic kaleidoscope with astral color schemes.",
     "features": [
       "mouse-driven"
     ],
@@ -587,6991 +202,484 @@
     ]
   },
   {
-    "id": "voronoi-zoom-turbulence",
-    "name": "Voronoi Zoom Turbulence",
-    "url": "shaders/voronoi-zoom-turbulence.wgsl",
+    "id": "astral-veins",
+    "name": "Astral Veins",
+    "url": "shaders/astral-veins.wgsl",
     "category": "image",
-    "description": "Divides the screen into Voronoi cells where each cell applies a chaotic, time-varying zoom. Mouse proximity calms or agitates the turbulence.",
-    "params": [
-      {
-        "name": "Cell Density",
-        "type": "float",
-        "default": 1,
-        "min": 1,
-        "max": 5,
-        "target": "zoom_params.x",
-        "id": "cell_density"
-      },
-      {
-        "name": "Turbulence Speed",
-        "type": "float",
-        "default": 1,
-        "min": 0,
-        "max": 3,
-        "target": "zoom_params.y",
-        "id": "turbulence_speed"
-      },
-      {
-        "name": "Zoom Intensity",
-        "type": "float",
-        "default": 1,
-        "min": 0,
-        "max": 2,
-        "target": "zoom_params.z",
-        "id": "zoom_intensity"
-      },
-      {
-        "name": "Mouse Influence",
-        "type": "float",
-        "default": 1,
-        "min": -1,
-        "max": 1,
-        "target": "zoom_params.w",
-        "id": "mouse_influence"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "hyperbolic-dreamweaver",
-    "name": "Hyperbolic Dreamweaver",
-    "url": "shaders/hyperbolic-dreamweaver.wgsl",
-    "category": "image",
-    "description": "Infinite non-Euclidean Poincar\u00e9 disk tilings weaving the image through psychedelic M\u00f6bius transformations, depth-aware curvature, chromatic aberration, and glowing symmetry lines. Mouse centers the dream; ripples perturb the fabric.",
-    "params": [
-      {
-        "name": "Tile Count",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "desc": "Number of hyperbolic tiles (3-9)",
-        "id": "tile_count"
-      },
-      {
-        "name": "Curvature",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "desc": "Hyperbolic bending strength (depth-modulated)",
-        "id": "curvature"
-      },
-      {
-        "name": "Aberration",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "desc": "Chromatic splitting in curved space",
-        "id": "aberration"
-      },
-      {
-        "name": "Glow Intensity",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.4,
-        "desc": "Symmetry line luminescence",
-        "id": "glow_intensity"
-      }
-    ],
-    "features": [
-      "geometric",
-      "psychedelic",
-      "depth-aware",
-      "non-euclidean",
-      "interactive",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "time-lag-map",
-    "name": "Time-Lag Map",
-    "url": "shaders/time-lag-map.wgsl",
-    "category": "image",
-    "description": "Per-pixel temporal delay creating echo, smear, and time-displacement effects.",
-    "params": [
-      {
-        "id": "bufferLength",
-        "name": "Delay Length",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "mappingFunction",
-        "name": "Delay Pattern",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "feedbackMix",
-        "name": "Feedback Mix",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "motionSense",
-        "name": "Motion Sensitivity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "temporal-persistence",
-      "interactive",
-      "motion-detection",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-origami",
-    "name": "Interactive Origami",
-    "url": "shaders/interactive-origami.wgsl",
-    "category": "image",
-    "description": "Simulates folded paper creases that react to mouse position.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "foldScale",
-        "name": "Fold Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "foldDepth",
-        "name": "Fold Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "lightIntensity",
-        "name": "Light Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "unused",
-        "name": "Unused",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "kinetic-tiles",
-    "name": "Kinetic Tiles",
-    "category": "image",
-    "url": "shaders/kinetic_tiles.wgsl",
-    "description": "Grid of tiles that rotate and scale responsively to mouse proximity.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Grid Density",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Mouse Radius",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation Amt",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scale",
-        "name": "Tile Scale",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "datamosh",
-    "name": "Datamosh",
-    "url": "shaders/datamosh.wgsl",
-    "category": "image",
-    "description": "True video compression datamoshing with I/P-frame simulation, motion vector prediction, and authentic macroblock smearing artifacts.",
-    "features": [
-      "mouse-driven",
-      "multi-pass"
-    ],
-    "tags": [
-      "datamosh",
-      "glitch",
-      "compression",
-      "motion-vectors",
-      "retro",
-      "video-artifacts",
-      "smear",
-      "trail"
-    ],
-    "params": [
-      {
-        "id": "motion_strength",
-        "name": "Motion Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "Strength of motion vector displacement (creates smearing trails)"
-      },
-      {
-        "id": "iframe_interval",
-        "name": "I-Frame Interval",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "Time between full frame refreshes (0=often, 1=rarely)"
-      },
-      {
-        "id": "blend_amount",
-        "name": "Smear Blend",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "How much displaced pixels blend with current frame"
-      },
-      {
-        "id": "feedback_decay",
-        "name": "Trail Decay",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "description": "How long motion trails persist (higher=longer trails)"
-      }
-    ]
-  },
-  {
-    "id": "flip-matrix",
-    "name": "Flip Matrix",
-    "category": "image",
-    "url": "shaders/flip-matrix.wgsl",
-    "description": "Grid of tiles that flip vertically in pseudo-3D based on mouse proximity.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Grid Density",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Flip Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gap",
-        "name": "Tile Gap",
-        "type": "float",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixelation-drift",
-    "name": "Pixelation Drift",
-    "url": "shaders/pixelation-drift.wgsl",
-    "category": "image",
-    "description": "Dynamic pixelated mosaic with organic drifting motion and depth-aware pixel sizing. Watch as chunky pixels slowly morph and flow across the image.",
-    "params": [
-      {
-        "id": "pixelSize",
-        "name": "Pixel Size",
-        "default": 0.15,
-        "min": 0.01,
-        "max": 1.0
-      },
-      {
-        "id": "driftSpeed",
-        "name": "Drift Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorBleed",
-        "name": "Color Bleed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "depthInfluence",
-        "name": "Depth Influence",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "organic-motion",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-decay",
-    "name": "Digital Decay",
-    "url": "shaders/digital-decay.wgsl",
-    "category": "image",
-    "description": "",
-    "params": [
-      {
-        "id": "decayIntensity",
-        "name": "Decay Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "blockSize",
-        "name": "Block Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "corruptionSpeed",
-        "name": "Corruption Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "depthFocus",
-        "name": "Depth Focus",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "vhs-tracking",
-    "name": "VHS Tracking Error",
-    "url": "shaders/vhs-tracking.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Simulates VCR tracking errors with scanline tearing and chromatic aberration.",
-    "params": [
-      {
-        "name": "Tracking Error",
-        "id": "zoomParam1",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Noise Level",
-        "id": "zoomParam2",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Color Drift",
-        "id": "zoomParam3",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Scanlines",
-        "id": "zoomParam4",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-glitch-pass1",
-    "name": "Digital Glitch (Pass 1)",
-    "url": "shaders/digital-glitch-pass1.wgsl",
-    "category": "image",
-    "description": "Glitch field generation: block displacement, scanline tearing, bitwise corruption seeds, and per-pixel corruption masks. Outputs glitch field to dataTextureA.",
-    "tags": [
-      "glitch",
-      "bitwise",
-      "corruption",
-      "multi-pass",
-      "digital"
-    ],
-    "features": [
-      "multi-pass-1",
-      "mouse-driven"
-    ],
-    "multipass": {
-      "pass": 1,
-      "totalPasses": 2,
-      "nextShader": "digital-glitch-pass2"
-    },
-    "params": [
-      {
-        "id": "corruption_intensity",
-        "name": "Corruption Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "bit_manipulation",
-        "name": "Bit Manipulation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "error_propagation",
-        "name": "Error Propagation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "decay_rate",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "scan-distort",
-    "name": "Scan Distort",
-    "url": "shaders/scan-distort.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "block_size",
-        "name": "Block Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Size of distortion blocks"
-      },
-      {
-        "id": "quant_level",
-        "name": "Quantization Levels",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Color quantization levels"
-      },
-      {
-        "id": "mv_visibility",
-        "name": "MV Visibility",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Motion vector visibility"
-      },
-      {
-        "id": "glitch_freq",
-        "name": "Glitch Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Frequency of glitch pulses"
-      }
-    ]
-  },
-  {
-    "id": "neon-edges",
-    "name": "Neon Edges",
-    "url": "shaders/neon-edges.wgsl",
-    "category": "image",
-    "description": "",
-    "params": [
-      {
-        "id": "min_speed",
-        "name": "Min Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Minimum layer animation speed"
-      },
-      {
-        "id": "max_speed",
-        "name": "Max Speed",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Maximum layer animation speed"
-      },
-      {
-        "id": "edge_threshold",
-        "name": "Edge Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Edge detection threshold"
-      },
-      {
-        "id": "neon_intensity",
-        "name": "Neon Intensity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Intensity of the neon glow effect"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "audio-reactive",
-      "audio-driven",
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "pixel-rain",
-    "name": "Pixel Rain",
-    "url": "shaders/pixel-rain.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Matrix-style digital rain. Mouse repels and highlights drops.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Rain Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch / Tint",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "trail_fade",
-        "name": "Trail Fade",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Trail persistence/fade rate"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-glitch",
-    "name": "Digital Glitch",
-    "url": "shaders/digital-glitch.wgsl",
-    "category": "image",
-    "description": "",
-    "params": [
-      {
-        "id": "corruption_intensity",
-        "name": "Corruption Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Intensity of digital corruption effects"
-      },
-      {
-        "id": "bit_manipulation",
-        "name": "Bit Manipulation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Type and amount of bitwise corruption"
-      },
-      {
-        "id": "error_propagation",
-        "name": "Error Propagation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Spread of corruption to neighboring pixels"
-      },
-      {
-        "id": "decay_rate",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Rate of digital bit-depth decay"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "spectrum-bleed",
-    "name": "Spectrum Bleed",
-    "url": "shaders/spectrum-bleed.wgsl",
-    "category": "image",
-    "description": "Color channel separation and bleeding effects.",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "datamosh-brush",
-    "name": "Datamosh Brush",
-    "url": "shaders/datamosh-brush.wgsl",
-    "category": "image",
-    "description": "Interactive datamosh effect. Mouse drags and corrupts pixels like P-frame compression artifacts.",
-    "params": [
-      {
-        "id": "brush_size",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "block_size",
-        "name": "Block Crush",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Effect Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "stateful"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "byte-mosh",
-    "name": "Byte-Mosh Glitch",
-    "url": "shaders/byte-mosh.wgsl",
-    "category": "image",
-    "description": "Bitwise XOR, AND, shift, and rotate operations creating digital corruption effects.",
-    "params": [
-      {
-        "id": "operationMix",
-        "name": "Operation Mix",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "bitShift",
-        "name": "Bit Shift",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "errorRate",
-        "name": "Error Rate",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "blockSize",
-        "name": "Block Size",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "interactive",
-      "chromatic-aberration",
-      "glitch",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "rgb-glitch-trail",
-    "name": "RGB Glitch Trail",
-    "url": "shaders/rgb-glitch-trail.wgsl",
-    "category": "image",
-    "description": "Mouse leaves chromatic aberration trails. Creates retro TV glitch artifacts with RGB split.",
-    "params": [
-      {
-        "id": "decay_rate",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift_strength",
-        "name": "RGB Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos / Noise",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic",
-      "trail",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-waves",
-    "name": "Digital Waves",
-    "url": "shaders/digital-waves.wgsl",
-    "category": "image",
-    "description": "Digital wave interference patterns.",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "digital-glitch-pass2",
-    "name": "Digital Glitch (Pass 2)",
-    "url": "shaders/digital-glitch-pass2.wgsl",
-    "category": "image",
-    "description": "Error propagation and compositing pass: neighbor error spreading, digital decay with bit-depth reduction, chromatic aberration, scanline artifacts, and block inversion. Reads glitch field from dataTextureC.",
-    "tags": [
-      "glitch",
-      "decay",
-      "chromatic-aberration",
-      "multi-pass"
-    ],
-    "features": [
-      "multi-pass-2",
-      "mouse-driven"
-    ],
-    "multipass": {
-      "pass": 2,
-      "totalPasses": 2
-    },
-    "params": [
-      {
-        "id": "corruption_intensity",
-        "name": "Corruption Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "bit_manipulation",
-        "name": "Bit Manipulation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "error_propagation",
-        "name": "Error Propagation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "decay_rate",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "holographic-glitch",
-    "name": "Holographic Glitch",
-    "url": "shaders/holographic-glitch.wgsl",
-    "category": "image",
-    "description": "Futuristic holographic projection with RGB chromatic aberration, scanlines, digital artifacts, and unstable flickering. Perfect for sci-fi aesthetics.",
-    "params": [
-      {
-        "id": "glitchIntensity",
-        "name": "Glitch Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scanlineSpeed",
-        "name": "Scanline Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rgbShift",
-        "name": "RGB Shift",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "flicker",
-        "name": "Flicker",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "chromatic-aberration",
-      "sci-fi",
-      "audio-reactive",
-      "audio-driven",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "cyber-terminal-ascii",
-    "name": "Cyber Terminal ASCII",
-    "category": "image",
-    "url": "shaders/cyber-terminal-ascii.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Grid Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of the ASCII character grid"
-      },
-      {
-        "id": "color_mode",
-        "name": "Color Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Blend between monochrome and full color"
-      },
-      {
-        "id": "glow_strength",
-        "name": "Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Glow strength of the ASCII characters"
-      },
-      {
-        "id": "decoder_radius",
-        "name": "Decoder Radius",
-        "default": 0.3,
-        "min": 0.05,
-        "max": 0.4,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Radius of the binary decoder lens around the mouse"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "vinyl-scratch",
-    "name": "Vinyl Scratch",
-    "url": "shaders/vinyl-scratch.wgsl",
-    "category": "image",
-    "description": "Vintage vinyl record scratch effect.",
-    "params": [
-      {
-        "id": "scratch_density",
-        "name": "Scratch Amount",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "dust",
-        "name": "Dust Particles",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "warping",
-        "name": "Record Warp",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "sepia",
-        "name": "Vintage Tone",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "retro",
-      "texture",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "magnetic-ring",
-    "category": "image",
-    "url": "shaders/magnetic-ring.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "base_radius",
-        "name": "Base Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Base radius of the magnetic ring"
-      },
-      {
-        "id": "strength",
-        "name": "Distortion Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Strength of the distortion effect"
-      },
-      {
-        "id": "pulse_speed",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Speed of the ring pulse animation"
-      },
-      {
-        "id": "ring_thickness",
-        "name": "Ring Thickness",
-        "default": 0.3,
-        "min": 0.01,
-        "max": 0.3,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Thickness of the magnetic ring"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Magnetic Ring"
-  },
-  {
-    "id": "tile-twist",
-    "name": "Tile Twist",
-    "url": "shaders/tile-twist.wgsl",
-    "category": "image",
-    "description": "Grid tiles twist and rotate based on mouse proximity, enhanced with FBM domain warping, hash-jittered organic tiling, and SDF edge masking.",
-    "params": [
-      {
-        "id": "tileSize",
-        "name": "Tile Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "twist",
-        "name": "Twist Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Influence Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge_smoothness",
-        "name": "Edge Smoothness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "SDF edge softness for tile boundary alpha mask"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "geometry",
-      "temporal",
-      "upgraded-rgba",
-      "audio-reactive",
-      "depth-aware"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "organic",
-      "abstract"
-    ]
-  },
-  {
-    "id": "night-vision-scope",
-    "name": "Night Vision Scope",
-    "url": "shaders/night-vision-scope.wgsl",
-    "category": "image",
-    "description": "Simulates a night vision intensifier tube with a high-clarity scope area following the mouse.",
-    "params": [
-      {
-        "id": "scopeSize",
-        "name": "Scope Size",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0
-      },
-      {
-        "id": "grainAmount",
-        "name": "Noise Grain",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "brightness",
-        "name": "Brightness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "scanlineStrength",
-        "name": "Scanlines",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "image"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "bubble-wrap",
-    "name": "Bubble Wrap",
-    "url": "shaders/bubble-wrap.wgsl",
-    "category": "image",
-    "description": "Interactive bubble wrap that you can pop with your mouse. Popped bubbles stay popped!",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Bubble Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "popStrength",
-        "name": "Pop Strength",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "unused",
-        "name": "Unused",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "charcoal-rub",
-    "name": "Charcoal Rub",
-    "url": "shaders/charcoal-rub.wgsl",
-    "category": "image",
-    "description": "Scratch-off effect like rubbing charcoal paper. Mouse reveals image beneath textured overlay.",
-    "params": [
-      {
-        "id": "hardness",
-        "name": "Edge Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "texture_scale",
-        "name": "Paper Texture",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "reveal_rate",
-        "name": "Rub Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fade_speed",
-        "name": "Fade Back",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "interactive",
-      "stateful"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "hex-pulse",
-    "name": "Hex Pulse",
-    "url": "shaders/hex-pulse.wgsl",
-    "category": "image",
-    "description": "Hexagonal pixelation that pulses in size based on proximity to the mouse cursor.",
-    "params": [
-      {
-        "id": "baseSize",
-        "name": "Base Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulseStrength",
-        "name": "Pulse Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "fabric-zipper",
-    "name": "Fabric Zipper",
-    "url": "shaders/fabric-zipper.wgsl",
-    "category": "image",
-    "description": "Unzip the canvas to reveal the underlying image. Drag the mouse vertically to control the zipper.",
-    "params": [
-      {
-        "id": "teeth_density",
-        "name": "Teeth Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of zipper teeth"
-      },
-      {
-        "id": "spread",
-        "name": "Opening Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Width of the zipper opening"
-      },
-      {
-        "id": "weave_freq",
-        "name": "Weave Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Frequency of the fabric weave pattern"
-      },
-      {
-        "id": "jaggedness",
-        "name": "Tooth Jaggedness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Amplitude of tooth jaggedness"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "paper-cutout",
-    "name": "Paper Cutout",
-    "url": "shaders/paper-cutout.wgsl",
-    "category": "image",
-    "description": "Quantizes the image into paper layers with drop shadows controlled by the mouse.",
-    "params": [
-      {
-        "id": "layers",
-        "name": "Layers",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shadowDist",
-        "name": "Shadow Dist",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Softness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "separation",
-        "name": "Separation",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-warp",
-    "name": "Neon Warp",
-    "url": "shaders/neon-warp.wgsl",
-    "category": "image",
-    "description": "Mouse movement warps the image fabric, revealing neon edges and glowing trails.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "neon",
-        "name": "Neon Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Color Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Warp Decay",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "particle-swarm",
-    "name": "Particle Swarm",
-    "url": "shaders/particle-swarm.wgsl",
-    "category": "image",
-    "description": "Pixels behave like a swarm of particles attracted to the mouse, with spring physics returning them to their origin.",
-    "params": [
-      {
-        "id": "stiffness",
-        "name": "Spring Stiffness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "force",
-        "name": "Mouse Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Interact Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "physics"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "oscilloscope-overlay",
-    "name": "Oscilloscope Overlay",
-    "url": "shaders/oscilloscope-overlay.wgsl",
-    "category": "image",
-    "description": "Overlays a real-time luminance waveform of the image scanline at the mouse cursor's vertical position.",
-    "params": [
-      {
-        "id": "amplitude",
-        "name": "Amplitude",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "thickness",
-        "name": "Line Thickness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "opacity",
-        "name": "Wave Opacity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scan_alpha",
-        "name": "Scanline Alpha",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "overlay"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "sphere-projection",
-    "name": "Sphere Projection",
-    "url": "shaders/sphere-projection.wgsl",
-    "category": "image",
-    "description": "Projects the image onto a 3D sphere that can be rotated with the mouse.",
-    "features": [
-      "mouse-driven",
-      "3d"
-    ],
-    "params": [
-      {
-        "id": "zoom",
-        "name": "Sphere Zoom",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Zoom level of the sphere projection"
-      },
-      {
-        "id": "rotation",
-        "name": "Spin Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Auto-rotation speed of the sphere"
-      },
-      {
-        "id": "light",
-        "name": "Lighting",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Amount of directional lighting"
-      },
-      {
-        "id": "ambient",
-        "name": "Ambient Light",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 0.6,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Ambient light level on the sphere"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "moire-interference",
-    "label": "Moir\u00e9 Interference",
-    "name": "Moir\u00e9 Interference",
-    "url": "shaders/moire-interference.wgsl",
-    "category": "image",
-    "icon": "wifi",
-    "description": "Generates dynamic interference patterns between the center and the mouse position.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "name": "Frequency",
-        "id": "x",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "name": "Distortion",
-        "id": "y",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "name": "Aberration",
-        "id": "z",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.2
-      },
-      {
-        "name": "Complexity",
-        "id": "w",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "voronoi-glass",
-    "name": "Voronoi Glass",
-    "url": "shaders/voronoi-glass.wgsl",
-    "category": "image",
-    "description": "Refractive glass cells based on Voronoi patterns that shift with the mouse.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Cell Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refract",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "border",
-        "name": "Border Width",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "attract",
-        "name": "Mouse Attract",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "geometry",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "rgb-fluid",
-    "name": "RGB Fluidity",
-    "url": "shaders/rgb-fluid.wgsl",
-    "category": "image",
-    "description": "Image behaves like a fluid, stirred by the mouse cursor.",
+    "description": "Glowing, flowing veins that wrap around geometry, pulse, and colour‑cycle. Click to seed new veins.",
     "params": [
       {
         "id": "speed",
         "name": "Flow Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "force",
-        "name": "Mouse Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "magnetic-rgb",
-    "name": "Magnetic RGB",
-    "category": "image",
-    "url": "shaders/magnetic-rgb.wgsl",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Strength",
-        "default": 0.5,
         "min": 0,
         "max": 1
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "swirl",
-        "name": "Swirl",
-        "default": 0.4,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "motion-heatmap",
-    "name": "Motion Heatmap",
-    "url": "shaders/motion-heatmap.wgsl",
-    "category": "image",
-    "description": "Visualizes video motion and mouse interaction as a heatmap.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Heat Decay",
-        "default": 0.05,
-        "min": 0.001,
-        "max": 0.3
-      },
-      {
-        "id": "sensitivity",
-        "name": "Motion Sens.",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 10.0
-      },
-      {
-        "id": "mouse_heat",
-        "name": "Mouse Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "velvet-vortex",
-    "name": "Velvet Vortex",
-    "url": "shaders/velvet-vortex.wgsl",
-    "category": "image",
-    "description": "A spiraling, velvety distortion that swirls video content around the mouse cursor.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Vortex Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "strength",
-        "name": "Swirl Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulse",
-        "name": "Pulse Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "data-stream-corruption",
-    "name": "Data Stream Corruption",
-    "url": "shaders/data-stream-corruption.wgsl",
-    "category": "image",
-    "description": "Vertical data streams fall like rain; your mouse leaves a trail of corrupted code blocks.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Stream Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "brush",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Glitch Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "persistence",
-        "name": "Persistence",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "glitch"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-reveal",
-    "name": "Digital Rain Reveal",
-    "url": "shaders/digital-reveal.wgsl",
-    "category": "image",
-    "description": "Hides the image behind digital rain; move the mouse to reveal the content.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Rain Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "size",
-        "name": "Reveal Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fade",
-        "name": "Trail Fade",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Rain Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "artistic"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "prismatic-feedback-loop",
-    "name": "Prismatic Feedback Loop (Pass 2)",
-    "url": "shaders/prismatic-feedback-loop.wgsl",
-    "category": "image",
-    "description": "Consumes displacement from Pass 1 to create chromatic aberration, temporal feedback, and glowing halos.",
-    "params": [
-      {
-        "id": "feedbackAmount",
-        "name": "Feedback",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "blurRadius",
-        "name": "Blur Radius",
-        "default": 1,
-        "min": 0,
-        "max": 10
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 0.8,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "chromaticSpread",
-        "name": "Chromatic Spread",
-        "default": 0.02,
-        "min": 0,
-        "max": 0.2
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "feedback",
-      "chromatic",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "strip-scan-glitch",
-    "name": "Strip Scan Glitch",
-    "url": "shaders/strip-scan-glitch.wgsl",
-    "category": "image",
-    "description": "Slices the image into vertical strips that drift and jitter, controlled by mouse position.",
-    "params": [
-      {
-        "id": "strips",
-        "name": "Strip Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Scroll Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "jitter",
-        "name": "Glitch Jitter",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rgb",
-        "name": "RGB Split",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "hypnotic-spiral",
-    "name": "Hypnotic Spiral",
-    "url": "shaders/hypnotic-spiral.wgsl",
-    "category": "image",
-    "description": "Breathing, rotating spirals with color cycling; mouse warps and twists the spiral geometry.",
-    "params": [
-      {
-        "id": "arms",
-        "name": "Arms",
-        "default": 3,
-        "min": 1,
-        "max": 12
-      },
-      {
-        "id": "rotationSpeed",
-        "name": "Rotation Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "colorCycle",
-        "name": "Color Cycle",
-        "default": 0.2,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "warpIntensity",
-        "name": "Warp",
-        "default": 0.5,
-        "min": 0,
-        "max": 2
-      }
-    ],
-    "features": [
-      "interactive",
-      "spiral",
-      "visual",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "light-leaks",
-    "name": "Light Leaks",
-    "url": "shaders/light-leaks.wgsl",
-    "category": "image",
-    "description": "Simulates film light leaks. Move the mouse to change the light source angle.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "warmth",
-        "name": "Warmth",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "size",
-        "name": "Leak Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Drift Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "overlay"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "venetian-blinds",
-    "name": "Venetian Blinds",
-    "url": "shaders/venetian-blinds.wgsl",
-    "category": "image",
-    "description": "Interactive venetian blinds effect. Mouse Y controls the openness of the slats.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Slat Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "openness",
-        "name": "Base Openness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color",
-        "name": "Slat Brightness",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "phase",
-        "name": "Phase Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "rgb-shift-brush",
-    "name": "RGB Shift Brush",
-    "url": "shaders/rgb-shift-brush.wgsl",
-    "category": "image",
-    "description": "Paint with RGB channel separation trails using the mouse.",
-    "params": [
-      {
-        "id": "shift",
-        "name": "Shift Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "size",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hue",
-        "name": "Hue Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-volumetric-zoom",
-    "name": "Liquid Volumetric Zoom",
-    "url": "shaders/liquid-volumetric-zoom.wgsl",
-    "category": "image",
-    "description": "Unified 3D fluid zoom that merges parallax, vortex dynamics, plasma flow and chromatic aberration into a single volumetric zoom.",
-    "params": [
-      {
-        "id": "fg_speed",
-        "name": "Foreground Speed",
-        "default": 1,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "bg_speed",
-        "name": "Background Speed",
-        "default": 0.8,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "parallax",
-        "name": "Parallax",
-        "default": 0.5,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "fog_density",
-        "name": "Fog Density",
-        "default": 0.6,
-        "min": 0,
-        "max": 4
-      }
-    ],
-    "features": [
-      "volumetric",
-      "raymarched",
-      "depth",
-      "fluid",
-      "single-pass-multilayer",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-pixel-wind",
-    "name": "Pixel Wind",
-    "url": "shaders/interactive-pixel-wind.wgsl",
-    "category": "image",
-    "description": "Wind effect driven by cursor direction.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Wind Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "trails",
-        "name": "Trail Length",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 0.99
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "feedback"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "spectral-smear",
-    "name": "Spectral Smear",
-    "url": "shaders/spectral-smear.wgsl",
-    "category": "image",
-    "description": "Leaves a colorful spectral trail that follows the mouse.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Brush Radius",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "speed",
-        "name": "Color Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "history"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-cursor-trace",
-    "name": "Particle Physics Trace",
-    "url": "shaders/neon-cursor-trace.wgsl",
-    "category": "image",
-    "description": "Spring-mass cursor physics with persistent phosphor trails, electric arc jitter, audio-reactive particle spawning, and multi-point neon glow along a velocity-smoothed trajectory.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Trace Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Trace Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spring",
-        "name": "Spring Stiffness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Electric Chaos",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "audio-reactive",
-      "spring-physics",
-      "phosphor-decay",
-      "electric-arc",
-      "multi-point-trail",
-      "particle-spawn",
-      "velocity-smear",
-      "ripple-spark"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive",
-      "neon",
-      "particles",
-      "physics"
-    ]
-  },
-  {
-    "id": "voronoi-shatter",
-    "name": "Voronoi Shatter",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Shard Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "force",
-        "name": "Shatter Force",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gaps",
-        "name": "Shard Gaps",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "url": "shaders/voronoi-shatter.wgsl",
-    "description": "Breaks the image into crystalline shards that react to mouse movement.",
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "gravity-lens",
-    "name": "Gravity Lens",
-    "category": "image",
-    "url": "shaders/gravity-lens.wgsl",
-    "params": [
-      {
-        "id": "mass",
-        "name": "Mass",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "horizon",
-        "name": "Horizon",
-        "default": 0.2,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "accretion",
-        "name": "Accretion",
-        "default": 0.8,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "lighthouse-reveal",
-    "name": "Lighthouse Reveal",
-    "url": "shaders/lighthouse-reveal.wgsl",
-    "category": "image",
-    "description": "A rotating beam of light that reveals the image, emanating from the mouse position.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "radius",
-        "name": "Beam Length",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.5
-      },
-      {
-        "id": "width",
-        "name": "Beam Width",
-        "default": 0.2,
-        "min": 0.05,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "ambient",
-        "name": "Ambient Light",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "interactive-film-burn",
-    "name": "Film Burn",
-    "url": "shaders/interactive-film-burn.wgsl",
-    "category": "image",
-    "description": "Simulates burning film reel with organic edges and grain, centered on the cursor.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Burn Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Burn Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "grain",
-        "name": "Grain Strength",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glow",
-        "name": "Edge Glow",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "noise",
-      "texture"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-lens",
-    "name": "Liquid Lens",
-    "url": "shaders/liquid-lens.wgsl",
-    "category": "image",
-    "description": "Simulates a magnifying liquid lens at the mouse position with chromatic aberration.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "abberation",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge",
-        "name": "Edge Shade",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "thermal-touch",
-    "name": "Thermal Touch",
-    "url": "shaders/thermal-touch.wgsl",
-    "category": "image",
-    "description": "False-color thermal vision where the mouse acts as a heat source.",
-    "params": [
-      {
-        "id": "heatIntensity",
-        "name": "Heat Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ambientTemp",
-        "name": "Ambient Temp",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorMode",
-        "name": "Color Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "crystal-freeze",
-    "name": "Crystal Freeze",
-    "url": "shaders/crystal-freeze.wgsl",
-    "category": "image",
-    "description": "Mouse freezes the image into growing ice crystals with physical light transmission. Features Voronoi-based crystal cells with Fresnel reflection, path absorption, and purity-based scattering.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Freeze Decay",
-        "default": 0.99,
-        "min": 0.9,
-        "max": 0.999,
-        "description": "How long frozen crystals persist"
-      },
-      {
-        "id": "scale",
-        "name": "Crystal Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Size of crystal cells"
-      },
-      {
-        "id": "refraction",
-        "name": "Material IOR",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Refractive index: Ice (1.31) to Glass (1.5)"
-      },
-      {
-        "id": "purity",
-        "name": "Ice Purity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Crystal clarity: Pure ice transmits more light, cloudy ice scatters more"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "alpha-transmission",
-      "persistence"
-    ],
-    "tags": [
-      "crystal",
-      "ice",
-      "freeze",
-      "transmission",
-      "voronoi",
-      "physical"
-    ]
-  },
-  {
-    "id": "interactive-voronoi-lens",
-    "name": "Interactive Voronoi Lens",
-    "url": "shaders/interactive-voronoi-lens.wgsl",
-    "category": "image",
-    "description": "Breaks the image into Voronoi cells that act as lenses. Mouse proximity intensifies the effect.",
-    "params": [
-      {
-        "id": "cell_density",
-        "name": "Cell Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of Voronoi cells"
-      },
-      {
-        "id": "lens_strength",
-        "name": "Lens Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Strength of the lens distortion"
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Randomness of cell point movement"
-      },
-      {
-        "id": "lens_curve",
-        "name": "Lens Curve",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Curvature of the lens bulge effect"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "scanline-sorting",
-    "name": "Scanline Sorting",
-    "url": "shaders/scanline-sorting.wgsl",
-    "category": "image",
-    "description": "Sorts pixels by luminance within a moving scanline band controlled by the mouse. Reacts to audio bass for intensified sorting.",
-    "params": [
-      {
-        "id": "thresh",
-        "name": "Sort Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Scan Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Auto Speed",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dir",
-        "name": "Dir (H/V)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "labels": [
-          "Horizontal",
-          "Vertical"
-        ]
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "sorting",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "matrix-curtain",
-    "name": "Matrix Curtain",
-    "url": "shaders/matrix-curtain.wgsl",
-    "category": "image",
-    "description": "Digital rain streams that part horizontally based on mouse position.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Rain Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "density",
-        "name": "Column Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Curtain Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitchiness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-glitch",
-    "name": "Interactive Glitch",
-    "url": "shaders/interactive-glitch.wgsl",
-    "category": "image",
-    "description": "Digital glitch artifacts that intensify around the mouse cursor.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Base Intensity",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Influence Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Glitch Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "blockScale",
-        "name": "Block Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "glitch-cathedral",
-    "name": "Glitch Cathedral",
-    "url": "shaders/glitch-cathedral.wgsl",
-    "category": "image",
-    "description": "Stained-glass geometric patterns with glitch artifacts; mouse triggers channel separation and pixel sorting.",
-    "params": [
-      {
-        "id": "cellSize",
-        "name": "Cell Size",
-        "default": 20,
-        "min": 2,
-        "max": 200
-      },
-      {
-        "id": "rgbSplit",
-        "name": "RGB Split",
-        "default": 0.02,
-        "min": 0,
-        "max": 0.2
-      },
-      {
-        "id": "sortStrength",
-        "name": "Sort Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "patternSpeed",
-        "name": "Pattern Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 4
-      }
-    ],
-    "features": [
-      "interactive",
-      "glitch",
-      "geometric",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "molten-glass",
-    "name": "Molten Glass",
-    "url": "shaders/molten-glass.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Melts the image under the mouse cursor like hot glass.",
-    "params": [
-      {
-        "id": "heat-radius",
-        "name": "Heat Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "cooling-rate",
-        "name": "Cooling Rate",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "crystal-refraction",
-    "name": "Crystal Refraction",
-    "url": "shaders/crystal-refraction.wgsl",
-    "category": "image",
-    "description": "Interactive faceted crystal lens with physical light transmission. Features IOR-based chromatic dispersion, Fresnel reflection at edges, and variable crystal thickness affecting light path.",
-    "params": [
-      {
-        "id": "facetScale",
-        "name": "Facet Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Number of crystal facets around mouse"
-      },
-      {
-        "id": "dispersion",
-        "name": "IOR / Dispersion",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Refractive index affecting chromatic dispersion: Quartz to Diamond"
-      },
-      {
-        "id": "strength",
-        "name": "Refraction Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Amount of lens distortion"
-      },
-      {
-        "id": "thickness",
-        "name": "Crystal Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Physical thickness affecting light transmission and absorption"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "alpha-transmission",
-      "chromatic-aberration",
-      "physical-refraction",
-      "audio-reactive",
-      "audio-driven",
-      "advanced-alpha"
-    ],
-    "tags": [
-      "crystal",
-      "lens",
-      "refraction",
-      "dispersion",
-      "transmission",
-      "fresnel",
-      "audio",
-      "music",
-      "reactive",
-      "alpha",
-      "physical-transmittance"
-    ]
-  },
-  {
-    "id": "glass-bead-curtain",
-    "name": "Glass Bead Curtain",
-    "url": "shaders/glass-bead-curtain.wgsl",
-    "category": "image",
-    "description": "A curtain of refractive glass beads that parts for the cursor.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Bead Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Size of glass beads"
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Refraction strength"
-      },
-      {
-        "id": "tension",
-        "name": "Interact Tension",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Curtain tension on interaction"
-      },
-      {
-        "id": "glass_density",
-        "name": "Glass Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Beer-Lambert density factor"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "magnetic-interference",
-    "name": "Magnetic Interference",
-    "url": "shaders/magnetic-interference.wgsl",
-    "category": "image",
-    "description": "Simulates magnetic distortion on a CRT screen, pulling pixels and separating colors.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Strength",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scanlines",
-        "name": "Scanlines",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "prismatic-3d-compositor",
-    "name": "Prismatic 3D Compositor (Pass 2)",
-    "url": "shaders/prismatic-3d-compositor.wgsl",
-    "category": "image",
-    "description": "Adds parallax shifting, volumetric glow, chromatic aberration and final composite with depth-aware blending.",
-    "params": [
-      {
-        "id": "glowRadius",
-        "name": "Glow Radius",
-        "default": 1,
-        "min": 0,
-        "max": 10
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 1,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "parallaxAmount",
-        "name": "Parallax",
-        "default": 1,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.02,
-        "min": 0,
-        "max": 0.2
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "volumetric",
-      "depth",
-      "lighting",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "rgb-split-glitch",
-    "name": "RGB Split Glitch",
-    "url": "shaders/rgb-split-glitch.wgsl",
-    "category": "image",
-    "description": "Splits RGB channels based on mouse proximity.",
-    "params": [
-      {
-        "id": "split",
-        "name": "Split Dist",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Angle Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "noise",
-        "name": "Jitter Noise",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neural-nexus",
-    "name": "Neural Nexus",
-    "url": "shaders/neural-nexus.wgsl",
-    "category": "image",
-    "description": "Biological neural network simulation with pulsing electrical signals; mouse sends shockwaves through synapses.",
-    "params": [
-      {
-        "id": "networkDensity",
-        "name": "Density",
-        "default": 1,
-        "min": 0.1,
-        "max": 4
-      },
-      {
-        "id": "signalSpeed",
-        "name": "Signal Speed",
-        "default": 1,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "decayRate",
-        "name": "Decay",
-        "default": 0.5,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "branchComplexity",
-        "name": "Branches",
-        "default": 2,
-        "min": 1,
-        "max": 8
-      }
-    ],
-    "features": [
-      "interactive",
-      "organic",
-      "network",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-sort-radial",
-    "name": "Radial Pixel Stretch",
-    "url": "shaders/pixel-sort-radial.wgsl",
-    "category": "image",
-    "description": "Radially stretches pixels from the mouse position based on luminance.",
-    "params": [
-      {
-        "id": "stretch",
-        "name": "Stretch Amt",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "thresh",
-        "name": "Luma Thresh",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dir",
-        "name": "Direction",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "nano-repair",
-    "name": "Nano-Tech Repair",
-    "url": "shaders/nano-repair.wgsl",
-    "category": "image",
-    "description": "The image is corrupted by digital rot. Use the mouse to deploy nano-bots that repair the image.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Repair Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "decay",
-        "name": "Decay Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scanlines",
-        "name": "Scanlines",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "feedback"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-mold",
-    "name": "Digital Mold",
-    "url": "shaders/digital-mold.wgsl",
-    "category": "image",
-    "description": "A digital decay effect that grows from the mouse cursor, eating away the image.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
       },
       {
         "id": "scale",
         "name": "Noise Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
+      {
+        "id": "intensity",
+        "name": "Glow Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hueShift",
+        "name": "Hue Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "interactive",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "aurora-rift-2",
+    "name": "Aurora Rift V2",
+    "url": "shaders/aurora-rift-2.wgsl",
+    "category": "image",
+    "description": "Enhanced aurora effects with improved color gradients.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "aurora-rift-gemini",
+    "name": "Aurora Rift Gemini",
+    "url": "shaders/aurora-rift-gemini.wgsl",
+    "category": "image",
+    "description": "An enhanced simulation of aurora borealis, with dynamic, time-driven color shifts, deeper atmospheric rifts, and shimmering, mouse-driven particle effects.",
+    "features": [
+      "mouse-driven",
+      "time-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "aurora-rift",
+    "name": "Aurora Rift",
+    "url": "shaders/aurora-rift.wgsl",
+    "category": "image",
+    "description": "Aurora borealis-inspired lighting effects with atmospheric rifts.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "bioluminescent",
+    "name": "Bioluminescent Growth",
+    "url": "shaders/bioluminescent.wgsl",
+    "category": "image",
+    "description": "Living, organic growth patterns that spread across surfaces like glowing fungus. Click to plant spores, watch them grow over time with depth-aware branching.",
+    "params": [
       {
         "id": "spread",
-        "name": "Spread Radius",
+        "name": "Spread Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "vaporwave-horizon",
-    "name": "Vaporwave Horizon",
-    "url": "shaders/vaporwave-horizon.wgsl",
-    "category": "image",
-    "description": "Transforms the image into a retro-futuristic landscape with a mouse-controlled horizon and grid.",
-    "params": [
-      {
-        "id": "gridSpeed",
-        "name": "Grid Speed",
-        "default": 0.5,
-        "min": -2.0,
-        "max": 2.0
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "gridScale",
-        "name": "Grid Scale",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 2.0
-      },
-      {
-        "id": "warpAmount",
-        "name": "Curve Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "image"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "biomimetic-scales",
-    "name": "Biomimetic Scales",
-    "url": "shaders/biomimetic-scales.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "scale_size",
-        "name": "Scale Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "roughness",
-        "name": "Roughness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "reaction_radius",
-        "name": "Reaction Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "lift",
-        "name": "Lift Strength",
+        "id": "density",
+        "name": "Branch Density",
         "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "radial-slit-scan",
-    "name": "Radial Slit Scan",
-    "url": "shaders/radial-slit-scan.wgsl",
-    "category": "image",
-    "description": "A time-displacement effect that radiates from the cursor.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Scan Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Scan Width",
-        "default": 0.2,
-        "min": 0.01,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Fade to Now",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "feedback"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-hex-armor",
-    "name": "Cyber Hex Armor",
-    "url": "shaders/cyber-hex-armor.wgsl",
-    "category": "image",
-    "description": "A hexagonal tech armor overlay that retracts when the mouse approaches.",
-    "params": [
-      {
-        "id": "hex_size",
-        "name": "Hex Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Size of the hexagonal grid cells"
-      },
-      {
-        "id": "glow_intensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Intensity of the hex edge glow"
-      },
-      {
-        "id": "reveal_radius",
-        "name": "Reveal Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Radius around mouse where armor retracts"
-      },
-      {
-        "id": "border_thickness",
-        "name": "Border Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Thickness of hexagon borders"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "overlay"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-contour-drag",
-    "name": "Neon Wake",
-    "url": "shaders/neon-contour-drag.wgsl",
-    "category": "image",
-    "description": "Detects edges and applies a neon glow that is warped by the mouse cursor like a magnetic field.",
-    "params": [
-      {
-        "id": "edgeStrength",
-        "name": "Edge Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dragRadius",
-        "name": "Warp Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "image",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music"
-    ]
-  },
-  {
-    "id": "sketch-reveal",
-    "name": "Sketch Reveal",
-    "url": "shaders/sketch-reveal.wgsl",
-    "category": "image",
-    "description": "Transforms the world into a pencil sketch, allowing you to 'paint' the reality back in with your mouse.",
-    "params": [
-      {
-        "id": "brushSize",
-        "name": "Brush Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edgeStrength",
-        "name": "Edge Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "contrast",
-        "name": "Sketch Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Brush Softness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "rgb-delay-brush",
-    "name": "RGB Delay Brush",
-    "url": "shaders/rgb-delay-brush.wgsl",
-    "category": "image",
-    "description": "Reveals past frames in RGB channels. Painting with the mouse creates colorful time-delayed trails.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Persistence",
-        "default": 0.9,
-        "min": 0.5,
-        "max": 0.99,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "How long trails persist over time"
-      },
-      {
-        "id": "split",
-        "name": "Time Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Amount of RGB channel time separation"
-      },
-      {
-        "id": "radius",
-        "name": "Brush Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Size of the brush around the mouse"
-      },
-      {
-        "id": "alpha_scale",
-        "name": "Alpha Absorption Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Scale of wavelength-dependent alpha absorption"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "knitted-fabric",
-    "name": "Knitted Fabric",
-    "url": "shaders/knitted-fabric.wgsl",
-    "category": "image",
-    "description": "Simulates a knitted wool texture. Mouse interaction pulls and stretches the fabric.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Stitch Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Pull Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Pull Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shadow",
-        "name": "Texture Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "quantum-prism",
-    "url": "shaders/quantum-prism.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Quantum Prism",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
         "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "infinite-spiral-zoom",
-    "name": "Infinite Spiral Zoom",
-    "url": "shaders/infinite-spiral-zoom.wgsl",
-    "category": "image",
-    "description": "Applies a complex log-polar mapping to create an infinite spiral zoom into the mouse cursor.",
-    "params": [
-      {
-        "id": "zoom_speed",
-        "name": "Zoom Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spiral_angle",
-        "name": "Spiral Twist",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "branches",
-        "name": "Branches",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "center_offset",
-        "name": "Center Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "refraction-shards",
-    "name": "Refraction Shards",
-    "url": "shaders/refraction-shards.wgsl",
-    "category": "image",
-    "description": "Splits the image into glass-like shards that refract light based on mouse position.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Shard Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "roughness",
-        "name": "Roughness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chromatic",
-        "name": "Prism Effect",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "origami-fold",
-    "name": "Origami Fold",
-    "url": "shaders/origami-fold.wgsl",
-    "category": "image",
-    "description": "Simulates a paper fold effect where the image is creased and folded based on the mouse position.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Fold Radius",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "shadowStrength",
-        "name": "Shadow Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Fold Angle",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 6.28
-      },
-      {
-        "id": "transparency",
-        "name": "Transparency",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "vortex-drag",
-    "name": "Vortex Drag",
-    "url": "shaders/vortex-drag.wgsl",
-    "category": "image",
-    "description": "Twisting vortex distortion that follows the mouse cursor.",
-    "params": [
-      {
-        "id": "twist",
-        "name": "Twist Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Vortex Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pinch",
-        "name": "Pinch/Bulge",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hardness",
-        "name": "Edge Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music"
-    ]
-  },
-  {
-    "id": "quantum-superposition",
-    "name": "Quantum Superposition",
-    "url": "shaders/quantum-superposition.wgsl",
-    "category": "image",
-    "description": "Image vibrates between states, stabilizing when observed (mouse hover).",
-    "params": [
-      {
-        "id": "chaos_speed",
-        "name": "Oscillation Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos_amount",
-        "name": "Chaos Probability",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "stability_radius",
-        "name": "Observation Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rgb_split",
-        "name": "RGB Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "particle-disperse",
-    "name": "Particle Disperse",
-    "url": "shaders/particle-disperse.wgsl",
-    "category": "image",
-    "description": "Mouse blows particles away with wind physics. Particles return to original position with spring forces.",
-    "params": [
-      {
-        "id": "wind_force",
-        "name": "Wind Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "return_speed",
-        "name": "Spring Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Wind Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "physics",
-      "interactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "reactive-glass-grid",
-    "name": "Reactive Glass Grid",
-    "url": "shaders/reactive-glass-grid.wgsl",
-    "category": "image",
-    "description": "A grid of refractive glass tiles that light up and distort based on mouse proximity.",
-    "params": [
-      {
-        "id": "tile_size",
-        "name": "Tile Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "max": 1
       },
       {
         "id": "glow",
         "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge_smooth",
-        "name": "Edge Smoothness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-halftone-spin",
-    "name": "Interactive Halftone Spin",
-    "url": "shaders/interactive-halftone-spin.wgsl",
-    "category": "image",
-    "description": "CMYK halftone pattern where the grid rotation is driven by mouse proximity.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Dot Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "separation",
-        "name": "CMYK Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "halftone"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-compression",
-    "name": "Digital Compression",
-    "url": "shaders/digital-compression.wgsl",
-    "category": "image",
-    "description": "Simulates digital artifacts and compression blocks. Mouse controls the clear focus area.",
-    "params": [
-      {
-        "id": "blockSize",
-        "name": "Block Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorDepth",
-        "name": "Bit Crush",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "artifacts",
-        "name": "Artifacts",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "focus",
-        "name": "Focus Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "stipple-engraving",
-    "name": "Stipple Engraving",
-    "category": "image",
-    "url": "shaders/stipple-engraving.wgsl",
-    "description": "Converts the image into a vintage stipple engraving. Mouse proximity acts as a spotlight, revealing details by increasing luminance.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "name": "Density",
-        "id": "density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Contrast",
-        "id": "contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Spot Radius",
-        "id": "radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Spot Brightness",
-        "id": "intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "spirograph-reveal",
-    "name": "Spirograph Reveal",
-    "url": "shaders/spirograph-reveal.wgsl",
-    "category": "image",
-    "description": "Reveals the image through a complex, rotating spirograph pattern centered on the mouse.",
-    "params": [
-      {
-        "id": "petals",
-        "name": "Petals",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "complexity",
-        "name": "Complexity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "thickness",
-        "name": "Line Thickness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "voronoi-light",
-    "name": "Voronoi Light",
-    "url": "shaders/voronoi-light.wgsl",
-    "category": "image",
-    "description": "Voronoi cells light up and react when the mouse is near.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Cell Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Light Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mode",
-        "name": "Mode (Tech/Glass)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "impasto-swirl",
-    "name": "Impasto Swirl",
-    "url": "shaders/impasto-swirl.wgsl",
-    "category": "image",
-    "description": "Simulates wet oil paint mixing. Mouse acts as a smudge tool that stirs the image.",
-    "params": [
-      {
-        "id": "brush",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smudge",
-        "name": "Smudge Strength",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dry",
-        "name": "Paint Dry Speed",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "noise",
-        "name": "Canvas Texture",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-focus",
-    "name": "Cyber Focus",
-    "url": "shaders/cyber-focus.wgsl",
-    "category": "image",
-    "description": "High-tech focus mode where the area around the mouse is crisp, while the background suffers from digital interference and chromatic aberration.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Focus Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "blur",
-        "name": "Blur Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch Intensity",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "vhs-jog",
-    "name": "VHS Jog Wheel",
-    "url": "shaders/vhs-jog.wgsl",
-    "category": "image",
-    "description": "Simulate VHS tracking and jogging. Mouse X controls distortion (jog), Mouse Y controls tracking.",
-    "params": [
-      {
-        "id": "noise",
-        "name": "Static Noise",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distFreq",
-        "name": "Dist. Freq",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "bleed",
-        "name": "Color Bleed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scanlines",
-        "name": "Scanlines",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "magma-fissure",
-    "name": "Magma Fissure",
-    "url": "shaders/magma-fissure.wgsl",
-    "category": "image",
-    "description": "Burn glowing fissures into the image with the mouse.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Cooling Rate",
-        "default": 0.96,
-        "min": 0.9,
-        "max": 0.999
-      },
-      {
-        "id": "width",
-        "name": "Fissure Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Heat Haze",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Brush Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "flux-core",
-    "name": "Flux Core",
-    "category": "image",
-    "url": "shaders/flux-core.wgsl",
-    "description": "Energy arcs emit from the cursor, connecting to bright areas in the image.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
+        "default": 0.7,
         "min": 0,
-        "max": 1,
-        "step": 0.01
+        "max": 1
       },
       {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "sliding-tile-glitch",
-    "name": "Sliding Tile Glitch",
-    "category": "image",
-    "url": "shaders/sliding-tile-glitch.wgsl",
-    "description": "Grid tiles slide and glitch when touched by the mouse.",
-    "params": [
-      {
-        "id": "gridDensity",
-        "name": "Grid Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "slideSpeed",
-        "name": "Slide Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Restoration",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "infinite-video-feedback",
-    "name": "Infinite Video Feedback",
-    "url": "shaders/infinite-video-feedback.wgsl",
-    "category": "image",
-    "description": "Create a feedback loop with the previous frame, applying zoom and rotation centered on the mouse.",
-    "params": [
-      {
-        "id": "feedback",
-        "name": "Feedback Decay",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 0.99
-      },
-      {
-        "id": "zoom",
-        "name": "Zoom Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "swirling-void",
-    "name": "Swirling Void",
-    "url": "shaders/swirling-void.wgsl",
-    "category": "image",
-    "description": "A powerful vortex that twists the image around the mouse cursor, simulating a black hole accretion disk with audio-reactive strength.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Vortex Strength",
-        "default": 0.5,
-        "min": -1.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Event Horizon",
+        "id": "spores",
+        "name": "Spore Count",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "darkness",
-        "name": "Void Darkness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "audioReact",
-        "name": "Audio Reactivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "split-dimension",
-    "name": "Split Dimension",
-    "url": "shaders/split-dimension.wgsl",
-    "category": "image",
-    "description": "Splits the screen into two dimensions. One side is normal, the other is a glitched negative. The split follows the mouse.",
-    "features": [
-      "mouse-driven",
-      "glitch"
-    ],
-    "params": [
-      {
-        "id": "glitch",
-        "name": "Glitch Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "negative",
-        "name": "Negative Str",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Split Angle",
-        "default": 0.0,
-        "min": -1.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "blueprint-reveal",
-    "name": "Blueprint Reveal",
-    "url": "shaders/blueprint-reveal.wgsl",
-    "category": "image",
-    "description": "Interactive blueprint schematic that you can erase to reveal reality.",
-    "params": [
-      {
-        "id": "edgeStrength",
-        "name": "Edge Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gridOpacity",
-        "name": "Grid Opacity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Reveal Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "echo-ripple",
-    "name": "Echo Ripple",
-    "url": "shaders/echo-ripple.wgsl",
-    "category": "image",
-    "description": "Mouse movement creates expanding ripples that echo and persist in time. Audio reactivity drives ripple amplitude and color splitting, while depth-aware parallax separates foreground and background distortion.",
-    "params": [
-      {
-        "id": "freq",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Echo Decay",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "strength",
-        "name": "Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "audio-reactive",
       "depth-aware",
-      "upgraded-rgba"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio-reactive",
-      "ripple",
-      "feedback",
-      "interactive"
-    ]
-  },
-  {
-    "id": "interactive-emboss",
-    "name": "Interactive Emboss",
-    "url": "shaders/interactive-emboss.wgsl",
-    "category": "image",
-    "description": "Emboss effect where the light source follows the mouse cursor.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mix",
-        "name": "Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorMode",
-        "name": "Color Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "labels": [
-          "Gray",
-          "Color"
-        ]
-      },
-      {
-        "id": "emboss_depth",
-        "name": "Emboss Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Depth of emboss effect"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "ascii-lens",
-    "name": "ASCII Lens",
-    "url": "shaders/ascii-lens.wgsl",
-    "category": "image",
-    "description": "Reveals the image as procedural ASCII characters within a lens radius around the mouse.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Lens Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Radius of the ASCII lens"
-      },
-      {
-        "id": "density",
-        "name": "Character Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Density of ASCII characters in the lens"
-      },
-      {
-        "id": "line_width",
-        "name": "Glyph Line Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Width of glyph lines in the ASCII characters"
-      },
-      {
-        "id": "brightness_bias",
-        "name": "Brightness Threshold Bias",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Bias for brightness threshold comparisons"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-organic",
-    "name": "Cyber Organic Scanner",
-    "url": "shaders/cyber-organic.wgsl",
-    "category": "image",
-    "description": "Scans the image to reveal a pulsating organic layer beneath.",
-    "params": [
-      {
-        "id": "scanSpeed",
-        "name": "Scan Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "organicScale",
-        "name": "Organic Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "revealRadius",
-        "name": "Reveal Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulseSpeed",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "refractive-bubbles",
-    "name": "Refractive Bubbles",
-    "url": "shaders/refractive-bubbles.wgsl",
-    "category": "image",
-    "description": "Floating bubbles around the cursor that distort the background like glass.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Bubble Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction Index",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "count",
-        "name": "Bubble Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "wobble",
-        "name": "Wobble Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "sequin-flip",
-    "name": "Sequin Flip",
-    "url": "shaders/sequin-flip.wgsl",
-    "category": "image",
-    "description": "Simulates reversible sequins that flip to reveal a metallic back when brushed by the mouse.",
-    "params": [
-      {
-        "id": "grid_size",
-        "name": "Grid Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "flip_radius",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "specular",
-        "name": "Shine",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "back_color",
-        "name": "Gold/Silver",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cross-stitch",
-    "name": "Cross Stitch Reveal",
-    "url": "shaders/cross-stitch.wgsl",
-    "category": "image",
-    "description": "Quantizes the image into cross-stitch patterns. Mouse movement unravels or distorts the fabric.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Stitch Scale",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "thickness",
-        "name": "Thread Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Unravel Chaos",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "geometry"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "virtual-lens",
-    "name": "Virtual Lens",
-    "url": "shaders/virtual-lens.wgsl",
-    "category": "image",
-    "description": "A virtual magnifying glass with chromatic aberration and audio-reactive pulse.",
-    "params": [
-      {
-        "id": "mag",
-        "name": "Magnification",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Lens Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "infinite-fractal-feedback",
-    "name": "Infinite Fractal Feedback",
-    "url": "shaders/infinite-fractal-feedback.wgsl",
-    "category": "image",
-    "description": "Perpetual zoom tunnel with rotating mandala patterns. Mouse controls the zoom focal point and rotation speed.",
-    "params": [
-      {
-        "id": "zoomRate",
-        "name": "Zoom Rate",
-        "default": 0.8,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "spiralTightness",
-        "name": "Spiral Tightness",
-        "default": 0.6,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.2,
-        "min": -1,
-        "max": 1
-      },
-      {
-        "id": "feedbackStrength",
-        "name": "Feedback",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "interactive",
-      "fractal",
-      "feedback",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "rgb-iso-lines",
-    "name": "RGB Iso Lines",
-    "url": "shaders/rgb-iso-lines.wgsl",
-    "category": "image",
-    "description": "Visualizes the R, G, and B channels as separated contour maps. Mouse controls the parallax separation.",
-    "params": [
-      {
-        "id": "thickness",
-        "name": "Line Thickness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Thickness of contour lines"
-      },
-      {
-        "id": "frequency",
-        "name": "Contour Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Density of contour lines"
-      },
-      {
-        "id": "parallax",
-        "name": "Parallax Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Amount of RGB channel parallax separation"
-      },
-      {
-        "id": "bg_opacity",
-        "name": "Background Opacity",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.5,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Opacity of the original image behind contours"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "quantized-ripples",
-    "name": "Quantized Ripples",
-    "url": "shaders/quantized-ripples.wgsl",
-    "category": "image",
-    "description": "Quantizes the image (posterization) with levels that ripple out from the mouse position.",
-    "params": [
-      {
-        "id": "frequency",
-        "name": "Ripple Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amplitude",
-        "name": "Ripple Amplitude",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Ripple Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "depth",
-        "name": "Color Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "poly-art",
-    "name": "Poly Art",
-    "url": "shaders/poly-art.wgsl",
-    "category": "image",
-    "description": "Transforms the image into a low-poly Voronoi mosaic. Mouse interaction distorts the grid density.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Cell Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edges",
-        "name": "Edge Width",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "randomness",
-        "name": "Randomness",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "influence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-drag-smear",
-    "name": "Pixel Drag Smear",
-    "url": "shaders/pixel-drag-smear.wgsl",
-    "category": "image",
-    "description": "Smudge and drag pixels like wet paint, creating persistent trails.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Brush Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "strength",
-        "name": "Drag Strength",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Decay Rate",
-        "default": 0.95,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mode",
-        "name": "Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "edge-glow-mouse",
-    "name": "Edge Glow",
-    "url": "shaders/edge-glow-mouse.wgsl",
-    "category": "image",
-    "description": "Detects edges in the image which glow intensely when near the mouse cursor.",
-    "params": [
-      {
-        "id": "threshold",
-        "name": "Edge Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glowRadius",
-        "name": "Glow Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorCycle",
-        "name": "Color Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "elastic-strip",
-    "name": "Elastic Strip",
-    "url": "shaders/elastic-strip.wgsl",
-    "category": "image",
-    "description": "Divides the image into strips that stretch elastically towards the mouse cursor.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Strip Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "strength",
-        "name": "Stretch Strength",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "falloff",
-        "name": "Influence Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dir",
-        "name": "Direction (V/H)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "labels": [
-          "Vertical Strips",
-          "Horizontal Strips"
-        ]
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "volumetric-rainbow-clouds",
-    "name": "Volumetric Rainbow Clouds (Pass 1)",
-    "url": "shaders/volumetric-rainbow-clouds.wgsl",
-    "category": "image",
-    "description": "Generates 3D noise clouds with normals, lighting, and depth-aware rainbow coloring for a volumetric prismatic effect.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Scale",
-        "default": 1,
-        "min": 0.1,
-        "max": 5
-      },
-      {
-        "id": "flowSpeed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.8,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "lightIntensity",
-        "name": "Light Intensity",
-        "default": 1,
-        "min": 0,
-        "max": 4
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "volumetric",
-      "depth",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-frost",
-    "name": "Interactive Frost",
-    "url": "shaders/frost-reveal.wgsl",
-    "category": "image",
-    "description": "Realistic frost grows over the image; use your mouse (warmth) to melt it away.",
-    "params": [
-      {
-        "id": "growth",
-        "name": "Growth Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Melt Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "opacity",
-        "name": "Frost Opacity",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chroma-lens",
-    "name": "Chroma Lens",
-    "url": "shaders/chroma-lens.wgsl",
-    "category": "image",
-    "description": "A magnifying lens effect that splits color channels (chromatic aberration) towards the edges.",
-    "params": [
-      {
-        "id": "magnification",
-        "name": "Magnification",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Lens Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "blurEdges",
-        "name": "Edge Blur",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "mouse-gravity",
-    "name": "Interactive Gravity",
-    "url": "shaders/mouse-gravity.wgsl",
-    "category": "image",
-    "description": "Gravitational distortion field that follows the mouse cursor.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Gravity Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Event Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Chrom. Aberration",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "darkness",
-        "name": "Core Darkness",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-fluid-warp",
-    "name": "Neon Fluid Warp",
-    "url": "shaders/neon-fluid-warp.wgsl",
-    "category": "image",
-    "description": "Distorts the image like a fluid around the mouse, adding neon edges.",
-    "params": [
-      {
-        "id": "warpStrength",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "liquidity",
-        "name": "Liquidity",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "cmyk-halftone-interactive",
-    "name": "CMYK Halftone Interactive",
-    "url": "shaders/cmyk-halftone-interactive.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Dot Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle_offset",
-        "name": "Angle Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "separation",
-        "name": "Channel Spread",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "darkness",
-        "name": "Ink Darkness",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-voronoi-web",
-    "name": "Voronoi Web",
-    "url": "shaders/interactive-voronoi-web.wgsl",
-    "category": "image",
-    "description": "Dynamic voronoi web connected to the cursor.",
-    "params": [
-      {
-        "id": "thickness",
-        "name": "Web Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scale",
-        "name": "Cell Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glow",
-        "name": "Glow Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulse",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "voronoi"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "double-exposure",
-    "name": "Double Exposure Zoom",
-    "category": "image",
-    "url": "shaders/double-exposure.wgsl",
-    "description": "Blends the image with a zoomed and rotated version of itself, pivoted around the mouse cursor. Reacts subtly to audio bass.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "name": "Zoom Level",
-        "id": "zoom",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Rotation",
-        "id": "rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Opacity",
-        "id": "opacity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Saturation",
-        "id": "saturation",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "zoom",
-      "overlay"
-    ]
-  },
-  {
-    "id": "holographic-edge-ripple",
-    "name": "Holographic Edge Ripple",
-    "url": "shaders/holographic-edge-ripple.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "description": "Edges ripple and split into RGB components based on mouse proximity.",
-    "params": [
-      {
-        "name": "Wave Speed",
-        "id": "wave-speed",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 10.0
-      },
-      {
-        "name": "Frequency",
-        "id": "frequency",
-        "default": 20.0,
-        "min": 1.0,
-        "max": 100.0
-      },
-      {
-        "name": "Aberration",
-        "id": "aberration",
-        "default": 0.02,
-        "min": 0.0,
-        "max": 0.1
-      },
-      {
-        "name": "Edge Threshold",
-        "id": "edge-threshold",
-        "default": 0.2,
-        "min": 0.01,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music"
-    ]
-  },
-  {
-    "id": "entropy-grid",
-    "name": "Entropy Grid",
-    "url": "shaders/entropy-grid.wgsl",
-    "category": "image",
-    "description": "Scrambles the image into a chaotic grid. Mouse restores order (or creates chaos) with audio-reactive chaos.",
-    "params": [
-      {
-        "id": "gridSize",
-        "name": "Grid Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos Level",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "invert",
-        "name": "Invert Effect",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "rainbow-vector-field",
-    "name": "Rainbow Vector Field (Pass 1)",
-    "url": "shaders/rainbow-vector-field.wgsl",
-    "category": "image",
-    "description": "Generates a base rainbow pattern and computes a displacement field (stored to depth) for a follow-up prismatic feedback pass.",
-    "params": [
-      {
-        "id": "frequency",
-        "name": "Frequency",
-        "default": 4.0,
-        "min": 0.1,
-        "max": 12.0
-      },
-      {
-        "id": "saturation",
-        "name": "Saturation",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "brightness",
-        "name": "Brightness",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "displacementScale",
-        "name": "Displacement Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "mouse-driven",
-      "color"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chromatic-shockwave",
-    "name": "Chromatic Shockwave",
-    "url": "shaders/chromatic-shockwave.wgsl",
-    "category": "image",
-    "description": "Continuous chromatic ripples emanating from the mouse.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "freq",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ring_count",
-        "name": "Ring Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Number of shockwave rings"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-glitch-hologram",
-    "name": "Cyber Glitch Hologram",
-    "url": "shaders/cyber-glitch-hologram.wgsl",
-    "category": "image",
-    "description": "A sci-fi holographic projection with interactive interference and chromatic aberration.",
-    "params": [
-      {
-        "id": "hologramIntensity",
-        "name": "Hologram Int.",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitchAmount",
-        "name": "Glitch Amt.",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scanSpeed",
-        "name": "Scan Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "mouseRadius",
-        "name": "Mouse Inf.",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "ferrofluid",
-    "name": "Magnetic Ferrofluid",
-    "url": "shaders/ferrofluid.wgsl",
-    "category": "image",
-    "description": "Simulates magnetic ferrofluid spikes attracted to the mouse.",
-    "params": [
-      {
-        "id": "spikeScale",
-        "name": "Spike Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "attraction",
-        "name": "Attraction",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-wind-chimes",
-    "name": "Pixel Wind Chimes",
-    "url": "shaders/pixel-wind-chimes.wgsl",
-    "category": "image",
-    "description": "Slices the image into hanging vertical strips that swing like wind chimes when pushed by the mouse.",
-    "params": [
-      {
-        "name": "Strip Count",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "strip_count"
-      },
-      {
-        "name": "Sway Amount",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "sway_amount"
-      },
-      {
-        "name": "Wind Speed",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "wind_speed"
-      },
-      {
-        "name": "Gap Size",
-        "type": "float",
-        "default": 0.1,
-        "min": 0,
-        "max": 1,
-        "id": "gap_size"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "luma-topography",
-    "name": "Luma Topography",
-    "url": "shaders/luma-topography.wgsl",
-    "category": "image",
-    "description": "Visualizes the image as a 3D terrain map where brightness determines height. The mouse controls a dynamic light source.",
-    "params": [
-      {
-        "id": "height",
-        "name": "Relief Height",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Light Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shininess",
-        "name": "Shininess",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ambient",
-        "name": "Ambient Light",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "lighting"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-fisheye",
-    "name": "Interactive Fisheye",
-    "url": "shaders/interactive-fisheye.wgsl",
-    "category": "image",
-    "description": "Barrel distortion lens that magnifies the area under the mouse with audio-reactive radius and depth-aware alpha modulation.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Lens Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "curve",
-        "name": "Bulge Curve",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "vignette",
-        "name": "Edge Vignette",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "geometry",
-      "audio-reactive",
-      "audio-driven",
-      "depth-aware"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "solarize-warp",
-    "name": "Solarize Warp",
-    "url": "shaders/solarize-warp.wgsl",
-    "category": "image",
-    "description": "Twists the image around the mouse cursor while applying a solarization effect.",
-    "params": [
-      {
-        "id": "twist",
-        "name": "Twist Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Solarize Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "unused",
-        "name": "Unused",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "hyper-chromatic-delay",
-    "name": "Hyper-Chromatic Delay",
-    "url": "shaders/hyper-chromatic-delay.wgsl",
-    "category": "image",
-    "description": "Spectral Multi-Tap Echo with wavelength-dependent refraction, per-channel lens distortion, motion-aware temporal blur, and audio-reverb-inspired feedback echoes.",
-    "params": [
-      {
-        "id": "sepStrength",
-        "name": "RGB Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Shift Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mouseInf",
-        "name": "Mouse Influence",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
       "temporal-persistence",
-      "chromatic-aberration",
-      "spectral-dispersion",
-      "multi-tap-temporal",
-      "lens-distortion",
-      "motion-trails",
-      "audio-reverb"
+      "interactive",
+      "multi-mode",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
     ],
     "tags": [
       "filter",
       "image-processing",
-      "spectral",
-      "echo",
-      "reverb",
-      "distortion",
-      "audio-reactive"
+      "audio",
+      "music",
+      "reactive"
     ]
   },
   {
-    "id": "slinky-distort",
-    "name": "Slinky Distortion",
-    "url": "shaders/slinky-distort.wgsl",
+    "id": "chromatic-crawler",
+    "name": "Chromatic Crawler",
+    "url": "shaders/chromatic-crawler.wgsl",
     "category": "image",
-    "description": "Slices the image into horizontal bands that shift back and forth like a slinky.",
+    "description": "Chaotic color-swapping regions that crawl across the screen with Voronoi-based patterns.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
     "params": [
       {
-        "id": "slices",
-        "name": "Slice Count",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "strength",
-        "name": "Sway Strength",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "phase",
+        "id": "param2",
         "name": "Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "smooth",
-        "name": "Smoothness",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
+    ]
+  },
+  {
+    "id": "chromatic-folds-2",
+    "name": "Chromatic Folds V2",
+    "url": "shaders/chromatic-folds-2.wgsl",
+    "category": "image",
+    "description": "Enhanced geometric color folding with improved warping.",
+    "features": [
+      "mouse-driven"
     ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "chromatic-folds-gemini",
+    "name": "Chromatic Folds Gemini",
+    "url": "shaders/chromatic-folds-gemini.wgsl",
+    "category": "image",
+    "description": "An advanced geometric color folding and warping effect with dynamic, time-driven animation, fractal layering, and interactive, mouse-driven vortex manipulation.",
     "features": [
       "mouse-driven",
-      "distortion"
+      "time-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
     ]
   },
   {
-    "id": "temporal-rift",
-    "name": "Temporal Rift",
-    "url": "shaders/temporal-rift.wgsl",
+    "id": "chromatic-folds",
+    "name": "Chromatic Folds",
+    "url": "shaders/chromatic-folds.wgsl",
     "category": "image",
-    "description": "Creates temporal echoes and time-smearing trails where the mouse moves.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Rift Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chroma",
-        "name": "Chroma Split",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mix",
-        "name": "Echo Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
+    "description": "Geometric color folding and warping effects.",
     "features": [
       "mouse-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ]
-  },
-  {
-    "id": "contour-flow",
-    "name": "Contour Flow",
-    "category": "image",
-    "url": "shaders/contour-flow.wgsl",
-    "description": "Image pixels flow along their luminance contours, reacting to mouse proximity.",
-    "features": [
-      "mouse-driven"
     ],
     "params": [
       {
-        "name": "Flow Speed",
-        "id": "flowSpeed",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "name": "Flow Length",
-        "id": "flowLength",
+        "id": "param2",
+        "name": "Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "name": "Mouse Radius",
-        "id": "mouseRadius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "name": "Edge Sens.",
-        "id": "edgeDetect",
+        "id": "param4",
+        "name": "Detail",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
     ]
   },
   {
-    "id": "parallax-glow-compositor",
-    "name": "Parallax Glow Compositor (Pass 2)",
-    "url": "shaders/parallax-glow-compositor.wgsl",
+    "id": "chromatic-infection",
+    "name": "Chromatic Infection",
+    "url": "shaders/chromatic-infection.wgsl",
     "category": "image",
-    "description": "Compositor that applies chromatic aberration, volumetric glow, and depth-aware compositing for volumetric zooms.",
+    "description": "Strong colours spread like a living organism, infecting neutral regions with organic, pulsing tendrils. Watch vibrant hues consume the dull!",
     "params": [
-      {
-        "id": "glowRadius",
-        "name": "Glow Radius",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 10.0
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 4.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.02,
-        "min": 0.0,
-        "max": 0.2
-      },
-      {
-        "id": "bloomThreshold",
-        "name": "Bloom Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "volumetric",
-      "depth",
-      "composite"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "ink-bleed",
-    "name": "Ink Bleed",
-    "url": "shaders/ink-bleed.wgsl",
-    "category": "image",
-    "description": "Click to drop spreading ink that permanently stains the video feed.",
-    "params": [
-      {
-        "id": "inkHue",
-        "name": "Ink Hue",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
       {
         "id": "spreadSpeed",
         "name": "Spread Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "fadeSpeed",
-        "name": "Fade Speed",
-        "default": 0.05,
-        "min": 0.0,
-        "max": 1.0
+        "id": "intensity",
+        "name": "Infection Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "density",
-        "name": "Ink Density",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
+        "id": "satThresh",
+        "name": "Saturation Threshold",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "tendrilScale",
+        "name": "Tendril Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-sort-explorer",
-    "name": "Pixel Sort Explorer",
-    "url": "shaders/pixel-sort-explorer.wgsl",
-    "category": "image",
-    "description": "Locally sorts pixels within a mouse-controlled spotlight radius.",
-    "params": [
-      {
-        "id": "thresh",
-        "name": "Sort Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Spot Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dir",
-        "name": "Direction (V/H)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smooth",
-        "name": "Smoothness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "colour-masking",
+      "organic-growth",
       "mouse-driven"
     ],
     "tags": [
@@ -7580,109 +688,11 @@
     ]
   },
   {
-    "id": "neon-echo",
-    "name": "Neon Echo",
-    "url": "shaders/neon-echo.wgsl",
+    "id": "chromatic-manifold-2",
+    "name": "Chromatic Manifold V2",
+    "url": "shaders/chromatic-manifold-2.wgsl",
     "category": "image",
-    "description": "Creates glowing trails from moving edges in the video, with colors influenced by mouse position.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Edge Sense",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hue",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mix",
-        "name": "Echo Mix",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "quantum-ripples",
-    "name": "Quantum Ripples",
-    "url": "shaders/quantum-ripples.wgsl",
-    "category": "image",
-    "description": "Mouse-driven quantum interference waves with FBM turbulence, multi-source superposition, and audio reactivity.",
-    "params": [
-      {
-        "id": "waveFreq",
-        "name": "Wave Freq",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "waveSpeed",
-        "name": "Propagate Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortionStr",
-        "name": "Distortion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "interactive",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "waves",
-      "interference",
-      "turbulence"
-    ]
-  },
-  {
-    "id": "rgb-ripple-waves",
-    "name": "RGB Ripple Waves",
-    "url": "shaders/rgb-ripple-waves.wgsl",
-    "category": "image",
-    "description": "Separates RGB channels into distinct ripple waves emanating from the mouse cursor.",
+    "description": "Enhanced 4D topological color manifold.",
     "features": [
       "mouse-driven"
     ],
@@ -7726,44 +736,108 @@
     ]
   },
   {
-    "id": "neon-pulse",
-    "name": "Neon Pulse Distortion",
-    "url": "shaders/neon-pulse.wgsl",
+    "id": "chromatic-manifold",
+    "name": "Chromatic Manifold",
+    "url": "shaders/chromatic-manifold.wgsl",
     "category": "image",
-    "description": "Distorts the image with a pulsating neon wave emanating from the cursor.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glow",
-        "name": "Neon Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
+    "description": "4D topological color manifold with HDR tears, temporal persistence, and depth-driven curvature.",
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
     ],
     "features": [
       "mouse-driven",
-      "distortion",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "color_boost",
+        "name": "Color Boost",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Saturation and color intensity boost"
+      },
+      {
+        "id": "warpStrength",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of spatial warp"
+      },
+      {
+        "id": "tearThreshold",
+        "name": "Tear Threshold",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Threshold for HDR tear artifacts"
+      },
+      {
+        "id": "curvature",
+        "name": "Curvature Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Depth-driven curvature amount"
+      }
+    ]
+  },
+  {
+    "id": "cosmic-flow",
+    "name": "Cosmic Flow Pro",
+    "url": "shaders/cosmic-flow.wgsl",
+    "category": "image",
+    "description": "Depth-aware ethereal energy field with domain warping, temporal trails, chromatic aberration, and multiple color modes ranges.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Pattern Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Glow Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Phase",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "chromatic-aberration",
+      "multi-mode",
+      "mouse-driven",
       "audio-reactive",
       "audio-driven"
     ],
@@ -7776,94 +850,439 @@
     ]
   },
   {
-    "id": "volumetric-depth-zoom",
-    "name": "Volumetric Depth Zoom (Pass 1)",
-    "url": "shaders/volumetric-depth-zoom.wgsl",
+    "id": "double-exposure-zoom",
+    "name": "Double Exposure Zoom",
+    "url": "shaders/double-exposure-zoom.wgsl",
     "category": "image",
-    "description": "Raymarched volumetric zoom using multiple depth slices, DOF, parallax and edge specular lighting.",
+    "description": "Blends the image with a zoomed and rotated copy of itself, pivoting around the mouse cursor.",
     "params": [
-      {
-        "id": "fg_speed",
-        "name": "Foreground Speed",
-        "default": 1,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "bg_speed",
-        "name": "Background Speed",
-        "default": 0.8,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "parallax_str",
-        "name": "Parallax",
-        "default": 0.5,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "fog_density",
-        "name": "Fog Density",
-        "default": 0.8,
-        "min": 0,
-        "max": 4
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "volumetric",
-      "depth",
-      "mouse-driven",
-      "advanced-alpha"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "alpha",
-      "depth-layered"
-    ]
-  },
-  {
-    "id": "holographic-prism",
-    "name": "Holographic Prism",
-    "url": "shaders/holographic-prism.wgsl",
-    "category": "image",
-    "description": "Splits the image into spectral shards that rotate and shift, creating a holographic lens effect.",
-    "params": [
-      {
-        "id": "facets",
-        "name": "Facet Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dispersion",
-        "name": "Dispersion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
       {
         "id": "rotation",
         "name": "Rotation",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "glitch",
-        "name": "Holo Glitch",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "id": "zoom",
+        "name": "Zoom Level",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edgeFade",
+        "name": "Edge Fade",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "audioReact",
+        "name": "Audio Reactivity",
+        "default": 0,
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
       "mouse-driven",
-      "chromatic-aberration",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "encaustic-wax",
+    "name": "Encaustic Wax",
+    "description": "Simulates the translucent, textured look of hot wax painting. Mouse interaction melts the wax locally.",
+    "url": "shaders/encaustic-wax.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "blur",
+      "texture"
+    ],
+    "params": [
+      {
+        "id": "thickness",
+        "name": "Wax Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "texture",
+        "name": "Surface Texture",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Melt Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "intensity",
+        "name": "Melt Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "green-tracer",
+    "name": "Green Tracer World",
+    "url": "shaders/green-tracer.wgsl",
+    "category": "image",
+    "description": "Surreal green video effect with persistent motion trails, edge glow, and film grain. Perfect for toxic/night‑vision aesthetics.",
+    "params": [
+      {
+        "id": "trailLen",
+        "name": "Trail Length",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glowInt",
+        "name": "Glow Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "greenTint",
+        "name": "Green Tint",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noiseAmt",
+        "name": "Film Grain",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
+      }
+    ],
+    "features": [
+      "temporal‑persistence",
+      "edge‑glow",
+      "film‑grain",
+      "depth‑aware",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "halftone-reveal",
+    "name": "Halftone Reveal",
+    "category": "image",
+    "url": "shaders/halftone-reveal.wgsl",
+    "description": "Renders the image as a coarse halftone pattern that resolves into a clear image near the mouse.",
+    "params": [
+      {
+        "name": "Dot Size",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "id": "dot_size"
+      },
+      {
+        "name": "Angle",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "angle"
+      },
+      {
+        "name": "Reveal Size",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "id": "reveal_size"
+      },
+      {
+        "name": "Magnify",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "id": "magnify"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ion-stream",
+    "name": "Ion Stream",
+    "url": "shaders/ion-stream.wgsl",
+    "category": "image",
+    "features": [
+      "upgraded-rgba",
+      "depth-aware",
+      "displacement",
+      "turbulence",
+      "mouse-driven"
+    ],
+    "description": "A stream of ionized particles that reacts to the mouse cursor, tinting pixels as they flow.",
+    "params": [
+      {
+        "name": "Stream Strength",
+        "id": "zoomParam1",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Falloff",
+        "id": "zoomParam2",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Turbulence",
+        "id": "zoomParam3",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Ion Color",
+        "id": "zoomParam4",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "lidar",
+    "name": "LiDAR Scanner Pro",
+    "url": "shaders/lidar.wgsl",
+    "category": "image",
+    "description": "Multi-mode LiDAR with point clouds, persistence trails, and 3D edge detection. Modes: Linear/Radial/Spiral scan.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Scan Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Beam Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contours",
+        "name": "Contour Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edges",
+        "name": "Edge Sensitivity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "multi-mode",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "luminance-wind",
+    "name": "Luminance Wind",
+    "category": "image",
+    "url": "shaders/luminance-wind.wgsl",
+    "description": "Pixels are blown by a digital wind. Lighter pixels are lighter weight and travel further. Mouse controls wind direction.",
+    "params": [
+      {
+        "name": "Wind Speed",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "wind_speed"
+      },
+      {
+        "name": "Trail Decay",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.8,
+        "id": "trail_decay"
+      },
+      {
+        "name": "Luma Threshold",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.1,
+        "id": "luma_threshold"
+      },
+      {
+        "name": "Turbulence",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.2,
+        "id": "turbulence"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "mouse-pixel-sort",
+    "name": "Mouse Pixel Sort",
+    "url": "shaders/mouse-pixel-sort.wgsl",
+    "category": "image",
+    "description": "Luminance-based pixel sorting controlled by mouse proximity.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "threshold",
+        "name": "Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "length",
+        "name": "Sort Length",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "direction",
+        "name": "Direction (V/H)",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Invert Sort",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "nebulous-dream",
+    "name": "Nebulous Dream",
+    "url": "shaders/nebulous-dream.wgsl",
+    "category": "image",
+    "description": "Swirling vortex of rainbow candy clouds with fractal noise and flow fields.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "neon-edge-diffusion",
+    "name": "Neon Edge Diffusion",
+    "url": "shaders/neon-edge-diffusion.wgsl",
+    "category": "image",
+    "description": "Sobel edge detection with neon-diffusion and color bleeding.",
+    "features": [
+      "mouse-driven",
       "audio-reactive",
       "audio-driven"
     ],
@@ -7872,1623 +1291,56 @@
       "image-processing",
       "audio",
       "music"
-    ]
-  },
-  {
-    "id": "anamorphic-flare",
-    "name": "Anamorphic Flare",
-    "url": "shaders/anamorphic-flare.wgsl",
-    "category": "image",
-    "description": "Generates a cinematic horizontal lens flare centered on the mouse position.",
-    "params": [
-      {
-        "id": "width",
-        "name": "Flare Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Threshold",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-glitch-cubes",
-    "name": "Interactive Glitch Cubes",
-    "url": "shaders/interactive-glitch-cubes.wgsl",
-    "category": "image",
-    "description": "Image is mapped onto a grid of extruded cubes that react to mouse height.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Cube Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "extrusion",
-        "name": "Extrusion Height",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gap",
-        "name": "Grid Gap",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shadow",
-        "name": "Shadow Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "pseudo-3d"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "radial-hex-lens",
-    "name": "Radial Hex Lens",
-    "url": "shaders/radial-hex-lens.wgsl",
-    "category": "image",
-    "description": "A hexagonal mosaic that distorts and magnifies around the mouse position.",
-    "features": [
-      "mouse-driven"
     ],
     "params": [
       {
-        "id": "scale",
-        "name": "Hex Scale",
+        "id": "viscosity",
+        "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Size of hexagonal pixels"
-      },
-      {
-        "id": "radius",
-        "name": "Lens Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Radius of the lens effect"
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Amount of magnification distortion"
-      },
-      {
-        "id": "edge_hardness",
-        "name": "Hex Edge Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Hardness of hexagon cell edges"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "signal-tuner",
-    "name": "Signal Tuner",
-    "url": "shaders/signal-tuner.wgsl",
-    "category": "image",
-    "description": "Applies TV-style signal interference and wave distortion localized around the mouse.",
-    "params": [
-      {
-        "id": "frequency",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amplitude",
-        "name": "Interference",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Drift Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "noise",
-        "name": "Static Noise",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-reveal",
-    "name": "Pixel Reveal",
-    "url": "shaders/pixel-reveal.wgsl",
-    "category": "image",
-    "description": "Pixelates the image, with a clear window (or obscuring block) around the mouse.",
-    "params": [
-      {
-        "id": "pixelSize",
-        "name": "Pixel Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "invert",
-        "name": "Invert Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "interactive-ripple",
-    "name": "Interactive Ripple",
-    "url": "shaders/interactive-ripple.wgsl",
-    "category": "image",
-    "description": "Classic water ripple effect following cursor.",
-    "params": [
-      {
-        "id": "amplitude",
-        "name": "Wave Height",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "frequency",
-        "name": "Wave Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "wave"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "phosphor-magnifier",
-    "label": "Phosphor Magnifier",
-    "name": "Phosphor Magnifier",
-    "url": "shaders/phosphor-magnifier.wgsl",
-    "category": "image",
-    "icon": "search",
-    "description": "Simulates a CRT phosphor mask. Use mouse to magnify the screen pixels.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "name": "Zoom Level",
-        "id": "x",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "name": "Pixel Size",
-        "id": "y",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "name": "Glow",
-        "id": "z",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3
-      },
-      {
-        "name": "Lens Size",
-        "id": "w",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-lattice",
-    "name": "Cyber Lattice",
-    "category": "image",
-    "url": "shaders/cyber-lattice.wgsl",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "description": "A dynamic holographic grid that reacts to mouse movement and clicks.",
-    "params": [
-      {
-        "name": "Grid Scale",
-        "id": "scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Distortion",
-        "id": "distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Glow",
-        "id": "glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Radius",
-        "id": "radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "sonic-distortion",
-    "name": "Sonic Distortion",
-    "url": "shaders/sonic-distortion.wgsl",
-    "category": "image",
-    "description": "Superellipse-masked sonic distortion with Lissajous wave interference, FBM domain warping, rose curve modulation, and alpha-ghosted echo trails.",
-    "params": [
-      {
-        "id": "freq",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amp",
-        "name": "Amplitude",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion",
-      "superellipse",
-      "lissajous",
-      "fbm",
-      "temporal",
-      "echo-trails"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "fiber-optic-weave",
-    "name": "Fiber Optic Weave",
-    "url": "shaders/fiber-optic-weave.wgsl",
-    "category": "image",
-    "description": "Deconstructs image into glowing optical fibers that react to mouse movement.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Fiber Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glow",
-        "name": "Fiber Glow",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "force",
-        "name": "Mouse Force",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fray",
-        "name": "Weave Fray",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "foil-impression",
-    "name": "Foil Impression",
-    "url": "shaders/foil-impression.wgsl",
-    "category": "image",
-    "description": "Simulates a metallic foil surface. Pressing with the mouse flattens the foil to reveal the image relief and color.",
-    "params": [
-      {
-        "id": "pressure_radius",
-        "name": "Pressure Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "foil_roughness",
-        "name": "Foil Crinkle",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "relief_strength",
-        "name": "Image Emboss",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color_reveal",
-        "name": "Color Mix",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "glass-shatter",
-    "name": "Glass Shatter",
-    "url": "shaders/glass-shatter.wgsl",
-    "category": "image",
-    "description": "Interactive shattered glass effect where shards are pushed by the mouse.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Shard Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "displacement",
-        "name": "Displacement",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge",
-        "name": "Edge",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "glass-wall",
-    "url": "shaders/glass-wall.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Glass Wall",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "luma-force",
-    "name": "Luma Force",
-    "url": "shaders/luma-force.wgsl",
-    "category": "image",
-    "description": "Repels or attracts pixels based on mouse position and luminance weight.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mode",
-        "name": "Mode (Repel/Attract)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 1.0
-      },
-      {
-        "id": "lumaWeight",
-        "name": "Luma Weight",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "optical-feedback",
-    "name": "Optical Feedback Loop",
-    "url": "shaders/optical-feedback.wgsl",
-    "category": "image",
-    "description": "Infinite video feedback loop centered on the mouse cursor.",
-    "params": [
-      {
-        "id": "zoom",
-        "name": "Feedback Zoom",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Decay",
-        "default": 0.95,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift",
-        "name": "Hue Shift",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "digital-haze",
-    "category": "image",
-    "url": "shaders/digital-haze.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "pixel_strength",
-        "name": "Pixel Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Controls grid size for pixelation"
-      },
-      {
-        "id": "clear_radius",
-        "name": "Clear Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Radius around mouse where fog clears"
-      },
-      {
-        "id": "noise_amount",
-        "name": "Noise Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Amount of digital noise in the haze"
-      },
-      {
-        "id": "haze_density",
-        "name": "Haze Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Density of the volumetric haze"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Digital Haze"
-  },
-  {
-    "id": "raindrop-ripples",
-    "name": "Raindrop Ripples",
-    "url": "shaders/raindrop-ripples.wgsl",
-    "category": "image",
-    "description": "Raindrops fall creating ripples, but the mouse cursor acts as a shield.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Rain Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shield",
-        "name": "Shield Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "x-ray-reveal",
-    "name": "X-Ray Reveal",
-    "url": "shaders/x-ray-reveal.wgsl",
-    "category": "image",
-    "description": "Interactive X-Ray lens that reveals an inverted, edge-enhanced internal structure.",
-    "params": [
-      {
-        "id": "lens_size",
-        "name": "Lens Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Radius of the X-ray lens"
-      },
-      {
-        "id": "edge_strength",
-        "name": "Edge Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Strength of edge enhancement"
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Contrast of the X-ray effect"
-      },
-      {
-        "id": "lens_softness",
-        "name": "Lens Edge Softness",
-        "default": 0.075,
-        "min": 0.0,
-        "max": 0.15,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Softness of the lens edge falloff"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chronos-brush",
-    "name": "Chronos Brush",
-    "url": "shaders/chronos-brush.wgsl",
-    "category": "image",
-    "description": "Freeze time by painting over the video feed.",
-    "params": [
-      {
-        "id": "brushSize",
-        "name": "Brush Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Freeze Decay",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Time Edge Distort",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mode",
-        "name": "Mode (Paint/Erase)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "labels": [
-          "Freeze",
-          "Unfreeze"
-        ]
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-flashlight",
-    "name": "Neon Flashlight",
-    "url": "shaders/neon-flashlight.wgsl",
-    "category": "image",
-    "description": "Dark environment illuminated by a neon-edge detecting flashlight.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Beam Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Neon Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Edge Threshold",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ambient",
-        "name": "Ambient Light",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "cyber-rain",
-    "name": "Cyber Rain",
-    "url": "shaders/cyber-rain.wgsl",
-    "category": "image",
-    "description": "Neon rain on wet glass with mouse wiper.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Rain Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "blur",
-        "name": "Wet Blur",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "bloom",
-        "name": "Neon Bloom",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "wiper",
-        "name": "Wiper Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "magnetic-luma-sort",
-    "name": "Magnetic Luma Sort",
-    "url": "shaders/magnetic-luma-sort.wgsl",
-    "category": "image",
-    "description": "Pixels are magnetically pulled by the cursor based on brightness, creating trails.",
-    "params": [
-      {
-        "id": "pullStrength",
-        "name": "Pull Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Luma Threshold",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "trailDecay",
-        "name": "Trail Decay",
-        "default": 0.9,
-        "min": 0.5,
-        "max": 0.99
-      },
-      {
-        "id": "mode",
-        "name": "Attract/Repel",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "selective-color",
-    "name": "Voronoi Multi-Focal Selective",
-    "url": "shaders/selective-color.wgsl",
-    "category": "image",
-    "description": "Voronoi multi-focal selective desaturation with chromatic aberration, fractal noise masking, polar sectors, SDF shapes, ripple propagation, and depth-aware edge detection.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "desat",
-        "name": "Desat. Strength",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mask_feather",
-        "name": "Mask Feather",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Softness exponent for the mask edge"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "depth-aware",
-      "temporal"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "spectral-brush",
-    "name": "Spectral Brush",
-    "url": "shaders/spectral-brush.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "temporal"
-    ],
-    "description": "Reveals a spectral dimension where you paint with the mouse. Reacts to audio bass.",
-    "params": [
-      {
-        "id": "brush-size",
-        "name": "Brush Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spectral-shift",
-        "name": "Spectral Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "persistence",
-        "name": "Persistence",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge-hardness",
-        "name": "Edge Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "interactive-kuwahara",
-    "name": "Oil Painting (Kuwahara)",
-    "url": "shaders/interactive-kuwahara.wgsl",
-    "category": "image",
-    "description": "Applies an oil painting effect using a Kuwahara filter. Mouse distance controls the detail level (focus area).",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "satBoost",
-        "name": "Saturation",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mouseFalloff",
-        "name": "Focus Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hardness",
-        "name": "Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "artistic"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-strings",
-    "name": "Neon Strings",
-    "url": "shaders/neon-strings.wgsl",
-    "category": "image",
-    "description": "Vibrating neon strings generated from edge detection, agitated by the mouse.",
-    "params": [
-      {
-        "id": "thickness",
-        "name": "Edge Threshold",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "vibration",
-        "name": "Vibration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "neon",
-        "name": "Neon Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "magnetic-pixels",
-    "name": "Magnetic Pixels",
-    "url": "shaders/magnetic-pixels.wgsl",
-    "category": "image",
-    "description": "Pixels are magnetically repelled by the cursor, creating a void.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Force Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hardness",
-        "name": "Edge Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "rain-lens-wipe",
-    "name": "Rain Lens Wipe",
-    "url": "shaders/rain-lens-wipe.wgsl",
-    "category": "image",
-    "description": "Simulates raindrops on a lens. Use the mouse to wipe them away.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Rain Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Re-fog Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Wipe Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "density",
-        "name": "Rain Density",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "fluid-grid",
-    "name": "Fluid Grid",
-    "url": "shaders/fluid-grid.wgsl",
-    "category": "image",
-    "description": "Flowing grid distortion with fluid dynamics.",
-    "params": [
-      {
-        "id": "grid_size",
-        "name": "Grid Size",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "flow_speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
+        "description": "Liquid thickness/resistance"
       },
       {
         "id": "turbulence",
         "name": "Turbulence",
-        "default": 0.5,
+        "default": 0.4,
         "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "animated",
-      "grid",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "spectral-vortex",
-    "name": "Spectral Vortex",
-    "url": "shaders/spectral-vortex.wgsl",
-    "category": "image",
-    "description": "Spectral color vortex with twisted distortions.",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "twist_scale",
-        "name": "Twist Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Amount of twist distortion"
-      },
-      {
-        "id": "distortion_step",
-        "name": "Distortion Step",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Step size of distortion"
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
       },
       {
         "id": "color_shift",
         "name": "Color Shift",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Spectral color rotation"
-      },
-      {
-        "id": "curl_amp",
-        "name": "Curl Amplification",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Amplification of curl velocity field"
-      }
-    ]
-  },
-  {
-    "id": "infinite-zoom-lens",
-    "name": "Infinite Zoom Lens",
-    "url": "shaders/infinite-zoom-lens.wgsl",
-    "category": "image",
-    "description": "A recursive feedback lens that creates infinite tunnels inside a mouse-controlled circle.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "zoom",
-        "name": "Zoom Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Lens Radius",
         "default": 0.3,
-        "min": 0.1,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Feedback Persistence",
-        "default": 0.9,
-        "min": 0.5,
-        "max": 0.99
-      },
-      {
-        "id": "rotation",
-        "name": "Twist",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "vortex-warp",
-    "name": "Vortex Warp",
-    "url": "shaders/vortex-warp.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "description": "Swirls the image around the mouse cursor.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Vortex Strength",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "twist",
-        "name": "Spiral Twist",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Vortex turbulence amount"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "infinite-zoom",
-    "name": "Infinite Zoom",
-    "url": "shaders/infinite-zoom.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "zoom_speed",
-        "name": "Zoom Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Speed of infinite zoom"
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Hyperbolic distortion amount"
-      },
-      {
-        "id": "rotation",
-        "name": "Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Rotation of the zoom tunnel"
-      },
-      {
-        "id": "max_iterations",
-        "name": "Max Iterations",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Maximum fractal iterations"
+        "description": "Color manipulation amount"
       }
     ]
   },
   {
-    "id": "cyber-lens",
-    "name": "Cyber Lens",
-    "url": "shaders/cyber-lens.wgsl",
+    "id": "neural-dreamscape",
+    "name": "Neural Dreamscape",
+    "url": "shaders/neural-dreamscape.wgsl",
     "category": "image",
-    "description": "Digital fisheye with scan lines and chromatic aberration.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Lens Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "aberration",
-        "name": "Chromatic",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "scanlines",
-        "name": "Scan Lines",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "vignette",
-        "name": "Vignette",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "distortion",
-      "retro",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "black-hole",
-    "name": "Gravitational Lensing",
-    "url": "shaders/black-hole.wgsl",
-    "category": "image",
+    "description": "Neural network-inspired dreamlike visuals.",
     "features": [
       "mouse-driven"
     ],
@@ -9532,16 +1384,107 @@
     ]
   },
   {
-    "id": "ethereal-swirl",
-    "name": "Ethereal Swirl",
-    "url": "shaders/ethereal-swirl.wgsl",
+    "id": "neural-resonance",
+    "name": "Neural Resonance",
+    "url": "shaders/neural-resonance.wgsl",
     "category": "image",
-    "description": "Ethereal swirling motion with soft gradients.",
+    "description": "Runaway neural feedback loop with hallucinogenic pareidolic effects and breathing fractals.",
     "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
+      "mouse-driven"
     ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "quantum-foam",
+    "name": "Quantum Foam",
+    "url": "shaders/quantum-foam.wgsl",
+    "category": "image",
+    "description": "Quantum foam texture with spacetime fluctuations.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "quantum-fractal",
+    "name": "Quantum Fractal",
+    "url": "shaders/quantum-fractal.wgsl",
+    "category": "image",
+    "description": "Fractal quantum interference patterns.",
     "tags": [
       "filter",
       "image-processing",
@@ -9549,471 +1492,67 @@
       "music",
       "reactive"
     ],
+    "features": [
+      "audio-reactive",
+      "audio-driven",
+      "mouse-driven"
+    ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
+        "id": "scale",
         "name": "Scale",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "elastic-surface",
-    "name": "Elastic Surface",
-    "url": "shaders/elastic-surface.wgsl",
-    "category": "image",
-    "description": "Bouncy rubber-like surface distortion.",
-    "params": [
-      {
-        "id": "elasticity",
-        "name": "Elasticity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "frequency",
-        "name": "Wave Frequency",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "amplitude",
-        "name": "Wave Height",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "animated",
-      "wave",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "refraction-tunnel",
-    "name": "Refraction Tunnel",
-    "url": "shaders/refraction-tunnel.wgsl",
-    "category": "image",
-    "description": "Infinite refractive tunnel effect.",
-    "params": [
-      {
-        "id": "depth",
-        "name": "Tunnel Depth",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "twist",
-        "name": "Twist Amount",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "aberration",
-        "name": "Chromatic",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "speed",
-        "name": "Travel Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "animated",
-      "3d",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "perspective-tilt",
-    "name": "Perspective Tilt",
-    "url": "shaders/perspective-tilt.wgsl",
-    "category": "image",
-    "description": "Rotates the image plane in 3D space based on mouse position (Pitch/Yaw). Zoom param adjusts distance.",
-    "params": [
-      {
-        "id": "tilt_sensitivity",
-        "name": "Tilt Sensitivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Sensitivity of the tilt effect"
+        "description": "Fractal scale"
       },
       {
-        "id": "distance",
-        "name": "Distance (FOV)",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Camera distance / field of view"
-      },
-      {
-        "id": "pitch_enable",
-        "name": "Y-Axis Tilt (Pitch)",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Enable or scale pitch tilt amount"
-      },
-      {
-        "id": "plane_scale",
-        "name": "Plane Scale",
-        "default": 1.0,
-        "min": 0.5,
-        "max": 2.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Scale of the projected plane"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "fractal-kaleidoscope",
-    "name": "Fractal Kaleidoscope",
-    "url": "shaders/fractal-kaleidoscope.wgsl",
-    "category": "image",
-    "description": "Fractal patterns in a kaleidoscope arrangement.",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "pixel-storm",
-    "name": "Pixel Storm",
-    "url": "shaders/pixel-storm.wgsl",
-    "category": "image",
-    "description": "Mouse movement creates a chaotic storm of pixels.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Storm Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "trail",
-        "name": "Trail Length",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "sine-wave",
-    "name": "Sine Wave Distortion",
-    "url": "shaders/sine-wave.wgsl",
-    "category": "image",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "glass-brick-distortion",
-    "category": "image",
-    "url": "shaders/glass-brick-distortion.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Brick Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Grout Width",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Clear Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Glass Brick Wall"
-  },
-  {
-    "id": "fractal-image-surf",
-    "name": "Fractal Image Surf",
-    "url": "shaders/fractal-image-surf.wgsl",
-    "category": "image",
-    "description": "Maps the image onto a Julia Set fractal coordinate system, controlled by the mouse.",
-    "params": [
-      {
+        "id": "iterations",
         "name": "Iterations",
-        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Iteration depth"
+      },
+      {
+        "id": "entanglement",
+        "name": "Entanglement",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Quantum entanglement strength"
+      },
+      {
+        "id": "edge_glow",
+        "name": "Edge Glow",
         "default": 0.3,
         "min": 0,
         "max": 1,
-        "id": "iterations"
-      },
-      {
-        "name": "Zoom",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "zoom"
-      },
-      {
-        "name": "Offset X",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "offset_x"
-      },
-      {
-        "name": "Offset Y",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "offset_y"
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Glow on fractal edges"
       }
-    ],
+    ]
+  },
+  {
+    "id": "quantum-smear",
+    "name": "Quantum Smear",
+    "url": "shaders/quantum-smear.wgsl",
+    "category": "image",
+    "description": "Quantum particle disintegration with stochastic advection and pointillist effects.",
     "features": [
       "mouse-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ]
-  },
-  {
-    "id": "data-slicer",
-    "name": "Data Slicer",
-    "url": "shaders/data-slicer.wgsl",
-    "category": "image",
-    "description": "Glitchy horizontal slicing effect with chromatic aberration. Mouse Y controls influence area, Mouse X controls offset direction.",
-    "params": [
-      {
-        "id": "slideSpeed",
-        "name": "Jitter Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "sliceHeight",
-        "name": "Slice Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos Amount",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Color Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
     ],
-    "features": [
-      "mouse-driven",
-      "distortion"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "bubble-lens",
-    "name": "Bubble Lens",
-    "url": "shaders/bubble-lens.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "A magnifying bubble lens distortion that follows the mouse cursor.",
     "params": [
       {
         "id": "param1",
@@ -10047,114 +1586,96 @@
         "max": 1,
         "step": 0.01
       }
+    ]
+  },
+  {
+    "id": "quantum-wormhole",
+    "name": "Quantum Wormhole",
+    "url": "shaders/quantum-wormhole.wgsl",
+    "category": "image",
+    "description": "Wormhole-like spacetime distortion effects.",
+    "features": [
+      "mouse-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ]
-  },
-  {
-    "id": "kaleidoscope",
-    "name": "Rose FBM Kaleidoscope",
-    "url": "shaders/kaleidoscope.wgsl",
-    "category": "image",
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "audio-reactive",
-      "audio-driven"
     ],
     "params": [
       {
-        "id": "segments",
-        "name": "Segments",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Rotation Speed",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "zoom",
-        "name": "Zoom",
+        "id": "param2",
+        "name": "Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "edge_softness",
-        "name": "Edge Softness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "prismatic-mosaic",
-    "name": "Prismatic Mosaic",
-    "url": "shaders/prismatic-mosaic.wgsl",
+    "id": "radiating-displacement",
+    "name": "Radiating Displacement",
+    "url": "shaders/radiating-displacement.wgsl",
     "category": "image",
-    "description": "Color tiles break apart and reassemble into shifting prisms, turning strong colors into a kaleidoscopic mosaic that ripples across the image.",
+    "description": "Rippling displacement waves emanate only from strong colours; neutrals stay sharp. Mouse-click to seed ripples.",
     "params": [
       {
-        "id": "min_speed",
-        "name": "Min Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Minimum layer animation speed"
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "max_speed",
-        "name": "Max Speed",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Maximum layer animation speed"
+        "id": "strength",
+        "name": "Displace Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "saturation_boost",
-        "name": "Saturation Boost",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Saturation boost amount"
+        "id": "satThresh",
+        "name": "Saturation Threshold",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "fog_density",
-        "name": "Fog Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Volumetric fog density"
+        "id": "radius",
+        "name": "Wave Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
       "depth-aware",
       "temporal-persistence",
+      "interactive",
       "colour-masking",
       "mouse-driven"
     ],
@@ -10164,5632 +1685,198 @@
     ]
   },
   {
-    "id": "magnetic-field",
-    "name": "Magnetic Field",
-    "url": "shaders/magnetic-field.wgsl",
+    "id": "radiating-haze",
+    "name": "Radiating Haze",
+    "url": "shaders/radiating-haze.wgsl",
     "category": "image",
-    "description": "Magnetic field lines distortion effect.",
+    "description": "Animated aura around strong colours; browns, greys & blacks are ignored. Now with colour-mode switch.",
     "params": [
       {
-        "id": "strength",
-        "name": "Field Strength",
+        "id": "speed",
+        "name": "Wave Speed",
         "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Aura Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "satThresh",
+        "name": "Saturation Threshold",
+        "default": 0.4,
         "min": 0,
         "max": 1
       },
       {
         "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "density",
-        "name": "Field Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "mode",
-        "name": "Mode",
+        "name": "Aura Radius",
         "default": 0.5,
         "min": 0,
         "max": 1
       }
     ],
     "features": [
-      "animated",
-      "physics",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
+      "depth-aware",
+      "temporal-persistence",
+      "colour-masking",
+      "multi-mode",
+      "mouse-driven"
     ],
     "tags": [
       "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
+      "image-processing"
     ]
   },
   {
-    "id": "gemstone-fractures",
-    "name": "Gemstone Fractures",
-    "url": "shaders/gemstone-fractures.wgsl",
+    "id": "rain",
+    "name": "Rain",
+    "url": "shaders/rain.wgsl",
     "category": "image",
-    "features": [
-      "alpha-transmission",
-      "physical-refraction"
+    "tags": [
+      "filter",
+      "image-processing"
     ],
-    "description": "Fragments the image into crystalline shards with physical light transmission. Features internal fractures that scatter light, variable purity per cell, and IOR-based refraction.",
+    "features": [
+      "mouse-driven"
+    ],
     "params": [
       {
-        "name": "Facet Size",
-        "id": "zoomParam1",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Size of Voronoi crystal cells"
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "name": "Refractive Index",
-        "id": "zoomParam2",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "IOR: Quartz (1.54) to Diamond (2.42)"
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "name": "Rotation",
-        "id": "zoomParam3",
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "rainbow-cloud",
+    "name": "Rainbow Cloud",
+    "url": "shaders/rainbow-cloud.wgsl",
+    "category": "image",
+    "description": "Colorful cloud formations with rainbow gradients.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "rorschach-inkblot",
+    "name": "Rorschach Inkblot",
+    "url": "shaders/rorschach-inkblot.wgsl",
+    "category": "image",
+    "description": "Symmetrical inkblot visualization using the Rorschach test aesthetic.",
+    "params": [
+      {
+        "name": "Threshold",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "target": "zoom_params.x",
+        "id": "threshold"
+      },
+      {
+        "name": "Distortion",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "target": "zoom_params.y",
+        "id": "distortion"
+      },
+      {
+        "name": "Smoothness",
+        "type": "float",
         "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Cell rotation animation speed"
-      },
-      {
-        "name": "Fracture Density",
-        "id": "zoomParam4",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Internal fractures: 0 = pure crystal, 1 = heavily fractured"
-      }
-    ],
-    "tags": [
-      "crystal",
-      "gemstone",
-      "fracture",
-      "transmission",
-      "voronoi",
-      "physical"
-    ]
-  },
-  {
-    "id": "voronoi-faceted-glass",
-    "name": "Voronoi Faceted Glass",
-    "url": "shaders/voronoi-faceted-glass.wgsl",
-    "category": "image",
-    "description": "Cellular glass distortion effect.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "target": "zoom_params.z",
+        "id": "smoothness"
       },
       {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "vortex",
-    "name": "Clean Vortex",
-    "url": "shaders/vortex.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "phase-shift",
-    "name": "Phase Shift",
-    "url": "shaders/phase-shift.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "RGB channels are rotationally shifted relative to the mouse position.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "psy-swirls",
-    "name": "Psychedelic Rainbow Swirls",
-    "url": "shaders/generative-psy-swirls.wgsl",
-    "category": "image",
-    "description": "Generative swirling vortex fields with multi-layer procedural noise flow, spectral rainbow HSV cycles from polar angles, temporal twisting, and psychedelic distortion. Mouse attracts swirls; ripples spawn color bursts.",
-    "params": [
-      {
-        "name": "Swirl Speed",
-        "type": "range",
-        "min": 0,
-        "max": 2,
-        "default": 1,
-        "desc": "Global rotation and flow velocity",
-        "id": "swirl_speed"
-      },
-      {
-        "name": "Layer Count",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "desc": "Number of nested swirl layers (2-6)",
-        "id": "layer_count"
-      },
-      {
-        "name": "Rainbow Speed",
-        "type": "range",
-        "min": 0,
-        "max": 2,
-        "default": 0.8,
-        "desc": "Hue cycling rate",
-        "id": "rainbow_speed"
-      },
-      {
-        "name": "Twist Intensity",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.6,
-        "desc": "Vortex distortion strength (depth-reduced)",
-        "id": "twist_intensity"
-      }
-    ],
-    "features": [
-      "generative",
-      "procedural",
-      "psychedelic",
-      "rainbow",
-      "swirls",
-      "vortex",
-      "depth-aware",
-      "interactive",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "gen-temporal-motion-smear",
-    "name": "Temporal Motion Smear",
-    "url": "shaders/gen-temporal-motion-smear.wgsl",
-    "category": "image",
-    "description": "Motion-aware temporal smearing using frame differencing and directional blur, creating colorful trails that follow moving objects",
-    "tags": [
-      "temporal",
-      "motion",
-      "smear",
-      "trails",
-      "frame-differencing",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "temporal",
-      "motion-aware",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "persistence",
-        "name": "Trail Persistence",
-        "default": 0.85,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "sensitivity",
-        "name": "Motion Sensitivity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "directionality",
-        "name": "Smear Directionality",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Color Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "gen-feedback-echo-chamber",
-    "name": "Feedback Echo Chamber",
-    "url": "shaders/gen-feedback-echo-chamber.wgsl",
-    "category": "image",
-    "description": "Multi-layer temporal echo with feedback decay, creating ghost images of previous frames fading into depth with color grading per layer",
-    "tags": [
-      "temporal",
-      "echo",
-      "feedback",
-      "multi-layer",
-      "ghosting",
-      "audio",
-      "music",
-      "reactive",
-      "alpha",
-      "accumulative"
-    ],
-    "features": [
-      "temporal",
-      "multi-pass",
-      "audio-reactive",
-      "audio-driven",
-      "advanced-alpha"
-    ],
-    "params": [
-      {
-        "id": "echoCount",
-        "name": "Echo Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "decayRate",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "spacing",
-        "name": "Echo Spacing",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "turing-veins",
-    "name": "Turing Veins",
-    "url": "shaders/generative-turing-veins.wgsl",
-    "category": "image",
-    "description": "Generative multiscale reaction-diffusion Turing patterns forming organic vein/networks with bioluminescent glow. Procedurally evolves over time; depth increases complexity; mouse perturbs fields. Subtly distorts and overlays input image.",
-    "params": [
-      {
-        "name": "Scale 1",
-        "type": "range",
-        "min": 0,
-        "max": 2,
-        "default": 1,
-        "desc": "Primary Turing pattern scale (depth-modulated)",
-        "id": "scale_1"
-      },
-      {
-        "name": "Scale 2",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.6,
-        "desc": "Secondary finer scale",
-        "id": "scale_2"
-      },
-      {
-        "name": "Feed Rate",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "desc": "Reaction-diffusion activator/inhibitor balance",
-        "id": "feed_rate"
-      },
-      {
-        "name": "Vein Glow",
-        "type": "range",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "desc": "Bioluminescent emission intensity",
-        "id": "vein_glow"
-      }
-    ],
-    "features": [
-      "generative",
-      "procedural",
-      "reaction-diffusion",
-      "turing-patterns",
-      "depth-aware",
-      "biological",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-zoom",
-    "name": "Liquid Zoom",
-    "url": "shaders/liquid-zoom.wgsl",
-    "category": "image",
-    "description": "",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "liquid-viscous-grokcf1",
-    "name": "Liquid Viscous Nebula grokcf1",
-    "url": "shaders/liquid-viscous-grokcf1.wgsl",
-    "category": "image",
-    "description": "Enhanced viscous liquid with nebula glow, multi-layer flow, and cosmic viscosity.",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "liquid-perspective",
-    "name": "Liquid Perspective",
-    "url": "shaders/liquid-perspective.wgsl",
-    "category": "image",
-    "description": "",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
+        "name": "Invert Mode",
+        "type": "float",
         "default": 0,
         "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-fast",
-    "name": "Liquid Fast",
-    "url": "shaders/liquid-fast.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "liquid-v1",
-    "name": "Liquid (Ambient)",
-    "url": "shaders/liquid-v1.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "liquid-rainbow",
-    "name": "Liquid Rainbow",
-    "url": "shaders/liquid-rainbow.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "liquid-metal",
-    "name": "Liquid Metal",
-    "url": "shaders/liquid-metal.wgsl",
-    "category": "image",
-    "description": "",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "liquid-viscous-simple",
-    "name": "Liquid Viscous (Simple)",
-    "url": "shaders/liquid-viscous-simple.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "liquid-glitch",
-    "name": "Liquid Glitch",
-    "url": "shaders/liquid-glitch.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "glass-wipes",
-    "name": "Rainy Window",
-    "url": "shaders/glass-wipes.wgsl",
-    "category": "image",
-    "description": "Simulates rain on a window that distorts the view. Use the mouse to wipe the glass clean.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Rain Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "wiper",
-        "name": "Wiper Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dry_speed",
-        "name": "Drying Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-viscous",
-    "name": "Liquid Viscous",
-    "url": "shaders/liquid-viscous.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "liquid-rgb",
-    "name": "Liquid RGB",
-    "url": "shaders/liquid-rgb.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "luma-velocity-melt",
-    "name": "Luma Velocity Melt",
-    "url": "shaders/luma-velocity-melt.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Image melts downwards based on brightness. Mouse heat speeds up the melting.",
-    "params": [
-      {
-        "name": "Melt Speed",
-        "id": "melt-speed",
-        "default": 0.005,
-        "min": 0.0,
-        "max": 0.02
-      },
-      {
-        "name": "Heat Intensity",
-        "id": "heat-intensity",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0
-      },
-      {
-        "name": "Persistence",
-        "id": "persistence",
-        "default": 0.95,
-        "min": 0.5,
-        "max": 0.999
-      },
-      {
-        "name": "Luma Threshold",
-        "id": "luma-threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "ink-marbling",
-    "name": "Ink Marbling",
-    "url": "shaders/ink-marbling.wgsl",
-    "category": "image",
-    "description": "Distorts the image with fluid, ink-like domain warping.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "rain-ripples",
-    "name": "Rain Ripples",
-    "url": "shaders/rain-ripples.wgsl",
-    "category": "image",
-    "description": "Interactive water ripples and raindrops.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-jelly",
-    "name": "Liquid Jelly",
-    "url": "shaders/liquid-jelly.wgsl",
-    "category": "image",
-    "description": "Elastic liquid effect with subsurface scattering and alpha physics",
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "elastic-bounce",
-      "volume-shading",
-      "subsurface-scattering",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "liquid"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ]
-  },
-  {
-    "id": "liquid-oil",
-    "name": "Liquid Oil",
-    "url": "shaders/liquid-oil.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "liquid",
-    "name": "Liquid (Interactive)",
-    "url": "shaders/liquid.wgsl",
-    "category": "image",
-    "description": "",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "liquid-smear",
-    "name": "Liquid Smear",
-    "url": "shaders/liquid-smear.wgsl",
-    "category": "image",
-    "description": "Smudge pixels like wet paint with your mouse.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Smear Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "size",
-        "name": "Brush Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Persistence",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mix",
-        "name": "Mix Strength",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-mirror",
-    "name": "Liquid Mirror",
-    "url": "shaders/liquid-mirror.wgsl",
-    "category": "image",
-    "description": "Metallic liquid surface that reflects the image and ripples under the mouse.",
-    "params": [
-      {
-        "id": "distort",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smooth",
-        "name": "Smoothness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "reflect",
-        "name": "Reflectivity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "push",
-        "name": "Push Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "liquid-pass2",
-    "name": "Liquid (Pass 2)",
-    "url": "shaders/liquid-pass2.wgsl",
-    "category": "image",
-    "description": "Fluid rendering pass: surface normal calculation, Snell's law refraction, Fresnel reflection, Beer-Lambert wavelength-dependent absorption, specular highlights, and physics-based alpha blending.",
-    "tags": [
-      "liquid",
-      "refraction",
-      "fresnel",
-      "beer-lambert",
-      "multi-pass"
-    ],
-    "features": [
-      "multi-pass-2",
-      "mouse-driven"
-    ],
-    "multipass": {
-      "pass": 2,
-      "totalPasses": 2
-    },
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "liquid-pass1",
-    "name": "Liquid (Pass 1)",
-    "url": "shaders/liquid-pass1.wgsl",
-    "category": "image",
-    "description": "Capillary wave physics pass: surface tension simulation with Laplacian and biharmonic operators, gravity waves, ripple sources, and ambient micro-ripples. Outputs persistent height field to dataTextureA.",
-    "tags": [
-      "liquid",
-      "capillary-waves",
-      "physics",
-      "multi-pass"
-    ],
-    "features": [
-      "multi-pass-1",
-      "mouse-driven"
-    ],
-    "multipass": {
-      "pass": 1,
-      "totalPasses": 2,
-      "nextShader": "liquid-pass2"
-    },
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "slime-drip",
-    "name": "Slime Drip",
-    "url": "shaders/slime-drip.wgsl",
-    "category": "image",
-    "description": "A gooey, dripping slime effect that can be wiped away.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Drip Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amount",
-        "name": "Slime Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color",
-        "name": "Green Tint",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "texture",
-    "name": "Procedural Texture Analyzer",
-    "url": "shaders/texture.wgsl",
-    "category": "image",
-    "description": "Multi-scale texture analyzer with Laplacian edge enhancement, unsharp mask, temporal smoothing, golden-ratio vignette, and audio-reactive sparkle/glitch.",
-    "features": [
-      "depth-aware",
-      "upgraded-rgba",
-      "audio-reactive",
-      "temporal"
-    ],
-    "tags": [
-      "image",
-      "video",
-      "edge-enhance",
-      "unsharp",
-      "temporal",
-      "vignette",
-      "audio-reactive",
-      "vj"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Edge Enhance",
-        "default": 0.35,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Unsharp Mask",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Temporal Smooth",
-        "default": 0.25,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Audio Reactivity",
-        "default": 0.7,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "spectral-mesh",
-    "name": "Spectral Mesh",
-    "url": "shaders/spectral-mesh.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "grid_density",
-        "name": "Grid Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of the spectral mesh"
-      },
-      {
-        "id": "displacement",
-        "name": "Displacement Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Height of mesh displacement"
-      },
-      {
-        "id": "mouse_radius",
-        "name": "Mouse Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Radius of mouse interaction"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Spectral color shift"
-      }
-    ]
-  },
-  {
-    "id": "conv-reaction-convolution",
-    "name": "Reaction Convolution",
-    "url": "shaders/conv-reaction-convolution.wgsl",
-    "category": "image",
-    "description": "Gray-Scott reaction-diffusion applied as a convolution filter on the input image. Uses image luminance to seed chemical concentrations and mouse interaction to inject patterns.",
-    "tags": [
-      "convolution",
-      "reaction-diffusion",
-      "gray-scott",
-      "mouse-driven",
-      "interactive",
-      "rgba-as-data"
-    ],
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "diffA",
-        "name": "Diffusion A",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "diffB",
-        "name": "Diffusion B",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "feedRate",
-        "name": "Feed Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "mouseInfluence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "honey-melt",
-    "name": "Honey Melt",
-    "url": "shaders/honey-melt.wgsl",
-    "category": "image",
-    "description": "A golden hexagonal grid that melts under the mouse.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Cell Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Melt Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distort",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "glitch-ripple-drag",
-    "category": "image",
-    "url": "shaders/glitch-ripple-drag.wgsl",
-    "description": "Mouse emits expanding ripples that permanently drag and glitch the video pixels.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "drag",
-        "name": "Drag Strength",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "freq",
-        "name": "Ripple Freq",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "persist",
-        "name": "Persistence",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch Factor",
-        "type": "float",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Glitch Ripple Drag"
-  },
-  {
-    "id": "retro-gameboy",
-    "name": "Retro Game Boy",
-    "category": "image",
-    "description": "Simulates a classic handheld green dot-matrix display.",
-    "url": "shaders/retro-gameboy.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "pixel_size",
-        "name": "Pixel Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "grid_strength",
-        "name": "Grid Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shadow_offset",
-        "name": "Shadow Offset",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "crumpled-paper",
-    "name": "Crumpled Paper",
-    "category": "image",
-    "description": "Simulates the look of crumpled paper with interactive smoothing.",
-    "url": "shaders/crumpled-paper.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "scale",
-        "name": "Crumple Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "depth",
-        "name": "Crumple Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smooth_radius",
-        "name": "Smooth Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "light_strength",
-        "name": "Light Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "graphic-novel",
-    "name": "Graphic Novel",
-    "category": "image",
-    "description": "Transforms image into a comic book style with edge detection and halftone patterns.",
-    "url": "shaders/graphic_novel.wgsl",
-    "params": [
-      {
-        "id": "dotSize",
-        "name": "Dot Size",
-        "min": 0,
-        "max": 1,
-        "default": 0.3
-      },
-      {
-        "id": "edge",
-        "name": "Edge Strength",
-        "min": 0,
-        "max": 1,
-        "default": 0.5
-      },
-      {
-        "id": "levels",
-        "name": "Color Levels",
-        "min": 0,
-        "max": 1,
-        "default": 0.4
-      },
-      {
-        "id": "paper",
-        "name": "Paper Grain",
-        "min": 0,
-        "max": 1,
-        "default": 0.2
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-fractal-kernel",
-    "name": "Fractal Kernel",
-    "description": "Convolution kernel shaped by Mandelbrot set membership. Pixels inside the fractal are sampled, creating alien mathematically beautiful blur patterns. Alpha stores fractal iteration depth. Mouse warps the Mandelbrot center live.",
-    "url": "shaders/conv-fractal-kernel.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "kernel_radius",
-        "name": "Kernel Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "fractal_zoom",
-        "name": "Fractal Zoom",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "iterations",
-        "name": "Fractal Iterations",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Warp",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "fractal",
-      "mandelbrot",
-      "convolution",
-      "kernel",
-      "psychedelic",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-structure-tensor-flow",
-    "name": "Structure Tensor Flow",
-    "description": "Computes structure tensor, extracts eigenvectors for dominant texture orientation, and visualizes flow via Line Integral Convolution. RGBA32FLOAT packs eigenvector components, coherency, and LIC intensity. Mouse creates vortices in the flow field.",
-    "url": "shaders/conv-structure-tensor-flow.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "lic_steps",
-        "name": "LIC Steps",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "coherency_boost",
-        "name": "Coherency Boost",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "flow_speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Vortex",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "structure-tensor",
-      "LIC",
-      "flow-visualization",
-      "convolution",
-      "texture-analysis",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "color-blindness",
-    "name": "Color Blindness Sim",
-    "url": "shaders/color-blindness.wgsl",
-    "category": "image",
-    "description": "Simulates various forms of color blindness (Protanopia, Deuteranopia, Tritanopia) with split-screen comparison.",
-    "params": [
-      {
-        "id": "type",
-        "name": "Type (P/D/T)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "severity",
-        "name": "Severity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "split",
-        "name": "Split Screen",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "unused",
-        "name": "Unused",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "concentric-spin",
-    "name": "Concentric Spin",
-    "category": "image",
-    "url": "shaders/concentric-spin.wgsl",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "description": "Concentric rings that rotate in alternating directions. Mouse controls the center. Audio-reactive rotation with ring gap opacity.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Ring Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Rotation Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Smoothness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Ring Gap Opacity",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "steampunk-gear-lens",
-    "name": "Steampunk Gear Lens",
-    "url": "shaders/steampunk-gear-lens.wgsl",
-    "category": "image",
-    "description": "A rotating mechanical gear lens with sepia filter and audio-reactive rotation.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Gear Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "teeth",
-        "name": "Teeth Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Rotation Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "sepia",
-        "name": "Sepia Strength",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "steampunk",
-      "gear",
-      "mechanical",
-      "sepia"
-    ]
-  },
-  {
-    "id": "voxel-depth-sort",
-    "name": "Voxel Depth Sort",
-    "url": "shaders/voxel-depth-sort.wgsl",
-    "category": "image",
-    "description": "Converts the image into a 3D grid of floating blocks. Block height is determined by brightness, and mouse position tilts the view.",
-    "params": [
-      {
-        "id": "gridSize",
-        "name": "Block Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "extrusion",
-        "name": "Extrusion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shadow",
-        "name": "BG Darken",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gap",
-        "name": "Block Gap",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.8
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "3d-effect"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pin-art-3d",
-    "name": "Pin Art 3D",
-    "category": "image",
-    "description": "Simulates a 3D pin art toy where image brightness controls pin height. Mouse pushes pins down.",
-    "url": "shaders/pin-art-3d.wgsl",
-    "params": [
-      {
-        "name": "Density",
-        "id": "density",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Pin Radius",
-        "id": "radius",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.8
-      },
-      {
-        "name": "Push Strength",
-        "id": "push",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.8
-      },
-      {
-        "name": "Metallic",
-        "id": "shiny",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-steerable-pyramid",
-    "name": "Steerable Pyramid",
-    "description": "Decomposes image into oriented sub-bands at 0, 45, 90, and 135 degrees using steerable filters. RGBA32FLOAT stores full-precision signed sub-band coefficients for lossless reconstruction or artistic boosting. Mouse steers the decomposition angle.",
-    "url": "shaders/conv-steerable-pyramid.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "sigma",
-        "name": "Filter Scale",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "response_scale",
-        "name": "Response Scale",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "color_boost",
-        "name": "Color Boost",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Steer",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "steerable-pyramid",
-      "orientation",
-      "sub-band",
-      "convolution",
-      "wavelet",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-difference-of-gaussians-cascade",
-    "name": "Difference of Gaussians Cascade",
-    "description": "Multi-scale Difference-of-Gaussians at 4 scales with signed response storage. Creates neural-edge glow where edges at different scales colorize differently. RGBA32FLOAT stores signed bipolar responses in all channels. Mouse controls scale emphasis.",
-    "url": "shaders/conv-difference-of-gaussians-cascade.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "scale_base",
-        "name": "Scale Base",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "contrast",
-        "name": "Edge Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Focus",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "difference-of-gaussians",
-      "multi-scale",
-      "edge-detection",
-      "convolution",
-      "psychedelic",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-morphological-erosion-dilation",
-    "name": "Morphological Erosion Dilation",
-    "description": "Mathematical morphology on images \u2014 erosion shrinks bright regions, dilation expands them. RGBA32FLOAT packs erosion (R), dilation (G), gradient (B), and top-hat (A) into one pass. Mouse controls directional structuring element.",
-    "url": "shaders/conv-morphological-erosion-dilation.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "kernel_radius",
-        "name": "Kernel Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "erode_dilate_blend",
-        "name": "Erosion / Dilation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "gradient_boost",
-        "name": "Gradient Boost",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "morphological",
-      "convolution",
-      "erosion",
-      "dilation",
-      "edge-detection",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "data-moshing",
-    "name": "Data Moshing",
-    "url": "shaders/data-moshing.wgsl",
-    "category": "image",
-    "description": "Smears pixels based on mouse movement, simulating video compression artifacts and glitch art.",
-    "params": [
-      {
-        "id": "smear",
-        "name": "Smear Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Brush Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "decay",
-        "name": "Persistence",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "crush",
-        "name": "Bit Crush",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "polka-wave",
-    "name": "Polka Wave",
-    "category": "image",
-    "description": "Halftone effect where dot size responds to image brightness and interactive ripples.",
-    "url": "shaders/polka-wave.wgsl",
-    "params": [
-      {
-        "name": "Grid Density",
-        "id": "density",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Wave Amp",
-        "id": "wave_amp",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Wave Freq",
-        "id": "wave_freq",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Wave Speed",
-        "id": "wave_speed",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-non-local-means",
-    "name": "Non-Local Means",
-    "description": "Gold-standard denoising that averages similar patches across the image. Cranked to artistic overdrive for hallucinatory double-exposure effects. Alpha stores self-similarity importance map. Mouse controls focus zone precision.",
-    "url": "shaders/conv-non-local-means.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "patch_radius",
-        "name": "Patch Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "search_radius",
-        "name": "Search Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "filter_strength",
-        "name": "Filter Strength",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "overdrive",
-        "name": "Artistic Overdrive",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "non-local-means",
-      "convolution",
-      "denoising",
-      "patch-similarity",
-      "artistic",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-halftone-scanner",
-    "name": "Cyber Halftone Scanner",
-    "url": "shaders/cyber-halftone-scanner.wgsl",
-    "category": "image",
-    "description": "CMYK-style halftone pattern with a scanning glitch line.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Dot Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Scan Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "separation",
-        "name": "RGB Split",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "brightness",
-        "name": "Brightness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "ring-slicer",
-    "name": "Ring Slicer",
-    "category": "image",
-    "description": "Slices the image into rotating concentric rings centered on the mouse.",
-    "url": "shaders/ring_slicer.wgsl",
-    "params": [
-      {
-        "id": "density",
-        "name": "Ring Count",
-        "min": 0,
-        "max": 1,
-        "default": 0.5
-      },
-      {
-        "id": "speed",
-        "name": "Rotation Speed",
-        "min": 0,
-        "max": 1,
-        "default": 0.6
-      },
-      {
-        "id": "chaos",
-        "name": "Chaos",
-        "min": 0,
-        "max": 1,
-        "default": 0.1
-      },
-      {
-        "id": "center",
-        "name": "Mouse Follow",
-        "min": 0,
-        "max": 1,
-        "default": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "circular-pixelate",
-    "name": "Circular Pixelate",
-    "category": "image",
-    "description": "Renders the image as a grid of circles. Mouse controls density and radius.",
-    "url": "shaders/circular-pixelate.wgsl",
-    "params": [
-      {
-        "name": "Density",
-        "id": "density",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Radius",
-        "id": "radius",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.4
-      },
-      {
-        "name": "Hardness",
-        "id": "hardness",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.8
-      },
-      {
-        "name": "Bg Mix",
-        "id": "bg_mix",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "video-echo-chamber",
-    "name": "Video Echo Chamber",
-    "url": "shaders/video-echo-chamber.wgsl",
-    "category": "image",
-    "description": "Temporal trails that persist longer near the mouse cursor, creating a ghostly echo effect.",
-    "params": [
-      {
-        "id": "decay",
-        "name": "Global Decay",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 0.95
-      },
-      {
-        "id": "radius",
-        "name": "Mouse Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "echoStr",
-        "name": "Echo Strength",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "page-curl-interactive",
-    "name": "Page Curl Interactive",
-    "category": "image",
-    "url": "shaders/page-curl-interactive.wgsl",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "temporal",
-      "depth-aware",
-      "upgraded-rgba"
-    ],
-    "description": "Interactive page curl with audio-reactive RGB splitting, click shockwaves, depth-aware shadows, and temporal feedback trails.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Curl Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Shadow Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Feedback Amount",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Depth Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "interactive",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "ripple-blocks",
-    "name": "Ripple Blocks",
-    "category": "image",
-    "description": "Grid blocks that scale based on a wave pattern from the mouse.",
-    "url": "shaders/ripple-blocks.wgsl",
-    "params": [
-      {
-        "name": "Grid Size",
-        "id": "grid_size",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Wave Amp",
-        "id": "wave_amp",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Freq",
-        "id": "freq",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Speed",
-        "id": "speed",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-frequency-domain-notch",
-    "name": "Frequency Domain Notch",
-    "description": "Spatial-domain approximation of frequency notch filtering using tuned sinusoidal convolution kernels. Removes moire patterns or creates frequency painting. Alpha stores spectral response magnitude. Mouse selects target frequency band.",
-    "url": "shaders/conv-frequency-domain-notch.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "num_bands",
-        "name": "Frequency Bands",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "bandwidth",
-        "name": "Notch Bandwidth",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "boost_cut",
-        "name": "Boost / Cut",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "frequency-notch",
-      "spectral",
-      "convolution",
-      "moire-removal",
-      "frequency-painting",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-stochastic-stipple",
-    "name": "Stochastic Stipple",
-    "description": "Blue-noise dithered weighted Voronoi stippling creating pointillist art from any image. Each dot represents a local neighborhood sized by average luminance. Alpha stores continuous stipple density for downstream dot-size variation. Mouse creates higher-resolution stipple zone.",
-    "url": "shaders/conv-stochastic-stipple.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "cell_size",
-        "name": "Cell Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "threshold",
-        "name": "Stipple Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "saturation",
-        "name": "Color Saturation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Resolution",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "stipple",
-      "pointillism",
-      "blue-noise",
-      "dithering",
-      "convolution",
-      "artistic",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "glitch-reveal",
-    "name": "Glitch Reveal",
-    "description": "A chaotic digital noise field that is stabilized and clarified by the proximity of the cursor.",
-    "url": "shaders/glitch-reveal.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "block",
-        "name": "Block Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scatter",
-        "name": "Scatter Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Reveal Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Jitter Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "triangle-mosaic",
-    "name": "Triangle Mosaic",
-    "category": "image",
-    "description": "Breaks the image into an equilateral triangle grid. Mouse controls scale and twist.",
-    "url": "shaders/triangle-mosaic.wgsl",
-    "params": [
-      {
-        "name": "Scale",
-        "id": "scale",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Rotation",
-        "id": "rotation",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      },
-      {
-        "name": "Twist",
-        "id": "twist",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      },
-      {
-        "name": "Mix",
-        "id": "mix",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chroma-threads",
-    "name": "Chroma Threads",
-    "url": "shaders/chroma-threads.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "thread_density",
-        "name": "Thread Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of chromatic threads"
-      },
-      {
-        "id": "vibration_amp",
-        "name": "Vibration Amp",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Amplitude of thread vibration"
-      },
-      {
-        "id": "rgb_split",
-        "name": "RGB Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Chromatic aberration strength"
-      },
-      {
-        "id": "decay",
-        "name": "Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Trail decay factor"
-      }
-    ]
-  },
-  {
-    "id": "cross-conv-mouse-bilateral",
-    "name": "Bilateral Paint",
-    "url": "shaders/cross-conv-mouse-bilateral.wgsl",
-    "category": "image",
-    "description": "Crossover shader combining bilateral convolution with mouse-driven painting. The cursor acts as a brush that applies edge-preserving smoothing \u2014 stronger near the cursor, with click boosting the effect.",
-    "tags": [
-      "crossover",
-      "convolution",
-      "bilateral",
-      "mouse-driven",
-      "paint",
-      "interactive"
-    ],
-    "features": [
-      "crossover",
-      "mouse-driven",
-      "advanced-convolution"
-    ],
-    "params": [
-      {
-        "id": "brushSize",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "edgePreserve",
-        "name": "Edge Preservation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "strength",
-        "name": "Effect Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "frost-reveal",
-    "name": "Frost Reveal",
-    "url": "shaders/frost-reveal.wgsl",
-    "category": "image",
-    "description": "Interactive frost reveal effect with crystalline patterns that form based on mouse interaction.",
-    "features": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "tensor-flow-sculpting",
-    "name": "Tensor Flow Sculpting",
-    "url": "shaders/tensor-flow-sculpting.wgsl",
-    "category": "image",
-    "description": "Depth is treated as a 4-D strain tensor that warps and sculpts the image like clay \u2014 bulk regions bend dramatically while high-frequency edge details stay crisp.",
-    "tags": [
-      "depth",
-      "tensor",
-      "warp",
-      "sculpt",
-      "flow",
-      "artistic",
-      "deformation",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "author": "AI",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Strain Scale",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.4,
-        "step": 0.01,
-        "description": "Amplitude of the tensor-field deformation."
-      },
-      {
-        "id": "param2",
-        "name": "Detail Preserve",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.6,
-        "step": 0.01,
-        "description": "How much high-frequency detail is added back after warping."
-      },
-      {
-        "id": "param3",
-        "name": "Flow Speed",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.3,
-        "step": 0.01,
-        "description": "Speed of the time-varying noise flow that modulates the tensor."
-      },
-      {
-        "id": "param4",
-        "name": "Tensor Mode",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0,
-        "step": 0.01,
-        "description": "Blend from stretch-dominant (0) to shear-dominant (1) deformation."
-      }
-    ]
-  },
-  {
-    "id": "neon-pulse-stream",
-    "category": "image",
-    "url": "shaders/neon-pulse-stream.wgsl",
-    "description": "Video luminance directs a fluid flow of neon trails injected by the mouse.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Trail Length",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Neon Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chaos",
-        "name": "Flow Chaos",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "name": "Neon Pulse Stream"
-  },
-  {
-    "id": "spec-histogram-equalize",
-    "name": "Histogram Equalize",
-    "url": "shaders/spec-histogram-equalize.wgsl",
-    "category": "image",
-    "description": "Real-time CLAHE histogram equalization using workgroup cooperative histogram building. Computes local histogram per 8x8 tile and remaps intensities via CDF for dramatic adaptive contrast enhancement.",
-    "tags": [
-      "histogram",
-      "equalization",
-      "CLAHE",
-      "contrast",
-      "cooperative",
-      "workgroup"
-    ],
-    "features": [
-      "cooperative-workgroup",
-      "histogram",
-      "CLAHE",
-      "contrast-enhancement"
-    ],
-    "params": [
-      {
-        "id": "clip_limit",
-        "name": "Clip Limit",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "strength",
-        "name": "Effect Strength",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "tile_blend",
-        "name": "Tile Blend",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color_preserve",
-        "name": "Color Preserve",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.6
-  },
-  {
-    "id": "bismuth-crystallizer",
-    "name": "Bismuth Crystallizer",
-    "url": "shaders/bismuth-crystallizer.wgsl",
-    "category": "image",
-    "description": "Generates geometric hopper crystal patterns with physical light transmission. Simulates bismuth crystals with thin-film interference iridescence, metallic Fresnel reflection, and oxide layer transmission.",
-    "params": [
-      {
-        "id": "steps",
-        "name": "Crystal Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Depth of hopper crystal recursion"
-      },
-      {
-        "id": "offset",
-        "name": "Hopper Offset",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Offset between crystal layers"
-      },
-      {
-        "id": "color_freq",
-        "name": "Iridescence Freq",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Thin-film interference color variation"
-      },
-      {
-        "id": "metallic",
-        "name": "Metallic / Mix",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Metallic reflection strength and effect mix"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "alpha-transmission",
-      "iridescence"
-    ],
-    "tags": [
-      "crystal",
-      "bismuth",
-      "hopper",
-      "iridescence",
-      "metallic",
-      "transmission",
-      "physical"
-    ]
-  },
-  {
-    "id": "liquid-chrome-ripple",
-    "name": "Liquid Chrome Ripple",
-    "url": "shaders/liquid-chrome-ripple.wgsl",
-    "category": "image",
-    "description": "Metallic liquid effect that ripples with mouse movement.",
-    "params": [
-      {
-        "id": "flow",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distort",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "metal",
-        "name": "Metalness",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "freq",
-        "name": "Ripple Freq",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "directional-blur-wipe",
-    "name": "Directional Blur Wipe",
-    "category": "image",
-    "description": "Splits the screen with a directional blur. Mouse controls split position and angle.",
-    "url": "shaders/directional-blur-wipe.wgsl",
-    "params": [
-      {
-        "name": "Split Pos",
-        "id": "split_pos",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Angle",
-        "id": "angle",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      },
-      {
-        "name": "Strength",
-        "id": "strength",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Samples",
-        "id": "samples",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "aerogel-smoke",
-    "name": "Aerogel Smoke",
-    "description": "Simulates the ethereal, frozen-smoke appearance of aerogel with volumetric lighting and Rayleigh scattering.",
-    "url": "shaders/aerogel-smoke.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "volumetric"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scattering",
-        "name": "Blue Scatter",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glow",
-        "name": "Light Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "bgmix",
-        "name": "Background Visibility",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "rgb-ripple-distortion",
-    "name": "RGB Ripple Distortion",
-    "url": "shaders/rgb-ripple-distortion.wgsl",
-    "category": "image",
-    "description": "A ripple effect that separates RGB channels based on distance from mouse.",
-    "params": [
-      {
-        "id": "freq",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amp",
-        "name": "Amplitude",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "sep",
-        "name": "Color Separation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "tilt-shift",
-    "name": "Tilt Shift Miniature",
-    "url": "shaders/tilt-shift.wgsl",
-    "category": "image",
-    "description": "Simulates a tilt-shift lens effect, blurring top and bottom to make the scene look like a miniature model.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Blur Amount",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Focus Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "saturation",
-        "name": "Saturation",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "plastic-bricks",
-    "name": "Plastic Bricks",
-    "category": "image",
-    "url": "shaders/plastic-bricks.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Simulates a plastic brick surface (like LEGO) with 3D studs. Mouse influences scale.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Brick Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Stud Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Relief Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Bevel",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "frosted-glass-lens",
-    "name": "Frosted Glass Lens",
-    "url": "shaders/frosted-glass-lens.wgsl",
-    "category": "image",
-    "description": "A frosted glass effect that reveals the clear image under the mouse cursor.",
-    "params": [
-      {
-        "id": "frost_amt",
-        "name": "Frost Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Lens Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Edge Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "optical-illusion-spin",
-    "name": "Optical Illusion Spin",
-    "category": "image",
-    "description": "Slices the image into rotating concentric rings. Mouse adds a twisting force.",
-    "url": "shaders/optical-illusion-spin.wgsl",
-    "params": [
-      {
-        "name": "Ring Count",
-        "id": "rings",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.5
-      },
-      {
-        "name": "Speed",
-        "id": "speed",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.2
-      },
-      {
-        "name": "Twist Force",
-        "id": "twist",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0.6
-      },
-      {
-        "name": "Alternating",
-        "id": "alt",
-        "min": 0,
-        "max": 1,
-        "step": 1,
-        "default": 1
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-gabor-texture-analyzer",
-    "name": "Gabor Texture Analyzer",
-    "description": "Gabor filter bank detecting oriented texture patterns at 0, 45, 90, and 135 degrees. RGBA32FLOAT stores signed bipolar responses in all four channels. Mouse rotates the filter bank for swirling texture segmentation.",
-    "url": "shaders/conv-gabor-texture-analyzer.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "frequency",
-        "name": "Gabor Frequency",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "sigma",
-        "name": "Gaussian Sigma",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "response_scale",
-        "name": "Response Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "gabor",
-      "convolution",
-      "texture-analysis",
-      "orientation",
-      "psychedelic",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-stretch-interactive",
-    "name": "Pixel Stretch",
-    "category": "image",
-    "description": "Stretches pixels from the mouse position to the screen edge, creating a spatial slit-scan effect.",
-    "url": "shaders/pixel-stretch-interactive.wgsl",
-    "params": [
-      {
-        "name": "Direction Mode",
-        "id": "mode",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      },
-      {
-        "name": "Jitter",
-        "id": "jitter",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      },
-      {
-        "name": "RGB Shift",
-        "id": "rgb_shift",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      },
-      {
-        "name": "Unused",
-        "id": "unused",
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "default": 0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-bilateral-grid-splat",
-    "name": "Bilateral Grid Splat",
-    "description": "Fast approximate bilateral filter using 3D grid splatting (spatial x, y + intensity). Achieves edge-preserving smoothing at O(1) per pixel. RGBA32FLOAT stores HDR accumulated color and weight. Mouse creates high-resolution detail zone.",
-    "url": "shaders/conv-bilateral-grid-splat.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "spatial_sigma",
-        "name": "Spatial Sigma",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "intensity_sigma",
-        "name": "Intensity Sigma",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "grid_resolution",
-        "name": "Grid Resolution",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Detail Zone",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "bilateral-grid",
-      "fast-bilateral",
-      "edge-preserving",
-      "convolution",
-      "splatting",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-anisotropic-diffusion",
-    "name": "Anisotropic Diffusion",
-    "description": "Perona-Malik anisotropic diffusion that smooths along edges but not across them. Creates oil-painting simplification into flat colored regions. Alpha stores per-pixel diffusion coefficient as a process map. Mouse acts as heat source accelerating diffusion.",
-    "url": "shaders/conv-anisotropic-diffusion.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "kappa",
-        "name": "Edge Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "dt",
-        "name": "Diffusion Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "iterations",
-        "name": "Iterations",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Heat",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "anisotropic-diffusion",
-      "perona-malik",
-      "oil-painting",
-      "convolution",
-      "edge-aware",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "kintsugi-repair",
-    "name": "Kintsugi Repair",
-    "url": "shaders/kintsugi-repair.wgsl",
-    "category": "image",
-    "description": "Simulates the Japanese art of repairing broken pottery with gold (Kintsugi). Voronoi patterns create cracks with gold filling.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Shard Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "width",
-        "name": "Gold Width",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "displacement",
-        "name": "Shatter Amount",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shiny",
-        "name": "Gold Sparkle",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "spec-cooperative-edge-linking",
-    "name": "Cooperative Edge Linking",
-    "url": "shaders/spec-cooperative-edge-linking.wgsl",
-    "category": "image",
-    "description": "Workgroup-cooperative edge detection and chain tracing. Uses shared memory union-find to link connected edges within each tile, assigning unique edge IDs for downstream segmentation and flow effects.",
-    "tags": [
-      "edge-detection",
-      "edge-linking",
-      "cooperative",
-      "workgroup",
-      "segmentation",
-      "union-find"
-    ],
-    "features": [
-      "cooperative-workgroup",
-      "edge-linking",
-      "segmentation",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "edge_threshold",
-        "name": "Edge Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "link_radius",
-        "name": "Link Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "color_mode",
-        "name": "Color Mode",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glow",
-        "name": "Edge Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "luma-refraction",
-    "name": "Luma Refraction",
-    "url": "shaders/luma-refraction.wgsl",
-    "category": "image",
-    "description": "Ripples propagate through the image, with speed determined by brightness. Bright areas are like water, dark areas like oil.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 2.0
-      },
-      {
-        "id": "force",
-        "name": "Mouse Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.98,
-        "min": 0.9,
-        "max": 0.999
-      },
-      {
-        "id": "refraction",
-        "name": "Refraction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "simulation"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "magnetic-chroma",
-    "name": "Magnetic Chroma",
-    "category": "image",
-    "url": "shaders/magnetic-chroma.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "RGB channels are pulled towards the mouse with a twisting distortion.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Pull Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Twist",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Falloff",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "gamma-ray-burst",
-    "name": "Gamma Ray Burst",
-    "category": "image",
-    "url": "shaders/gamma-ray-burst.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Intense radial blur and exposure burst originating from the mouse position.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Ray Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Exposure",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-bilateral-dream",
-    "name": "Bilateral Dream",
-    "description": "Edge-preserving bilateral smoothing with psychedelic color preservation. Uses RGBA32FLOAT alpha channel to store accumulated weight for deferred normalization. Mouse controls varying sharpness region.",
-    "url": "shaders/conv-bilateral-dream.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "spatial_sigma",
-        "name": "Spatial Sigma",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "color_sigma",
-        "name": "Color Sigma",
-        "default": 0.3,
-        "min": 0.05,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "hue_shift",
-        "name": "Psychedelic Hue Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "bilateral",
-      "convolution",
-      "edge-preserving",
-      "painterly",
-      "psychedelic",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "conv-guided-filter-depth",
-    "name": "Guided Filter Depth",
-    "description": "Guided filter using depth texture as guide for edge-aware filtering. Creates depth-of-field blur that perfectly respects object boundaries. Alpha stores filtering confidence coefficient. Mouse creates localized focus aperture.",
-    "url": "shaders/conv-guided-filter-depth.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "depth-aware",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "radius",
-        "name": "Filter Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "epsilon",
-        "name": "Edge Sensitivity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "depth_influence",
-        "name": "Depth Influence",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Focus",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "guided-filter",
-      "convolution",
-      "depth-aware",
-      "edge-preserving",
-      "depth-of-field",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "holographic-shatter",
-    "name": "Holographic Shatter",
-    "description": "Fractures the image into digital shards that react to cursor movement with holographic interference patterns.",
-    "url": "shaders/holographic-shatter.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "scale",
-        "name": "Shard Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "holo",
-        "name": "Hologram Intensity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "displace",
-        "name": "Displacement",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Glitch Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music"
-    ]
-  },
-  {
-    "id": "conv-spiral-blur",
-    "name": "Spiral Blur",
-    "description": "Logarithmic spiral convolution creating rotational motion blur along golden ratio spirals. RGBA32FLOAT stores HDR accumulated color and spiral coverage factor. Mouse controls spiral center and tightness for vortex-like effects.",
-    "url": "shaders/conv-spiral-blur.wgsl",
-    "category": "image",
-    "features": [
-      "advanced-convolution",
-      "rgba32float-exploiting",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "tightness",
-        "name": "Spiral Tightness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "num_arms",
-        "name": "Spiral Arms",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "samples",
-        "name": "Sample Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Center",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "spiral",
-      "logarithmic",
-      "golden-ratio",
-      "convolution",
-      "motion-blur",
-      "vortex",
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "fractal-noise-dissolve",
-    "name": "Fractal Noise Dissolve",
-    "url": "shaders/fractal-noise-dissolve.wgsl",
-    "category": "image",
-    "description": "Dissolves the image into fractal noise around the mouse.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Noise Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Hole Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge",
-        "name": "Edge Softness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "burn",
-        "name": "Burn Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "alucinate",
-    "name": "Alucinate",
-    "url": "shaders/alucinate.wgsl",
-    "category": "image",
-    "description": "Reaction-Diffusion Psychedelia with Gray-Scott Turing patterns, domain-warped FBM, kaleidoscopic IFS fractals, conformal mapping, and audio-reactive color science.",
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "reaction-diffusion",
-      "fbm-warping",
-      "kaleidoscopic-ifs",
-      "conformal-mapping",
-      "audio-reactive",
-      "chromatic-aberration"
-    ],
-    "tags": [
-      "psychedelic",
-      "warp",
-      "interactive",
-      "organic",
-      "fluid",
-      "filter",
-      "image-processing",
-      "fractal",
-      "reaction-diffusion",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "hex-lens",
-    "name": "Hex Lens Interactive",
-    "category": "image",
-    "url": "shaders/hex-lens.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Hexagonal grid where each cell acts as a lens, controlled by the mouse.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Tile Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Lens Zoom",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-scattering",
-    "name": "Pixel Scattering",
-    "url": "shaders/pixel-scattering.wgsl",
-    "category": "image",
-    "description": "Scatters pixels away from the mouse cursor like dust particles.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Scatter Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "strength",
-        "name": "Scatter Distance",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "size",
-        "name": "Particle Size",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "random",
-        "name": "Chaos",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "wave-halftone",
-    "category": "image",
-    "url": "shaders/wave-halftone.wgsl",
-    "description": "Halftone dot pattern with a waving grid and mouse magnification lens.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "size",
-        "name": "Dot Size",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "density",
-        "name": "Grid Density",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amp",
-        "name": "Wave Amp",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Wave Halftone"
-  },
-  {
-    "id": "spectral-slit-scan",
-    "category": "image",
-    "url": "shaders/spectral-slit-scan.wgsl",
-    "description": "RGB trails that decay at different rates, distorted by sine waves and mouse gravity.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "split",
-        "name": "RGB Split",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "trail",
-        "name": "Trail Length",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "freq",
-        "name": "Wave Freq",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amp",
-        "name": "Wave Amp",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "name": "Spectral Slit Scan"
-  },
-  {
-    "id": "signal-modulation",
-    "name": "Signal Modulation",
-    "category": "image",
-    "url": "shaders/signal-modulation.wgsl",
-    "description": "Simulates AM/FM signal distortion with mouse-controlled frequency and amplitude.",
-    "features": [
-      "mouse-driven",
-      "visual-effect"
-    ],
-    "params": [
-      {
-        "id": "freq",
-        "name": "Base Frequency",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amp",
-        "name": "Distortion Amt",
-        "type": "float",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Scroll Speed",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift",
-        "name": "Color Split",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "glitch-pixel-sort",
-    "name": "Glitch Pixel Sort",
-    "url": "shaders/glitch-pixel-sort.wgsl",
-    "category": "image",
-    "description": "Luminance-based pixel stretching controlled by mouse position.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "cyber-physical-portal",
-    "name": "Cyber Physical Portal",
-    "url": "shaders/cyber-physical-portal.wgsl",
-    "category": "image",
-    "description": "Reveals a cybernetic wireframe world through a glitchy portal at your mouse cursor.",
-    "params": [
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Base radius of the portal"
-      },
-      {
-        "id": "glitch_speed",
-        "name": "Glitch Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Speed of portal edge glitch jitter"
-      },
-      {
-        "id": "glow_sharpness",
-        "name": "Glow Sharpness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Sharpness of the portal edge glow"
-      },
-      {
-        "id": "grid_density",
-        "name": "Grid Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Density of the cyber grid inside the portal"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "luma-smear-interactive",
-    "name": "Kinetic Echo",
-    "url": "shaders/luma-smear-interactive.wgsl",
-    "category": "image",
-    "description": "Creates a motion trail based on brightness. Bright objects leave trails that decay over time. Mouse clears the trails.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Luma Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Eraser Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "phantom-lag",
-    "name": "Phantom Lag",
-    "url": "shaders/phantom-lag.wgsl",
-    "category": "image",
-    "features": [],
-    "description": "Creates trailing echoes of movement by blending past frames with spatial offsets.",
-    "params": [
-      {
-        "name": "Decay Rate",
-        "id": "zoomParam1",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Echo X",
-        "id": "zoomParam2",
-        "default": 0.55,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Echo Y",
-        "id": "zoomParam3",
-        "default": 0.55,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Hue Shift",
-        "id": "zoomParam4",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "zipper-reveal",
-    "name": "Zipper Reveal",
-    "url": "shaders/zipper-reveal.wgsl",
-    "category": "image",
-    "description": "Unzips the image to reveal darkness, controlled by the mouse position.",
-    "params": [
-      {
-        "id": "zipper_width",
-        "name": "Spread",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Width of the zipper V-shape opening"
-      },
-      {
-        "id": "tooth_size",
-        "name": "Tooth Size",
-        "default": 0.02,
-        "min": 0.005,
-        "max": 0.1,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Size of zipper teeth"
-      },
-      {
-        "id": "angle",
-        "name": "Angle",
-        "default": 0.0,
-        "min": -1.57,
-        "max": 1.57,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Rotation angle of the zipper"
-      },
-      {
-        "id": "tooth_amplitude",
-        "name": "Tooth Amplitude",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Amplitude of the tooth protrusion"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "pixel-sorter",
-    "name": "Pixel Sorter",
-    "url": "shaders/pixel-sorter.wgsl",
-    "category": "image",
-    "description": "Glitch art pixel sorting effect.",
-    "params": [
-      {
-        "id": "direction",
-        "name": "Sort Direction",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "reverse",
-        "name": "Reverse Sort",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensityScale",
-        "name": "Intensity Scale",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "threshold",
-        "name": "Sort Threshold Luma",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "electric-contours",
-    "name": "Electric Contours",
-    "url": "shaders/electric-contours.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Edge detection with electric glowing contours that react to mouse proximity.",
-    "params": [
-      {
-        "id": "edge_threshold",
-        "name": "Edge Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Base threshold for edge detection"
-      },
-      {
-        "id": "glow_intensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Intensity multiplier for the electric glow"
-      },
-      {
-        "id": "threshold_range",
-        "name": "Edge Threshold Range",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Range of the adaptive edge threshold"
-      },
-      {
-        "id": "spark_speed",
-        "name": "Spark Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Speed of electric spark animation"
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "breathing-kaleidoscope",
-    "name": "Breathing Kaleidoscope",
-    "url": "shaders/breathing-kaleidoscope.wgsl",
-    "category": "image",
-    "description": "Smoothly folds and unfolds the image into mirrored segments with a breathing animation; center and rotation are controllable.",
-    "params": [
-      {
-        "id": "cycleSpeed",
-        "name": "Cycle Speed",
-        "default": 0.2,
-        "min": 0,
-        "max": 2
-      },
-      {
-        "id": "segments",
-        "name": "Segments",
-        "default": 6,
-        "min": 2,
-        "max": 16
-      },
-      {
-        "id": "rotationSpeed",
-        "name": "Rotation Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 4
-      },
-      {
-        "id": "maxRotationPercent",
-        "name": "Max Rotation",
-        "default": 0.8,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "kaleidoscope",
-      "animated",
-      "visual-effects",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "hyper-space-jump",
-    "name": "Hyper Space Jump",
-    "url": "shaders/hyper-space-jump.wgsl",
-    "category": "image",
-    "description": "Streaks the image radially from the mouse position, simulating a hyperspace jump.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "interactive-pcb-traces",
-    "name": "Interactive PCB Traces",
-    "url": "shaders/interactive-pcb-traces.wgsl",
-    "category": "image",
-    "description": "Simulates a circuit board where traces light up with data pulses driven by the mouse.",
-    "params": [
-      {
-        "name": "Grid Scale",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
         "max": 1,
-        "id": "grid_scale"
-      },
-      {
-        "name": "Pulse Speed",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "pulse_speed"
-      },
-      {
-        "name": "Glow",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "glow"
-      },
-      {
-        "name": "Background",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "id": "background"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "warp-drive",
-    "name": "Warp Drive",
-    "category": "image",
-    "url": "shaders/warp_drive.wgsl",
-    "description": "Intense radial blur and chromatic aberration centered on the mouse.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Warp Speed",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Prism Split",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "brightness",
-        "name": "Core Glow",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "samples",
-        "name": "Blur Quality",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "neon-edge-reveal",
-    "name": "Neon Edge Reveal",
-    "url": "shaders/neon-edge-reveal.wgsl",
-    "category": "image",
-    "description": "Neon edge detection with interactive flashlight reveal.",
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
+        "target": "zoom_params.w",
+        "id": "invert_mode"
       }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
     ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "ascii-shockwave",
-    "name": "ASCII Shockwave",
-    "url": "shaders/ascii-shockwave.wgsl",
-    "category": "image",
-    "description": "A matrix-style digital shockwave that quantizes the image into procedural characters.",
     "features": [
       "mouse-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
     ]
   },
   {
@@ -15897,59 +1984,11 @@
     ]
   },
   {
-    "id": "radiating-displacement",
-    "name": "Radiating Displacement",
-    "url": "shaders/radiating-displacement.wgsl",
+    "id": "spectrogram-displace",
+    "name": "Spectrogram Displace",
+    "url": "shaders/spectrogram-displace.wgsl",
     "category": "image",
-    "description": "Rippling displacement waves emanate only from strong colours; neutrals stay sharp. Mouse-click to seed ripples.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "strength",
-        "name": "Displace Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "satThresh",
-        "name": "Saturation Threshold",
-        "default": 0.4,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "radius",
-        "name": "Wave Radius",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "colour-masking",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "nebulous-dream",
-    "name": "Nebulous Dream",
-    "url": "shaders/nebulous-dream.wgsl",
-    "category": "image",
-    "description": "Swirling vortex of rainbow candy clouds with fractal noise and flow fields.",
+    "description": "Audio-driven per-pixel displacements from an FFT texture.",
     "features": [
       "mouse-driven"
     ],
@@ -16041,1195 +2080,6 @@
     ]
   },
   {
-    "id": "neural-resonance",
-    "name": "Neural Resonance",
-    "url": "shaders/neural-resonance.wgsl",
-    "category": "image",
-    "description": "Runaway neural feedback loop with hallucinogenic pareidolic effects and breathing fractals.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "chromatic-folds-gemini",
-    "name": "Chromatic Folds Gemini",
-    "url": "shaders/chromatic-folds-gemini.wgsl",
-    "category": "image",
-    "description": "An advanced geometric color folding and warping effect with dynamic, time-driven animation, fractal layering, and interactive, mouse-driven vortex manipulation.",
-    "features": [
-      "mouse-driven",
-      "time-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "luminance-wind",
-    "name": "Luminance Wind",
-    "category": "image",
-    "url": "shaders/luminance-wind.wgsl",
-    "description": "Pixels are blown by a digital wind. Lighter pixels are lighter weight and travel further. Mouse controls wind direction.",
-    "params": [
-      {
-        "name": "Wind Speed",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "wind_speed"
-      },
-      {
-        "name": "Trail Decay",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.8,
-        "id": "trail_decay"
-      },
-      {
-        "name": "Luma Threshold",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.1,
-        "id": "luma_threshold"
-      },
-      {
-        "name": "Turbulence",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.2,
-        "id": "turbulence"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chromatic-folds",
-    "name": "Chromatic Folds",
-    "url": "shaders/chromatic-folds.wgsl",
-    "category": "image",
-    "description": "Geometric color folding and warping effects.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "cosmic-flow",
-    "name": "Cosmic Flow Pro",
-    "url": "shaders/cosmic-flow.wgsl",
-    "category": "image",
-    "description": "Depth-aware ethereal energy field with domain warping, temporal trails, chromatic aberration, and multiple color modes ranges.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "scale",
-        "name": "Pattern Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "intensity",
-        "name": "Glow Intensity",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Phase",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "chromatic-aberration",
-      "multi-mode",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "chromatic-manifold-2",
-    "name": "Chromatic Manifold V2",
-    "url": "shaders/chromatic-manifold-2.wgsl",
-    "category": "image",
-    "description": "Enhanced 4D topological color manifold.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "chromatic-infection",
-    "name": "Chromatic Infection",
-    "url": "shaders/chromatic-infection.wgsl",
-    "category": "image",
-    "description": "Strong colours spread like a living organism, infecting neutral regions with organic, pulsing tendrils. Watch vibrant hues consume the dull!",
-    "params": [
-      {
-        "id": "spreadSpeed",
-        "name": "Spread Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "intensity",
-        "name": "Infection Intensity",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "satThresh",
-        "name": "Saturation Threshold",
-        "default": 0.4,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "tendrilScale",
-        "name": "Tendril Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "colour-masking",
-      "organic-growth",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "ion-stream",
-    "name": "Ion Stream",
-    "url": "shaders/ion-stream.wgsl",
-    "category": "image",
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "displacement",
-      "turbulence",
-      "mouse-driven"
-    ],
-    "description": "A stream of ionized particles that reacts to the mouse cursor, tinting pixels as they flow.",
-    "params": [
-      {
-        "name": "Stream Strength",
-        "id": "zoomParam1",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Falloff",
-        "id": "zoomParam2",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Turbulence",
-        "id": "zoomParam3",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Ion Color",
-        "id": "zoomParam4",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "aurora-rift",
-    "name": "Aurora Rift",
-    "url": "shaders/aurora-rift.wgsl",
-    "category": "image",
-    "description": "Aurora borealis-inspired lighting effects with atmospheric rifts.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "astral-veins",
-    "name": "Astral Veins",
-    "url": "shaders/astral-veins.wgsl",
-    "category": "image",
-    "description": "Glowing, flowing veins that wrap around geometry, pulse, and colour\u2011cycle. Click to seed new veins.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "scale",
-        "name": "Noise Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "intensity",
-        "name": "Glow Intensity",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "hueShift",
-        "name": "Hue Shift",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "quantum-smear",
-    "name": "Quantum Smear",
-    "url": "shaders/quantum-smear.wgsl",
-    "category": "image",
-    "description": "Quantum particle disintegration with stochastic advection and pointillist effects.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "spectrogram-displace",
-    "name": "Spectrogram Displace",
-    "url": "shaders/spectrogram-displace.wgsl",
-    "category": "image",
-    "description": "Audio-driven per-pixel displacements from an FFT texture.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "quantum-fractal",
-    "name": "Quantum Fractal",
-    "url": "shaders/quantum-fractal.wgsl",
-    "category": "image",
-    "description": "Fractal quantum interference patterns.",
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "audio-reactive",
-      "audio-driven",
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "scale",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Fractal scale"
-      },
-      {
-        "id": "iterations",
-        "name": "Iterations",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Iteration depth"
-      },
-      {
-        "id": "entanglement",
-        "name": "Entanglement",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Quantum entanglement strength"
-      },
-      {
-        "id": "edge_glow",
-        "name": "Edge Glow",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Glow on fractal edges"
-      }
-    ]
-  },
-  {
-    "id": "aurora-rift-2",
-    "name": "Aurora Rift V2",
-    "url": "shaders/aurora-rift-2.wgsl",
-    "category": "image",
-    "description": "Enhanced aurora effects with improved color gradients.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "encaustic-wax",
-    "name": "Encaustic Wax",
-    "description": "Simulates the translucent, textured look of hot wax painting. Mouse interaction melts the wax locally.",
-    "url": "shaders/encaustic-wax.wgsl",
-    "category": "image",
-    "features": [
-      "mouse-driven",
-      "blur",
-      "texture"
-    ],
-    "params": [
-      {
-        "id": "thickness",
-        "name": "Wax Thickness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "texture",
-        "name": "Surface Texture",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Melt Radius",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.5
-      },
-      {
-        "id": "intensity",
-        "name": "Melt Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "thermal-vision",
-    "name": "Thermal Vision",
-    "url": "shaders/thermal-vision.wgsl",
-    "category": "image",
-    "description": "Heat signature camera view.",
-    "params": [
-      {
-        "id": "sensitivity",
-        "name": "Heat Sensitivity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "color_range",
-        "name": "Color Range",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "noise",
-        "name": "Sensor Noise",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "blur",
-        "name": "Thermal Blur",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "color-remap",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "lidar",
-    "name": "LiDAR Scanner Pro",
-    "url": "shaders/lidar.wgsl",
-    "category": "image",
-    "description": "Multi-mode LiDAR with point clouds, persistence trails, and 3D edge detection. Modes: Linear/Radial/Spiral scan.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Scan Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "width",
-        "name": "Beam Width",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "contours",
-        "name": "Contour Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "edges",
-        "name": "Edge Sensitivity",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "multi-mode",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "chromatic-manifold",
-    "name": "Chromatic Manifold",
-    "url": "shaders/chromatic-manifold.wgsl",
-    "category": "image",
-    "description": "4D topological color manifold with HDR tears, temporal persistence, and depth-driven curvature.",
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "color_boost",
-        "name": "Color Boost",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Saturation and color intensity boost"
-      },
-      {
-        "id": "warpStrength",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Strength of spatial warp"
-      },
-      {
-        "id": "tearThreshold",
-        "name": "Tear Threshold",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Threshold for HDR tear artifacts"
-      },
-      {
-        "id": "curvature",
-        "name": "Curvature Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Depth-driven curvature amount"
-      }
-    ]
-  },
-  {
-    "id": "rain",
-    "name": "Rain",
-    "url": "shaders/rain.wgsl",
-    "category": "image",
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "bioluminescent",
-    "name": "Bioluminescent Growth",
-    "url": "shaders/bioluminescent.wgsl",
-    "category": "image",
-    "description": "Living, organic growth patterns that spread across surfaces like glowing fungus. Click to plant spores, watch them grow over time with depth-aware branching.",
-    "params": [
-      {
-        "id": "spread",
-        "name": "Spread Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "density",
-        "name": "Branch Density",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.7,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "spores",
-        "name": "Spore Count",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "multi-mode",
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "chromatic-folds-2",
-    "name": "Chromatic Folds V2",
-    "url": "shaders/chromatic-folds-2.wgsl",
-    "category": "image",
-    "description": "Enhanced geometric color folding with improved warping.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "ambient-liquid",
-    "name": "Ambient Liquid",
-    "url": "shaders/ambient-liquid.wgsl",
-    "category": "image",
-    "description": "Gentle ambient liquid motion effects.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
-    ]
-  },
-  {
-    "id": "radiating-haze",
-    "name": "Radiating Haze",
-    "url": "shaders/radiating-haze.wgsl",
-    "category": "image",
-    "description": "Animated aura around strong colours; browns, greys & blacks are ignored. Now with colour-mode switch.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "intensity",
-        "name": "Aura Intensity",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "satThresh",
-        "name": "Saturation Threshold",
-        "default": 0.4,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "radius",
-        "name": "Aura Radius",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "colour-masking",
-      "multi-mode",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "quantum-wormhole",
-    "name": "Quantum Wormhole",
-    "url": "shaders/quantum-wormhole.wgsl",
-    "category": "image",
-    "description": "Wormhole-like spacetime distortion effects.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
     "id": "static-reveal",
     "name": "Static Reveal",
     "url": "shaders/static-reveal.wgsl",
@@ -17245,7 +2095,7 @@
         "id": "decay",
         "name": "Regrowth Speed",
         "default": 0.01,
-        "min": 0.0,
+        "min": 0,
         "max": 0.1
       },
       {
@@ -17258,16 +2108,16 @@
       {
         "id": "noise",
         "name": "Static Intensity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
+        "default": 1,
+        "min": 0,
+        "max": 1
       },
       {
         "id": "noiseScale",
         "name": "Noise Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
@@ -17276,151 +2126,6 @@
       "audio",
       "music",
       "reactive"
-    ]
-  },
-  {
-    "id": "aurora-rift-gemini",
-    "name": "Aurora Rift Gemini",
-    "url": "shaders/aurora-rift-gemini.wgsl",
-    "category": "image",
-    "description": "An enhanced simulation of aurora borealis, with dynamic, time-driven color shifts, deeper atmospheric rifts, and shimmering, mouse-driven particle effects.",
-    "features": [
-      "mouse-driven",
-      "time-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "green-tracer",
-    "name": "Green Tracer World",
-    "url": "shaders/green-tracer.wgsl",
-    "category": "image",
-    "description": "Surreal green video effect with persistent motion trails, edge glow, and film grain. Perfect for toxic/night\u2011vision aesthetics.",
-    "params": [
-      {
-        "id": "trailLen",
-        "name": "Trail Length",
-        "default": 0.6,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "glowInt",
-        "name": "Glow Intensity",
-        "default": 0.7,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "greenTint",
-        "name": "Green Tint",
-        "default": 0.8,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "noiseAmt",
-        "name": "Film Grain",
-        "default": 0.1,
-        "min": 0,
-        "max": 0.5
-      }
-    ],
-    "features": [
-      "temporal\u2011persistence",
-      "edge\u2011glow",
-      "film\u2011grain",
-      "depth\u2011aware",
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
-    "id": "astral-kaleidoscope",
-    "name": "Astral Kaleidoscope",
-    "url": "shaders/astral-kaleidoscope.wgsl",
-    "category": "image",
-    "description": "Cosmic kaleidoscope with astral color schemes.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
     ]
   },
   {
@@ -17477,108 +2182,6 @@
     ]
   },
   {
-    "id": "vortex-prism",
-    "name": "Vortex Prism",
-    "url": "shaders/vortex-prism.wgsl",
-    "category": "image",
-    "description": "Twists the image around the mouse cursor, separating colors like a prism.",
-    "params": [
-      {
-        "id": "twist",
-        "name": "Twist Force",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "prism",
-        "name": "Prism Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smoothness",
-        "name": "Smoothness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "rorschach-inkblot",
-    "name": "Rorschach Inkblot",
-    "url": "shaders/rorschach-inkblot.wgsl",
-    "category": "image",
-    "description": "Symmetrical inkblot visualization using the Rorschach test aesthetic.",
-    "params": [
-      {
-        "name": "Threshold",
-        "type": "float",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "target": "zoom_params.x",
-        "id": "threshold"
-      },
-      {
-        "name": "Distortion",
-        "type": "float",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "target": "zoom_params.y",
-        "id": "distortion"
-      },
-      {
-        "name": "Smoothness",
-        "type": "float",
-        "default": 0.1,
-        "min": 0,
-        "max": 1,
-        "target": "zoom_params.z",
-        "id": "smoothness"
-      },
-      {
-        "name": "Invert Mode",
-        "type": "float",
-        "default": 0,
-        "min": 0,
-        "max": 1,
-        "target": "zoom_params.w",
-        "id": "invert_mode"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "filter",
-      "image-processing"
-    ]
-  },
-  {
     "id": "temporal-echo",
     "name": "Temporal Echo",
     "url": "shaders/temporal-echo.wgsl",
@@ -17632,39 +2235,6417 @@
     ]
   },
   {
-    "id": "double-exposure-zoom",
-    "name": "Double Exposure Zoom",
-    "url": "shaders/double-exposure-zoom.wgsl",
+    "id": "thermal-vision",
+    "name": "Thermal Vision",
+    "url": "shaders/thermal-vision.wgsl",
     "category": "image",
-    "description": "Blends the image with a zoomed and rotated copy of itself, pivoting around the mouse cursor.",
+    "description": "Heat signature camera view.",
     "params": [
+      {
+        "id": "sensitivity",
+        "name": "Heat Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color_range",
+        "name": "Color Range",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noise",
+        "name": "Sensor Noise",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blur",
+        "name": "Thermal Blur",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "color-remap",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "vortex-prism",
+    "name": "Vortex Prism",
+    "url": "shaders/vortex-prism.wgsl",
+    "category": "image",
+    "description": "Twists the image around the mouse cursor, separating colors like a prism.",
+    "params": [
+      {
+        "id": "twist",
+        "name": "Twist Force",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "prism",
+        "name": "Prism Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smoothness",
+        "name": "Smoothness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "black-hole",
+    "name": "Gravitational Lensing",
+    "url": "shaders/black-hole.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "bubble-lens",
+    "name": "Bubble Lens",
+    "url": "shaders/bubble-lens.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "A magnifying bubble lens distortion that follows the mouse cursor.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-lens",
+    "name": "Cyber Lens",
+    "url": "shaders/cyber-lens.wgsl",
+    "category": "image",
+    "description": "Digital fisheye with scan lines and chromatic aberration.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Lens Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Chromatic",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanlines",
+        "name": "Scan Lines",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "vignette",
+        "name": "Vignette",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "distortion",
+      "retro",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "data-slicer",
+    "name": "Data Slicer",
+    "url": "shaders/data-slicer.wgsl",
+    "category": "image",
+    "description": "Glitchy horizontal slicing effect with chromatic aberration. Mouse Y controls influence area, Mouse X controls offset direction.",
+    "params": [
+      {
+        "id": "slideSpeed",
+        "name": "Jitter Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sliceHeight",
+        "name": "Slice Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos Amount",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Color Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "elastic-surface",
+    "name": "Elastic Surface",
+    "url": "shaders/elastic-surface.wgsl",
+    "category": "image",
+    "description": "Bouncy rubber-like surface distortion.",
+    "params": [
+      {
+        "id": "elasticity",
+        "name": "Elasticity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "frequency",
+        "name": "Wave Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amplitude",
+        "name": "Wave Height",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "animated",
+      "wave",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ethereal-swirl",
+    "name": "Ethereal Swirl",
+    "url": "shaders/ethereal-swirl.wgsl",
+    "category": "image",
+    "description": "Ethereal swirling motion with soft gradients.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "fluid-grid",
+    "name": "Fluid Grid",
+    "url": "shaders/fluid-grid.wgsl",
+    "category": "image",
+    "description": "Flowing grid distortion with fluid dynamics.",
+    "params": [
+      {
+        "id": "grid_size",
+        "name": "Grid Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "flow_speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "animated",
+      "grid",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "fractal-image-surf",
+    "name": "Fractal Image Surf",
+    "url": "shaders/fractal-image-surf.wgsl",
+    "category": "image",
+    "description": "Maps the image onto a Julia Set fractal coordinate system, controlled by the mouse.",
+    "params": [
+      {
+        "name": "Iterations",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "id": "iterations"
+      },
+      {
+        "name": "Zoom",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "zoom"
+      },
+      {
+        "name": "Offset X",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "offset_x"
+      },
+      {
+        "name": "Offset Y",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "offset_y"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "fractal-kaleidoscope",
+    "name": "Fractal Kaleidoscope",
+    "url": "shaders/fractal-kaleidoscope.wgsl",
+    "category": "image",
+    "description": "Fractal patterns in a kaleidoscope arrangement.",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gemstone-fractures",
+    "name": "Gemstone Fractures",
+    "url": "shaders/gemstone-fractures.wgsl",
+    "category": "image",
+    "features": [
+      "alpha-transmission",
+      "physical-refraction"
+    ],
+    "description": "Fragments the image into crystalline shards with physical light transmission. Features internal fractures that scatter light, variable purity per cell, and IOR-based refraction.",
+    "params": [
+      {
+        "name": "Facet Size",
+        "id": "zoomParam1",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "description": "Size of Voronoi crystal cells"
+      },
+      {
+        "name": "Refractive Index",
+        "id": "zoomParam2",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "description": "IOR: Quartz (1.54) to Diamond (2.42)"
+      },
+      {
+        "name": "Rotation",
+        "id": "zoomParam3",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "description": "Cell rotation animation speed"
+      },
+      {
+        "name": "Fracture Density",
+        "id": "zoomParam4",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "description": "Internal fractures: 0 = pure crystal, 1 = heavily fractured"
+      }
+    ],
+    "tags": [
+      "crystal",
+      "gemstone",
+      "fracture",
+      "transmission",
+      "voronoi",
+      "physical"
+    ]
+  },
+  {
+    "id": "glass-brick-distortion",
+    "category": "image",
+    "url": "shaders/glass-brick-distortion.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Brick Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Grout Width",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Clear Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Glass Brick Wall"
+  },
+  {
+    "id": "infinite-zoom-lens",
+    "name": "Infinite Zoom Lens",
+    "url": "shaders/infinite-zoom-lens.wgsl",
+    "category": "image",
+    "description": "A recursive feedback lens that creates infinite tunnels inside a mouse-controlled circle.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Zoom Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.3,
+        "min": 0.1,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Feedback Persistence",
+        "default": 0.9,
+        "min": 0.5,
+        "max": 0.99
+      },
+      {
+        "id": "rotation",
+        "name": "Twist",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "infinite-zoom",
+    "name": "Infinite Zoom",
+    "url": "shaders/infinite-zoom.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "zoom_speed",
+        "name": "Zoom Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Speed of infinite zoom"
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Hyperbolic distortion amount"
+      },
       {
         "id": "rotation",
         "name": "Rotation",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Rotation of the zoom tunnel"
+      },
+      {
+        "id": "max_iterations",
+        "name": "Max Iterations",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Maximum fractal iterations"
+      }
+    ]
+  },
+  {
+    "id": "kaleidoscope",
+    "name": "Rose FBM Kaleidoscope",
+    "url": "shaders/kaleidoscope.wgsl",
+    "category": "image",
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "segments",
+        "name": "Segments",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
         "id": "zoom",
-        "name": "Zoom Level",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Zoom",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "edgeFade",
-        "name": "Edge Fade",
+        "id": "edge_softness",
+        "name": "Edge Softness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "magnetic-field",
+    "name": "Magnetic Field",
+    "url": "shaders/magnetic-field.wgsl",
+    "category": "image",
+    "description": "Magnetic field lines distortion effect.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Field Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Field Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Mode",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "animated",
+      "physics",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "perspective-tilt",
+    "name": "Perspective Tilt",
+    "url": "shaders/perspective-tilt.wgsl",
+    "category": "image",
+    "description": "Rotates the image plane in 3D space based on mouse position (Pitch/Yaw). Zoom param adjusts distance.",
+    "params": [
+      {
+        "id": "tilt_sensitivity",
+        "name": "Tilt Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Sensitivity of the tilt effect"
+      },
+      {
+        "id": "distance",
+        "name": "Distance (FOV)",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Camera distance / field of view"
+      },
+      {
+        "id": "pitch_enable",
+        "name": "Y-Axis Tilt (Pitch)",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Enable or scale pitch tilt amount"
+      },
+      {
+        "id": "plane_scale",
+        "name": "Plane Scale",
+        "default": 1,
+        "min": 0.5,
+        "max": 2,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Scale of the projected plane"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "phase-shift",
+    "name": "Phase Shift",
+    "url": "shaders/phase-shift.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "RGB channels are rotationally shifted relative to the mouse position.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-storm",
+    "name": "Pixel Storm",
+    "url": "shaders/pixel-storm.wgsl",
+    "category": "image",
+    "description": "Mouse movement creates a chaotic storm of pixels.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Storm Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "trail",
+        "name": "Trail Length",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "prismatic-mosaic",
+    "name": "Prismatic Mosaic",
+    "url": "shaders/prismatic-mosaic.wgsl",
+    "category": "image",
+    "description": "Color tiles break apart and reassemble into shifting prisms, turning strong colors into a kaleidoscopic mosaic that ripples across the image.",
+    "params": [
+      {
+        "id": "min_speed",
+        "name": "Min Speed",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Minimum layer animation speed"
       },
       {
-        "id": "audioReact",
+        "id": "max_speed",
+        "name": "Max Speed",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Maximum layer animation speed"
+      },
+      {
+        "id": "saturation_boost",
+        "name": "Saturation Boost",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Saturation boost amount"
+      },
+      {
+        "id": "fog_density",
+        "name": "Fog Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Volumetric fog density"
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "colour-masking",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "refraction-tunnel",
+    "name": "Refraction Tunnel",
+    "url": "shaders/refraction-tunnel.wgsl",
+    "category": "image",
+    "description": "Infinite refractive tunnel effect.",
+    "params": [
+      {
+        "id": "depth",
+        "name": "Tunnel Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "twist",
+        "name": "Twist Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Chromatic",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Travel Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "animated",
+      "3d",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "sine-wave",
+    "name": "Sine Wave Distortion",
+    "url": "shaders/sine-wave.wgsl",
+    "category": "image",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "spectral-vortex",
+    "name": "Spectral Vortex",
+    "url": "shaders/spectral-vortex.wgsl",
+    "category": "image",
+    "description": "Spectral color vortex with twisted distortions.",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "twist_scale",
+        "name": "Twist Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Amount of twist distortion"
+      },
+      {
+        "id": "distortion_step",
+        "name": "Distortion Step",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Step size of distortion"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Spectral color rotation"
+      },
+      {
+        "id": "curl_amp",
+        "name": "Curl Amplification",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Amplification of curl velocity field"
+      }
+    ]
+  },
+  {
+    "id": "voronoi-faceted-glass",
+    "name": "Voronoi Faceted Glass",
+    "url": "shaders/voronoi-faceted-glass.wgsl",
+    "category": "image",
+    "description": "Cellular glass distortion effect.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "vortex-warp",
+    "name": "Vortex Warp",
+    "url": "shaders/vortex-warp.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "description": "Swirls the image around the mouse cursor.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Vortex Strength",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "twist",
+        "name": "Spiral Twist",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Vortex turbulence amount"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "vortex",
+    "name": "Clean Vortex",
+    "url": "shaders/vortex.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-feedback-echo-chamber",
+    "name": "Feedback Echo Chamber",
+    "url": "shaders/gen-feedback-echo-chamber.wgsl",
+    "category": "image",
+    "description": "Multi-layer temporal echo with feedback decay, creating ghost images of previous frames fading into depth with color grading per layer",
+    "tags": [
+      "temporal",
+      "echo",
+      "feedback",
+      "multi-layer",
+      "ghosting",
+      "audio",
+      "music",
+      "reactive",
+      "alpha",
+      "accumulative"
+    ],
+    "features": [
+      "temporal",
+      "multi-pass",
+      "audio-reactive",
+      "audio-driven",
+      "advanced-alpha"
+    ],
+    "params": [
+      {
+        "id": "echoCount",
+        "name": "Echo Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "decayRate",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "spacing",
+        "name": "Echo Spacing",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-temporal-motion-smear",
+    "name": "Temporal Motion Smear",
+    "url": "shaders/gen-temporal-motion-smear.wgsl",
+    "category": "image",
+    "description": "Motion-aware temporal smearing using frame differencing and directional blur, creating colorful trails that follow moving objects",
+    "tags": [
+      "temporal",
+      "motion",
+      "smear",
+      "trails",
+      "frame-differencing",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "temporal",
+      "motion-aware",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "persistence",
+        "name": "Trail Persistence",
+        "default": 0.85,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "sensitivity",
+        "name": "Motion Sensitivity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "directionality",
+        "name": "Smear Directionality",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Color Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "psy-swirls",
+    "name": "Psychedelic Rainbow Swirls",
+    "url": "shaders/generative-psy-swirls.wgsl",
+    "category": "image",
+    "description": "Generative swirling vortex fields with multi-layer procedural noise flow, spectral rainbow HSV cycles from polar angles, temporal twisting, and psychedelic distortion. Mouse attracts swirls; ripples spawn color bursts.",
+    "params": [
+      {
+        "name": "Swirl Speed",
+        "type": "range",
+        "min": 0,
+        "max": 2,
+        "default": 1,
+        "desc": "Global rotation and flow velocity",
+        "id": "swirl_speed"
+      },
+      {
+        "name": "Layer Count",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "desc": "Number of nested swirl layers (2-6)",
+        "id": "layer_count"
+      },
+      {
+        "name": "Rainbow Speed",
+        "type": "range",
+        "min": 0,
+        "max": 2,
+        "default": 0.8,
+        "desc": "Hue cycling rate",
+        "id": "rainbow_speed"
+      },
+      {
+        "name": "Twist Intensity",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.6,
+        "desc": "Vortex distortion strength (depth-reduced)",
+        "id": "twist_intensity"
+      }
+    ],
+    "features": [
+      "generative",
+      "procedural",
+      "psychedelic",
+      "rainbow",
+      "swirls",
+      "vortex",
+      "depth-aware",
+      "interactive",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "turing-veins",
+    "name": "Turing Veins",
+    "url": "shaders/generative-turing-veins.wgsl",
+    "category": "image",
+    "description": "Generative multiscale reaction-diffusion Turing patterns forming organic vein/networks with bioluminescent glow. Procedurally evolves over time; depth increases complexity; mouse perturbs fields. Subtly distorts and overlays input image.",
+    "params": [
+      {
+        "name": "Scale 1",
+        "type": "range",
+        "min": 0,
+        "max": 2,
+        "default": 1,
+        "desc": "Primary Turing pattern scale (depth-modulated)",
+        "id": "scale_1"
+      },
+      {
+        "name": "Scale 2",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.6,
+        "desc": "Secondary finer scale",
+        "id": "scale_2"
+      },
+      {
+        "name": "Feed Rate",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "desc": "Reaction-diffusion activator/inhibitor balance",
+        "id": "feed_rate"
+      },
+      {
+        "name": "Vein Glow",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "desc": "Bioluminescent emission intensity",
+        "id": "vein_glow"
+      }
+    ],
+    "features": [
+      "generative",
+      "procedural",
+      "reaction-diffusion",
+      "turing-patterns",
+      "depth-aware",
+      "biological",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ascii-glyph",
+    "name": "ASCII Glyphs",
+    "url": "shaders/ascii-glyph.wgsl",
+    "category": "image",
+    "description": "ASCII / SDF glyph morphing and atlas-based rendering.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "datamosh",
+    "name": "Datamosh",
+    "url": "shaders/datamosh.wgsl",
+    "category": "image",
+    "description": "True video compression datamoshing with I/P-frame simulation, motion vector prediction, and authentic macroblock smearing artifacts.",
+    "features": [
+      "mouse-driven",
+      "multi-pass"
+    ],
+    "tags": [
+      "datamosh",
+      "glitch",
+      "compression",
+      "motion-vectors",
+      "retro",
+      "video-artifacts",
+      "smear",
+      "trail"
+    ],
+    "params": [
+      {
+        "id": "motion_strength",
+        "name": "Motion Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Strength of motion vector displacement (creates smearing trails)"
+      },
+      {
+        "id": "iframe_interval",
+        "name": "I-Frame Interval",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "Time between full frame refreshes (0=often, 1=rarely)"
+      },
+      {
+        "id": "blend_amount",
+        "name": "Smear Blend",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "How much displaced pixels blend with current frame"
+      },
+      {
+        "id": "feedback_decay",
+        "name": "Trail Decay",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "description": "How long motion trails persist (higher=longer trails)"
+      }
+    ]
+  },
+  {
+    "id": "flip-matrix",
+    "name": "Flip Matrix",
+    "category": "image",
+    "url": "shaders/flip-matrix.wgsl",
+    "description": "Grid of tiles that flip vertically in pseudo-3D based on mouse proximity.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Grid Density",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Flip Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gap",
+        "name": "Tile Gap",
+        "type": "float",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "hyperbolic-dreamweaver",
+    "name": "Hyperbolic Dreamweaver",
+    "url": "shaders/hyperbolic-dreamweaver.wgsl",
+    "category": "image",
+    "description": "Infinite non-Euclidean Poincaré disk tilings weaving the image through psychedelic Möbius transformations, depth-aware curvature, chromatic aberration, and glowing symmetry lines. Mouse centers the dream; ripples perturb the fabric.",
+    "params": [
+      {
+        "name": "Tile Count",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "desc": "Number of hyperbolic tiles (3-9)",
+        "id": "tile_count"
+      },
+      {
+        "name": "Curvature",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "desc": "Hyperbolic bending strength (depth-modulated)",
+        "id": "curvature"
+      },
+      {
+        "name": "Aberration",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "desc": "Chromatic splitting in curved space",
+        "id": "aberration"
+      },
+      {
+        "name": "Glow Intensity",
+        "type": "range",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "desc": "Symmetry line luminescence",
+        "id": "glow_intensity"
+      }
+    ],
+    "features": [
+      "geometric",
+      "psychedelic",
+      "depth-aware",
+      "non-euclidean",
+      "interactive",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "interactive-origami",
+    "name": "Interactive Origami",
+    "url": "shaders/interactive-origami.wgsl",
+    "category": "image",
+    "description": "Simulates folded paper creases that react to mouse position.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "foldScale",
+        "name": "Fold Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "foldDepth",
+        "name": "Fold Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "lightIntensity",
+        "name": "Light Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "unused",
+        "name": "Unused",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "kinetic-tiles",
+    "name": "Kinetic Tiles",
+    "category": "image",
+    "url": "shaders/kinetic_tiles.wgsl",
+    "description": "Grid of tiles that rotate and scale responsively to mouse proximity.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Grid Density",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Mouse Radius",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation Amt",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Tile Scale",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "time-lag-map",
+    "name": "Time-Lag Map",
+    "url": "shaders/time-lag-map.wgsl",
+    "category": "image",
+    "description": "Per-pixel temporal delay creating echo, smear, and time-displacement effects.",
+    "params": [
+      {
+        "id": "bufferLength",
+        "name": "Delay Length",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mappingFunction",
+        "name": "Delay Pattern",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "feedbackMix",
+        "name": "Feedback Mix",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "motionSense",
+        "name": "Motion Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "temporal-persistence",
+      "interactive",
+      "motion-detection",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "voronoi-zoom-turbulence",
+    "name": "Voronoi Zoom Turbulence",
+    "url": "shaders/voronoi-zoom-turbulence.wgsl",
+    "category": "image",
+    "description": "Divides the screen into Voronoi cells where each cell applies a chaotic, time-varying zoom. Mouse proximity calms or agitates the turbulence.",
+    "params": [
+      {
+        "name": "Cell Density",
+        "type": "float",
+        "default": 1,
+        "min": 1,
+        "max": 5,
+        "target": "zoom_params.x",
+        "id": "cell_density"
+      },
+      {
+        "name": "Turbulence Speed",
+        "type": "float",
+        "default": 1,
+        "min": 0,
+        "max": 3,
+        "target": "zoom_params.y",
+        "id": "turbulence_speed"
+      },
+      {
+        "name": "Zoom Intensity",
+        "type": "float",
+        "default": 1,
+        "min": 0,
+        "max": 2,
+        "target": "zoom_params.z",
+        "id": "zoom_intensity"
+      },
+      {
+        "name": "Mouse Influence",
+        "type": "float",
+        "default": 1,
+        "min": -1,
+        "max": 1,
+        "target": "zoom_params.w",
+        "id": "mouse_influence"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "aerogel-smoke",
+    "name": "Aerogel Smoke",
+    "description": "Simulates the ethereal, frozen-smoke appearance of aerogel with volumetric lighting and Rayleigh scattering.",
+    "url": "shaders/aerogel-smoke.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "volumetric"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scattering",
+        "name": "Blue Scatter",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Light Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "bgmix",
+        "name": "Background Visibility",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "alucinate",
+    "name": "Alucinate",
+    "url": "shaders/alucinate.wgsl",
+    "category": "image",
+    "description": "Reaction-Diffusion Psychedelia with Gray-Scott Turing patterns, domain-warped FBM, kaleidoscopic IFS fractals, conformal mapping, and audio-reactive color science.",
+    "features": [
+      "upgraded-rgba",
+      "depth-aware",
+      "reaction-diffusion",
+      "fbm-warping",
+      "kaleidoscopic-ifs",
+      "conformal-mapping",
+      "audio-reactive",
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "psychedelic",
+      "warp",
+      "interactive",
+      "organic",
+      "fluid",
+      "filter",
+      "image-processing",
+      "fractal",
+      "reaction-diffusion",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "bismuth-crystallizer",
+    "name": "Bismuth Crystallizer",
+    "url": "shaders/bismuth-crystallizer.wgsl",
+    "category": "image",
+    "description": "Generates geometric hopper crystal patterns with physical light transmission. Simulates bismuth crystals with thin-film interference iridescence, metallic Fresnel reflection, and oxide layer transmission.",
+    "params": [
+      {
+        "id": "steps",
+        "name": "Crystal Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Depth of hopper crystal recursion"
+      },
+      {
+        "id": "offset",
+        "name": "Hopper Offset",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Offset between crystal layers"
+      },
+      {
+        "id": "color_freq",
+        "name": "Iridescence Freq",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Thin-film interference color variation"
+      },
+      {
+        "id": "metallic",
+        "name": "Metallic / Mix",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "description": "Metallic reflection strength and effect mix"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "alpha-transmission",
+      "iridescence"
+    ],
+    "tags": [
+      "crystal",
+      "bismuth",
+      "hopper",
+      "iridescence",
+      "metallic",
+      "transmission",
+      "physical"
+    ]
+  },
+  {
+    "id": "chroma-threads",
+    "name": "Chroma Threads",
+    "url": "shaders/chroma-threads.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "thread_density",
+        "name": "Thread Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of chromatic threads"
+      },
+      {
+        "id": "vibration_amp",
+        "name": "Vibration Amp",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Amplitude of thread vibration"
+      },
+      {
+        "id": "rgb_split",
+        "name": "RGB Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Chromatic aberration strength"
+      },
+      {
+        "id": "decay",
+        "name": "Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Trail decay factor"
+      }
+    ]
+  },
+  {
+    "id": "circular-pixelate",
+    "name": "Circular Pixelate",
+    "category": "image",
+    "description": "Renders the image as a grid of circles. Mouse controls density and radius.",
+    "url": "shaders/circular-pixelate.wgsl",
+    "params": [
+      {
+        "name": "Density",
+        "id": "density",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Radius",
+        "id": "radius",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.4
+      },
+      {
+        "name": "Hardness",
+        "id": "hardness",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.8
+      },
+      {
+        "name": "Bg Mix",
+        "id": "bg_mix",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "color-blindness",
+    "name": "Color Blindness Sim",
+    "url": "shaders/color-blindness.wgsl",
+    "category": "image",
+    "description": "Simulates various forms of color blindness (Protanopia, Deuteranopia, Tritanopia) with split-screen comparison.",
+    "params": [
+      {
+        "id": "type",
+        "name": "Type (P/D/T)",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "severity",
+        "name": "Severity",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "split",
+        "name": "Split Screen",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "unused",
+        "name": "Unused",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "concentric-spin",
+    "name": "Concentric Spin",
+    "category": "image",
+    "url": "shaders/concentric-spin.wgsl",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "description": "Concentric rings that rotate in alternating directions. Mouse controls the center. Audio-reactive rotation with ring gap opacity.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Ring Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Smoothness",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Ring Gap Opacity",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "conv-anisotropic-diffusion",
+    "name": "Anisotropic Diffusion",
+    "description": "Perona-Malik anisotropic diffusion that smooths along edges but not across them. Creates oil-painting simplification into flat colored regions. Alpha stores per-pixel diffusion coefficient as a process map. Mouse acts as heat source accelerating diffusion.",
+    "url": "shaders/conv-anisotropic-diffusion.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "kappa",
+        "name": "Edge Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "dt",
+        "name": "Diffusion Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "iterations",
+        "name": "Iterations",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Heat",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "anisotropic-diffusion",
+      "perona-malik",
+      "oil-painting",
+      "convolution",
+      "edge-aware",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-bilateral-dream",
+    "name": "Bilateral Dream",
+    "description": "Edge-preserving bilateral smoothing with psychedelic color preservation. Uses RGBA32FLOAT alpha channel to store accumulated weight for deferred normalization. Mouse controls varying sharpness region.",
+    "url": "shaders/conv-bilateral-dream.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "spatial_sigma",
+        "name": "Spatial Sigma",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "color_sigma",
+        "name": "Color Sigma",
+        "default": 0.3,
+        "min": 0.05,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "hue_shift",
+        "name": "Psychedelic Hue Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "bilateral",
+      "convolution",
+      "edge-preserving",
+      "painterly",
+      "psychedelic",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-bilateral-grid-splat",
+    "name": "Bilateral Grid Splat",
+    "description": "Fast approximate bilateral filter using 3D grid splatting (spatial x, y + intensity). Achieves edge-preserving smoothing at O(1) per pixel. RGBA32FLOAT stores HDR accumulated color and weight. Mouse creates high-resolution detail zone.",
+    "url": "shaders/conv-bilateral-grid-splat.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "spatial_sigma",
+        "name": "Spatial Sigma",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "intensity_sigma",
+        "name": "Intensity Sigma",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "grid_resolution",
+        "name": "Grid Resolution",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Detail Zone",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "bilateral-grid",
+      "fast-bilateral",
+      "edge-preserving",
+      "convolution",
+      "splatting",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-difference-of-gaussians-cascade",
+    "name": "Difference of Gaussians Cascade",
+    "description": "Multi-scale Difference-of-Gaussians at 4 scales with signed response storage. Creates neural-edge glow where edges at different scales colorize differently. RGBA32FLOAT stores signed bipolar responses in all channels. Mouse controls scale emphasis.",
+    "url": "shaders/conv-difference-of-gaussians-cascade.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "scale_base",
+        "name": "Scale Base",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "contrast",
+        "name": "Edge Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Focus",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "difference-of-gaussians",
+      "multi-scale",
+      "edge-detection",
+      "convolution",
+      "psychedelic",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-fractal-kernel",
+    "name": "Fractal Kernel",
+    "description": "Convolution kernel shaped by Mandelbrot set membership. Pixels inside the fractal are sampled, creating alien mathematically beautiful blur patterns. Alpha stores fractal iteration depth. Mouse warps the Mandelbrot center live.",
+    "url": "shaders/conv-fractal-kernel.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "kernel_radius",
+        "name": "Kernel Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "fractal_zoom",
+        "name": "Fractal Zoom",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "iterations",
+        "name": "Fractal Iterations",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Warp",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "fractal",
+      "mandelbrot",
+      "convolution",
+      "kernel",
+      "psychedelic",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-frequency-domain-notch",
+    "name": "Frequency Domain Notch",
+    "description": "Spatial-domain approximation of frequency notch filtering using tuned sinusoidal convolution kernels. Removes moire patterns or creates frequency painting. Alpha stores spectral response magnitude. Mouse selects target frequency band.",
+    "url": "shaders/conv-frequency-domain-notch.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "num_bands",
+        "name": "Frequency Bands",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "bandwidth",
+        "name": "Notch Bandwidth",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "boost_cut",
+        "name": "Boost / Cut",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "frequency-notch",
+      "spectral",
+      "convolution",
+      "moire-removal",
+      "frequency-painting",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-gabor-texture-analyzer",
+    "name": "Gabor Texture Analyzer",
+    "description": "Gabor filter bank detecting oriented texture patterns at 0, 45, 90, and 135 degrees. RGBA32FLOAT stores signed bipolar responses in all four channels. Mouse rotates the filter bank for swirling texture segmentation.",
+    "url": "shaders/conv-gabor-texture-analyzer.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "frequency",
+        "name": "Gabor Frequency",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "sigma",
+        "name": "Gaussian Sigma",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "response_scale",
+        "name": "Response Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "gabor",
+      "convolution",
+      "texture-analysis",
+      "orientation",
+      "psychedelic",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-guided-filter-depth",
+    "name": "Guided Filter Depth",
+    "description": "Guided filter using depth texture as guide for edge-aware filtering. Creates depth-of-field blur that perfectly respects object boundaries. Alpha stores filtering confidence coefficient. Mouse creates localized focus aperture.",
+    "url": "shaders/conv-guided-filter-depth.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "depth-aware",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "radius",
+        "name": "Filter Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "epsilon",
+        "name": "Edge Sensitivity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "depth_influence",
+        "name": "Depth Influence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Focus",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "guided-filter",
+      "convolution",
+      "depth-aware",
+      "edge-preserving",
+      "depth-of-field",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-morphological-erosion-dilation",
+    "name": "Morphological Erosion Dilation",
+    "description": "Mathematical morphology on images — erosion shrinks bright regions, dilation expands them. RGBA32FLOAT packs erosion (R), dilation (G), gradient (B), and top-hat (A) into one pass. Mouse controls directional structuring element.",
+    "url": "shaders/conv-morphological-erosion-dilation.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "kernel_radius",
+        "name": "Kernel Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "erode_dilate_blend",
+        "name": "Erosion / Dilation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "gradient_boost",
+        "name": "Gradient Boost",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "morphological",
+      "convolution",
+      "erosion",
+      "dilation",
+      "edge-detection",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-non-local-means",
+    "name": "Non-Local Means",
+    "description": "Gold-standard denoising that averages similar patches across the image. Cranked to artistic overdrive for hallucinatory double-exposure effects. Alpha stores self-similarity importance map. Mouse controls focus zone precision.",
+    "url": "shaders/conv-non-local-means.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "patch_radius",
+        "name": "Patch Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "search_radius",
+        "name": "Search Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "filter_strength",
+        "name": "Filter Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "overdrive",
+        "name": "Artistic Overdrive",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "non-local-means",
+      "convolution",
+      "denoising",
+      "patch-similarity",
+      "artistic",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-reaction-convolution",
+    "name": "Reaction Convolution",
+    "url": "shaders/conv-reaction-convolution.wgsl",
+    "category": "image",
+    "description": "Gray-Scott reaction-diffusion applied as a convolution filter on the input image. Uses image luminance to seed chemical concentrations and mouse interaction to inject patterns.",
+    "tags": [
+      "convolution",
+      "reaction-diffusion",
+      "gray-scott",
+      "mouse-driven",
+      "interactive",
+      "rgba-as-data"
+    ],
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "diffA",
+        "name": "Diffusion A",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "diffB",
+        "name": "Diffusion B",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "feedRate",
+        "name": "Feed Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "mouseInfluence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "conv-spiral-blur",
+    "name": "Spiral Blur",
+    "description": "Logarithmic spiral convolution creating rotational motion blur along golden ratio spirals. RGBA32FLOAT stores HDR accumulated color and spiral coverage factor. Mouse controls spiral center and tightness for vortex-like effects.",
+    "url": "shaders/conv-spiral-blur.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "tightness",
+        "name": "Spiral Tightness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "num_arms",
+        "name": "Spiral Arms",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "samples",
+        "name": "Sample Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Center",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "spiral",
+      "logarithmic",
+      "golden-ratio",
+      "convolution",
+      "motion-blur",
+      "vortex",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-steerable-pyramid",
+    "name": "Steerable Pyramid",
+    "description": "Decomposes image into oriented sub-bands at 0, 45, 90, and 135 degrees using steerable filters. RGBA32FLOAT stores full-precision signed sub-band coefficients for lossless reconstruction or artistic boosting. Mouse steers the decomposition angle.",
+    "url": "shaders/conv-steerable-pyramid.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "sigma",
+        "name": "Filter Scale",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "response_scale",
+        "name": "Response Scale",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "color_boost",
+        "name": "Color Boost",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Steer",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "steerable-pyramid",
+      "orientation",
+      "sub-band",
+      "convolution",
+      "wavelet",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-stochastic-stipple",
+    "name": "Stochastic Stipple",
+    "description": "Blue-noise dithered weighted Voronoi stippling creating pointillist art from any image. Each dot represents a local neighborhood sized by average luminance. Alpha stores continuous stipple density for downstream dot-size variation. Mouse creates higher-resolution stipple zone.",
+    "url": "shaders/conv-stochastic-stipple.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "cell_size",
+        "name": "Cell Size",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "threshold",
+        "name": "Stipple Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "saturation",
+        "name": "Color Saturation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Resolution",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "stipple",
+      "pointillism",
+      "blue-noise",
+      "dithering",
+      "convolution",
+      "artistic",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "conv-structure-tensor-flow",
+    "name": "Structure Tensor Flow",
+    "description": "Computes structure tensor, extracts eigenvectors for dominant texture orientation, and visualizes flow via Line Integral Convolution. RGBA32FLOAT packs eigenvector components, coherency, and LIC intensity. Mouse creates vortices in the flow field.",
+    "url": "shaders/conv-structure-tensor-flow.wgsl",
+    "category": "image",
+    "features": [
+      "advanced-convolution",
+      "rgba32float-exploiting",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "lic_steps",
+        "name": "LIC Steps",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "coherency_boost",
+        "name": "Coherency Boost",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "flow_speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Vortex",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "structure-tensor",
+      "LIC",
+      "flow-visualization",
+      "convolution",
+      "texture-analysis",
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cross-conv-mouse-bilateral",
+    "name": "Bilateral Paint",
+    "url": "shaders/cross-conv-mouse-bilateral.wgsl",
+    "category": "image",
+    "description": "Crossover shader combining bilateral convolution with mouse-driven painting. The cursor acts as a brush that applies edge-preserving smoothing — stronger near the cursor, with click boosting the effect.",
+    "tags": [
+      "crossover",
+      "convolution",
+      "bilateral",
+      "mouse-driven",
+      "paint",
+      "interactive"
+    ],
+    "features": [
+      "crossover",
+      "mouse-driven",
+      "advanced-convolution"
+    ],
+    "params": [
+      {
+        "id": "brushSize",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "edgePreserve",
+        "name": "Edge Preservation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "strength",
+        "name": "Effect Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "crumpled-paper",
+    "name": "Crumpled Paper",
+    "category": "image",
+    "description": "Simulates the look of crumpled paper with interactive smoothing.",
+    "url": "shaders/crumpled-paper.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "scale",
+        "name": "Crumple Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "depth",
+        "name": "Crumple Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smooth_radius",
+        "name": "Smooth Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "light_strength",
+        "name": "Light Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-halftone-scanner",
+    "name": "Cyber Halftone Scanner",
+    "url": "shaders/cyber-halftone-scanner.wgsl",
+    "category": "image",
+    "description": "CMYK-style halftone pattern with a scanning glitch line.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Dot Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Scan Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "separation",
+        "name": "RGB Split",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "brightness",
+        "name": "Brightness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "data-moshing",
+    "name": "Data Moshing",
+    "url": "shaders/data-moshing.wgsl",
+    "category": "image",
+    "description": "Smears pixels based on mouse movement, simulating video compression artifacts and glitch art.",
+    "params": [
+      {
+        "id": "smear",
+        "name": "Smear Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Brush Size",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "decay",
+        "name": "Persistence",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "crush",
+        "name": "Bit Crush",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "directional-blur-wipe",
+    "name": "Directional Blur Wipe",
+    "category": "image",
+    "description": "Splits the screen with a directional blur. Mouse controls split position and angle.",
+    "url": "shaders/directional-blur-wipe.wgsl",
+    "params": [
+      {
+        "name": "Split Pos",
+        "id": "split_pos",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Angle",
+        "id": "angle",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      },
+      {
+        "name": "Strength",
+        "id": "strength",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Samples",
+        "id": "samples",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "fractal-noise-dissolve",
+    "name": "Fractal Noise Dissolve",
+    "url": "shaders/fractal-noise-dissolve.wgsl",
+    "category": "image",
+    "description": "Dissolves the image into fractal noise around the mouse.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Noise Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Hole Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge",
+        "name": "Edge Softness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "burn",
+        "name": "Burn Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "frost-reveal",
+    "name": "Frost Reveal",
+    "url": "shaders/frost-reveal.wgsl",
+    "category": "image",
+    "description": "Interactive frost reveal effect with crystalline patterns that form based on mouse interaction.",
+    "features": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "frosted-glass-lens",
+    "name": "Frosted Glass Lens",
+    "url": "shaders/frosted-glass-lens.wgsl",
+    "category": "image",
+    "description": "A frosted glass effect that reveals the clear image under the mouse cursor.",
+    "params": [
+      {
+        "id": "frost_amt",
+        "name": "Frost Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Edge Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "gamma-ray-burst",
+    "name": "Gamma Ray Burst",
+    "category": "image",
+    "url": "shaders/gamma-ray-burst.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Intense radial blur and exposure burst originating from the mouse position.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Ray Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Exposure",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "glitch-reveal",
+    "name": "Glitch Reveal",
+    "description": "A chaotic digital noise field that is stabilized and clarified by the proximity of the cursor.",
+    "url": "shaders/glitch-reveal.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "block",
+        "name": "Block Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scatter",
+        "name": "Scatter Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Reveal Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Jitter Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "glitch-ripple-drag",
+    "category": "image",
+    "url": "shaders/glitch-ripple-drag.wgsl",
+    "description": "Mouse emits expanding ripples that permanently drag and glitch the video pixels.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "drag",
+        "name": "Drag Strength",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "freq",
+        "name": "Ripple Freq",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "persist",
+        "name": "Persistence",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitch Factor",
+        "type": "float",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Glitch Ripple Drag"
+  },
+  {
+    "id": "graphic-novel",
+    "name": "Graphic Novel",
+    "category": "image",
+    "description": "Transforms image into a comic book style with edge detection and halftone patterns.",
+    "url": "shaders/graphic_novel.wgsl",
+    "params": [
+      {
+        "id": "dotSize",
+        "name": "Dot Size",
+        "min": 0,
+        "max": 1,
+        "default": 0.3
+      },
+      {
+        "id": "edge",
+        "name": "Edge Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "id": "levels",
+        "name": "Color Levels",
+        "min": 0,
+        "max": 1,
+        "default": 0.4
+      },
+      {
+        "id": "paper",
+        "name": "Paper Grain",
+        "min": 0,
+        "max": 1,
+        "default": 0.2
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "hex-lens",
+    "name": "Hex Lens Interactive",
+    "category": "image",
+    "url": "shaders/hex-lens.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Hexagonal grid where each cell acts as a lens, controlled by the mouse.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Tile Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Lens Zoom",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "holographic-shatter",
+    "name": "Holographic Shatter",
+    "description": "Fractures the image into digital shards that react to cursor movement with holographic interference patterns.",
+    "url": "shaders/holographic-shatter.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "scale",
+        "name": "Shard Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "holo",
+        "name": "Hologram Intensity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "displace",
+        "name": "Displacement",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Glitch Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music"
+    ]
+  },
+  {
+    "id": "honey-melt",
+    "name": "Honey Melt",
+    "url": "shaders/honey-melt.wgsl",
+    "category": "image",
+    "description": "A golden hexagonal grid that melts under the mouse.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Cell Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Melt Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distort",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "kintsugi-repair",
+    "name": "Kintsugi Repair",
+    "url": "shaders/kintsugi-repair.wgsl",
+    "category": "image",
+    "description": "Simulates the Japanese art of repairing broken pottery with gold (Kintsugi). Voronoi patterns create cracks with gold filling.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Shard Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Gold Width",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "displacement",
+        "name": "Shatter Amount",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shiny",
+        "name": "Gold Sparkle",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "liquid-chrome-ripple",
+    "name": "Liquid Chrome Ripple",
+    "url": "shaders/liquid-chrome-ripple.wgsl",
+    "category": "image",
+    "description": "Metallic liquid effect that ripples with mouse movement.",
+    "params": [
+      {
+        "id": "flow",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distort",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "metal",
+        "name": "Metalness",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "freq",
+        "name": "Ripple Freq",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "luma-refraction",
+    "name": "Luma Refraction",
+    "url": "shaders/luma-refraction.wgsl",
+    "category": "image",
+    "description": "Ripples propagate through the image, with speed determined by brightness. Bright areas are like water, dark areas like oil.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 2
+      },
+      {
+        "id": "force",
+        "name": "Mouse Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.98,
+        "min": 0.9,
+        "max": 0.999
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "simulation"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "magnetic-chroma",
+    "name": "Magnetic Chroma",
+    "category": "image",
+    "url": "shaders/magnetic-chroma.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "RGB channels are pulled towards the mouse with a twisting distortion.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Pull Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Twist",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Falloff",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "neon-pulse-stream",
+    "category": "image",
+    "url": "shaders/neon-pulse-stream.wgsl",
+    "description": "Video luminance directs a fluid flow of neon trails injected by the mouse.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Trail Length",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Neon Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Flow Chaos",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "name": "Neon Pulse Stream"
+  },
+  {
+    "id": "optical-illusion-spin",
+    "name": "Optical Illusion Spin",
+    "category": "image",
+    "description": "Slices the image into rotating concentric rings. Mouse adds a twisting force.",
+    "url": "shaders/optical-illusion-spin.wgsl",
+    "params": [
+      {
+        "name": "Ring Count",
+        "id": "rings",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Speed",
+        "id": "speed",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.2
+      },
+      {
+        "name": "Twist Force",
+        "id": "twist",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.6
+      },
+      {
+        "name": "Alternating",
+        "id": "alt",
+        "min": 0,
+        "max": 1,
+        "step": 1,
+        "default": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "page-curl-interactive",
+    "name": "Page Curl Interactive",
+    "category": "image",
+    "url": "shaders/page-curl-interactive.wgsl",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "temporal",
+      "depth-aware",
+      "upgraded-rgba"
+    ],
+    "description": "Interactive page curl with audio-reactive RGB splitting, click shockwaves, depth-aware shadows, and temporal feedback trails.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Curl Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Shadow Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Feedback Amount",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Depth Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "interactive",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "pin-art-3d",
+    "name": "Pin Art 3D",
+    "category": "image",
+    "description": "Simulates a 3D pin art toy where image brightness controls pin height. Mouse pushes pins down.",
+    "url": "shaders/pin-art-3d.wgsl",
+    "params": [
+      {
+        "name": "Density",
+        "id": "density",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Pin Radius",
+        "id": "radius",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.8
+      },
+      {
+        "name": "Push Strength",
+        "id": "push",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.8
+      },
+      {
+        "name": "Metallic",
+        "id": "shiny",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-scattering",
+    "name": "Pixel Scattering",
+    "url": "shaders/pixel-scattering.wgsl",
+    "category": "image",
+    "description": "Scatters pixels away from the mouse cursor like dust particles.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Scatter Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strength",
+        "name": "Scatter Distance",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "size",
+        "name": "Particle Size",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "random",
+        "name": "Chaos",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-stretch-interactive",
+    "name": "Pixel Stretch",
+    "category": "image",
+    "description": "Stretches pixels from the mouse position to the screen edge, creating a spatial slit-scan effect.",
+    "url": "shaders/pixel-stretch-interactive.wgsl",
+    "params": [
+      {
+        "name": "Direction Mode",
+        "id": "mode",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      },
+      {
+        "name": "Jitter",
+        "id": "jitter",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      },
+      {
+        "name": "RGB Shift",
+        "id": "rgb_shift",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      },
+      {
+        "name": "Unused",
+        "id": "unused",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "plastic-bricks",
+    "name": "Plastic Bricks",
+    "category": "image",
+    "url": "shaders/plastic-bricks.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Simulates a plastic brick surface (like LEGO) with 3D studs. Mouse influences scale.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Brick Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Stud Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Relief Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Bevel",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "polka-wave",
+    "name": "Polka Wave",
+    "category": "image",
+    "description": "Halftone effect where dot size responds to image brightness and interactive ripples.",
+    "url": "shaders/polka-wave.wgsl",
+    "params": [
+      {
+        "name": "Grid Density",
+        "id": "density",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Wave Amp",
+        "id": "wave_amp",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Wave Freq",
+        "id": "wave_freq",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Wave Speed",
+        "id": "wave_speed",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "retro-gameboy",
+    "name": "Retro Game Boy",
+    "category": "image",
+    "description": "Simulates a classic handheld green dot-matrix display.",
+    "url": "shaders/retro-gameboy.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "pixel_size",
+        "name": "Pixel Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "grid_strength",
+        "name": "Grid Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shadow_offset",
+        "name": "Shadow Offset",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rgb-ripple-distortion",
+    "name": "RGB Ripple Distortion",
+    "url": "shaders/rgb-ripple-distortion.wgsl",
+    "category": "image",
+    "description": "A ripple effect that separates RGB channels based on distance from mouse.",
+    "params": [
+      {
+        "id": "freq",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amp",
+        "name": "Amplitude",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sep",
+        "name": "Color Separation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ring-slicer",
+    "name": "Ring Slicer",
+    "category": "image",
+    "description": "Slices the image into rotating concentric rings centered on the mouse.",
+    "url": "shaders/ring_slicer.wgsl",
+    "params": [
+      {
+        "id": "density",
+        "name": "Ring Count",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "id": "speed",
+        "name": "Rotation Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.6
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos",
+        "min": 0,
+        "max": 1,
+        "default": 0.1
+      },
+      {
+        "id": "center",
+        "name": "Mouse Follow",
+        "min": 0,
+        "max": 1,
+        "default": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ripple-blocks",
+    "name": "Ripple Blocks",
+    "category": "image",
+    "description": "Grid blocks that scale based on a wave pattern from the mouse.",
+    "url": "shaders/ripple-blocks.wgsl",
+    "params": [
+      {
+        "name": "Grid Size",
+        "id": "grid_size",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Wave Amp",
+        "id": "wave_amp",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Freq",
+        "id": "freq",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Speed",
+        "id": "speed",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "slime-drip",
+    "name": "Slime Drip",
+    "url": "shaders/slime-drip.wgsl",
+    "category": "image",
+    "description": "A gooey, dripping slime effect that can be wiped away.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Drip Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amount",
+        "name": "Slime Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color",
+        "name": "Green Tint",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "spec-cooperative-edge-linking",
+    "name": "Cooperative Edge Linking",
+    "url": "shaders/spec-cooperative-edge-linking.wgsl",
+    "category": "image",
+    "description": "Workgroup-cooperative edge detection and chain tracing. Uses shared memory union-find to link connected edges within each tile, assigning unique edge IDs for downstream segmentation and flow effects.",
+    "tags": [
+      "edge-detection",
+      "edge-linking",
+      "cooperative",
+      "workgroup",
+      "segmentation",
+      "union-find"
+    ],
+    "features": [
+      "cooperative-workgroup",
+      "edge-linking",
+      "segmentation",
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "edge_threshold",
+        "name": "Edge Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "link_radius",
+        "name": "Link Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_mode",
+        "name": "Color Mode",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glow",
+        "name": "Edge Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "spec-histogram-equalize",
+    "name": "Histogram Equalize",
+    "url": "shaders/spec-histogram-equalize.wgsl",
+    "category": "image",
+    "description": "Real-time CLAHE histogram equalization using workgroup cooperative histogram building. Computes local histogram per 8x8 tile and remaps intensities via CDF for dramatic adaptive contrast enhancement.",
+    "tags": [
+      "histogram",
+      "equalization",
+      "CLAHE",
+      "contrast",
+      "cooperative",
+      "workgroup"
+    ],
+    "features": [
+      "cooperative-workgroup",
+      "histogram",
+      "CLAHE",
+      "contrast-enhancement"
+    ],
+    "params": [
+      {
+        "id": "clip_limit",
+        "name": "Clip Limit",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "strength",
+        "name": "Effect Strength",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "tile_blend",
+        "name": "Tile Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_preserve",
+        "name": "Color Preserve",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "spectral-mesh",
+    "name": "Spectral Mesh",
+    "url": "shaders/spectral-mesh.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "grid_density",
+        "name": "Grid Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of the spectral mesh"
+      },
+      {
+        "id": "displacement",
+        "name": "Displacement Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Height of mesh displacement"
+      },
+      {
+        "id": "mouse_radius",
+        "name": "Mouse Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Radius of mouse interaction"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Spectral color shift"
+      }
+    ]
+  },
+  {
+    "id": "spectral-slit-scan",
+    "category": "image",
+    "url": "shaders/spectral-slit-scan.wgsl",
+    "description": "RGB trails that decay at different rates, distorted by sine waves and mouse gravity.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "split",
+        "name": "RGB Split",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "trail",
+        "name": "Trail Length",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "freq",
+        "name": "Wave Freq",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amp",
+        "name": "Wave Amp",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Spectral Slit Scan"
+  },
+  {
+    "id": "steampunk-gear-lens",
+    "name": "Steampunk Gear Lens",
+    "url": "shaders/steampunk-gear-lens.wgsl",
+    "category": "image",
+    "description": "A rotating mechanical gear lens with sepia filter and audio-reactive rotation.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Gear Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "teeth",
+        "name": "Teeth Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sepia",
+        "name": "Sepia Strength",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "steampunk",
+      "gear",
+      "mechanical",
+      "sepia"
+    ]
+  },
+  {
+    "id": "tensor-flow-sculpting",
+    "name": "Tensor Flow Sculpting",
+    "url": "shaders/tensor-flow-sculpting.wgsl",
+    "category": "image",
+    "description": "Depth is treated as a 4-D strain tensor that warps and sculpts the image like clay — bulk regions bend dramatically while high-frequency edge details stay crisp.",
+    "tags": [
+      "depth",
+      "tensor",
+      "warp",
+      "sculpt",
+      "flow",
+      "artistic",
+      "deformation",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "author": "AI",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Strain Scale",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01,
+        "description": "Amplitude of the tensor-field deformation."
+      },
+      {
+        "id": "param2",
+        "name": "Detail Preserve",
+        "min": 0,
+        "max": 1,
+        "default": 0.6,
+        "step": 0.01,
+        "description": "How much high-frequency detail is added back after warping."
+      },
+      {
+        "id": "param3",
+        "name": "Flow Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01,
+        "description": "Speed of the time-varying noise flow that modulates the tensor."
+      },
+      {
+        "id": "param4",
+        "name": "Tensor Mode",
+        "min": 0,
+        "max": 1,
+        "default": 0,
+        "step": 0.01,
+        "description": "Blend from stretch-dominant (0) to shear-dominant (1) deformation."
+      }
+    ]
+  },
+  {
+    "id": "texture",
+    "name": "Procedural Texture Analyzer",
+    "url": "shaders/texture.wgsl",
+    "category": "image",
+    "description": "Multi-scale texture analyzer with Laplacian edge enhancement, unsharp mask, temporal smoothing, golden-ratio vignette, and audio-reactive sparkle/glitch.",
+    "features": [
+      "depth-aware",
+      "upgraded-rgba",
+      "audio-reactive",
+      "temporal"
+    ],
+    "tags": [
+      "image",
+      "video",
+      "edge-enhance",
+      "unsharp",
+      "temporal",
+      "vignette",
+      "audio-reactive",
+      "vj"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Edge Enhance",
+        "default": 0.35,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Unsharp Mask",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Temporal Smooth",
+        "default": 0.25,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
         "name": "Audio Reactivity",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "tilt-shift",
+    "name": "Tilt Shift Miniature",
+    "url": "shaders/tilt-shift.wgsl",
+    "category": "image",
+    "description": "Simulates a tilt-shift lens effect, blurring top and bottom to make the scene look like a miniature model.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Blur Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Focus Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "saturation",
+        "name": "Saturation",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "triangle-mosaic",
+    "name": "Triangle Mosaic",
+    "category": "image",
+    "description": "Breaks the image into an equilateral triangle grid. Mouse controls scale and twist.",
+    "url": "shaders/triangle-mosaic.wgsl",
+    "params": [
+      {
+        "name": "Scale",
+        "id": "scale",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Rotation",
+        "id": "rotation",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      },
+      {
+        "name": "Twist",
+        "id": "twist",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0
+      },
+      {
+        "name": "Mix",
+        "id": "mix",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "video-echo-chamber",
+    "name": "Video Echo Chamber",
+    "url": "shaders/video-echo-chamber.wgsl",
+    "category": "image",
+    "description": "Temporal trails that persist longer near the mouse cursor, creating a ghostly echo effect.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Global Decay",
+        "default": 0.6,
+        "min": 0,
+        "max": 0.95
+      },
+      {
+        "id": "radius",
+        "name": "Mouse Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "echoStr",
+        "name": "Echo Strength",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "voxel-depth-sort",
+    "name": "Voxel Depth Sort",
+    "url": "shaders/voxel-depth-sort.wgsl",
+    "category": "image",
+    "description": "Converts the image into a 3D grid of floating blocks. Block height is determined by brightness, and mouse position tilts the view.",
+    "params": [
+      {
+        "id": "gridSize",
+        "name": "Block Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "extrusion",
+        "name": "Extrusion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shadow",
+        "name": "BG Darken",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gap",
+        "name": "Block Gap",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.8
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "3d-effect"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "wave-halftone",
+    "category": "image",
+    "url": "shaders/wave-halftone.wgsl",
+    "description": "Halftone dot pattern with a waving grid and mouse magnification lens.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "size",
+        "name": "Dot Size",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Grid Density",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amp",
+        "name": "Wave Amp",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Wave Halftone"
+  },
+  {
+    "id": "anamorphic-flare",
+    "name": "Anamorphic Flare",
+    "url": "shaders/anamorphic-flare.wgsl",
+    "category": "image",
+    "description": "Generates a cinematic horizontal lens flare centered on the mouse position.",
+    "params": [
+      {
+        "id": "width",
+        "name": "Flare Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Threshold",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ascii-lens",
+    "name": "ASCII Lens",
+    "url": "shaders/ascii-lens.wgsl",
+    "category": "image",
+    "description": "Reveals the image as procedural ASCII characters within a lens radius around the mouse.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Radius of the ASCII lens"
+      },
+      {
+        "id": "density",
+        "name": "Character Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Density of ASCII characters in the lens"
+      },
+      {
+        "id": "line_width",
+        "name": "Glyph Line Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Width of glyph lines in the ASCII characters"
+      },
+      {
+        "id": "brightness_bias",
+        "name": "Brightness Threshold Bias",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Bias for brightness threshold comparisons"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "biomimetic-scales",
+    "name": "Biomimetic Scales",
+    "url": "shaders/biomimetic-scales.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "scale_size",
+        "name": "Scale Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "roughness",
+        "name": "Roughness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "reaction_radius",
+        "name": "Reaction Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "lift",
+        "name": "Lift Strength",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "blueprint-reveal",
+    "name": "Blueprint Reveal",
+    "url": "shaders/blueprint-reveal.wgsl",
+    "category": "image",
+    "description": "Interactive blueprint schematic that you can erase to reveal reality.",
+    "params": [
+      {
+        "id": "edgeStrength",
+        "name": "Edge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gridOpacity",
+        "name": "Grid Opacity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Reveal Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "bubble-wrap",
+    "name": "Bubble Wrap",
+    "url": "shaders/bubble-wrap.wgsl",
+    "category": "image",
+    "description": "Interactive bubble wrap that you can pop with your mouse. Popped bubbles stay popped!",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Bubble Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "popStrength",
+        "name": "Pop Strength",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "unused",
+        "name": "Unused",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "charcoal-rub",
+    "name": "Charcoal Rub",
+    "url": "shaders/charcoal-rub.wgsl",
+    "category": "image",
+    "description": "Scratch-off effect like rubbing charcoal paper. Mouse reveals image beneath textured overlay.",
+    "params": [
+      {
+        "id": "hardness",
+        "name": "Edge Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "texture_scale",
+        "name": "Paper Texture",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "reveal_rate",
+        "name": "Rub Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fade_speed",
+        "name": "Fade Back",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "interactive",
+      "stateful"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "chroma-lens",
+    "name": "Chroma Lens",
+    "url": "shaders/chroma-lens.wgsl",
+    "category": "image",
+    "description": "A magnifying lens effect that splits color channels (chromatic aberration) towards the edges.",
+    "params": [
+      {
+        "id": "magnification",
+        "name": "Magnification",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blurEdges",
+        "name": "Edge Blur",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "chromatic-shockwave",
+    "name": "Chromatic Shockwave",
+    "url": "shaders/chromatic-shockwave.wgsl",
+    "category": "image",
+    "description": "Continuous chromatic ripples emanating from the mouse.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "freq",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ring_count",
+        "name": "Ring Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Number of shockwave rings"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "chronos-brush",
+    "name": "Chronos Brush",
+    "url": "shaders/chronos-brush.wgsl",
+    "category": "image",
+    "description": "Freeze time by painting over the video feed.",
+    "params": [
+      {
+        "id": "brushSize",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Freeze Decay",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Time Edge Distort",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Mode (Paint/Erase)",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "labels": [
+          "Freeze",
+          "Unfreeze"
+        ]
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cmyk-halftone-interactive",
+    "name": "CMYK Halftone Interactive",
+    "url": "shaders/cmyk-halftone-interactive.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Dot Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle_offset",
+        "name": "Angle Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "separation",
+        "name": "Channel Spread",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "darkness",
+        "name": "Ink Darkness",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "contour-flow",
+    "name": "Contour Flow",
+    "category": "image",
+    "url": "shaders/contour-flow.wgsl",
+    "description": "Image pixels flow along their luminance contours, reacting to mouse proximity.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "name": "Flow Speed",
+        "id": "flowSpeed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Flow Length",
+        "id": "flowLength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Mouse Radius",
+        "id": "mouseRadius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Edge Sens.",
+        "id": "edgeDetect",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cross-stitch",
+    "name": "Cross Stitch Reveal",
+    "url": "shaders/cross-stitch.wgsl",
+    "category": "image",
+    "description": "Quantizes the image into cross-stitch patterns. Mouse movement unravels or distorts the fabric.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Stitch Scale",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "thickness",
+        "name": "Thread Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Unravel Chaos",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "geometry"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "crystal-freeze",
+    "name": "Crystal Freeze",
+    "url": "shaders/crystal-freeze.wgsl",
+    "category": "image",
+    "description": "Mouse freezes the image into growing ice crystals with physical light transmission. Features Voronoi-based crystal cells with Fresnel reflection, path absorption, and purity-based scattering.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Freeze Decay",
+        "default": 0.99,
+        "min": 0.9,
+        "max": 0.999,
+        "description": "How long frozen crystals persist"
+      },
+      {
+        "id": "scale",
+        "name": "Crystal Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Size of crystal cells"
+      },
+      {
+        "id": "refraction",
+        "name": "Material IOR",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "description": "Refractive index: Ice (1.31) to Glass (1.5)"
+      },
+      {
+        "id": "purity",
+        "name": "Ice Purity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Crystal clarity: Pure ice transmits more light, cloudy ice scatters more"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "alpha-transmission",
+      "persistence"
+    ],
+    "tags": [
+      "crystal",
+      "ice",
+      "freeze",
+      "transmission",
+      "voronoi",
+      "physical"
+    ]
+  },
+  {
+    "id": "crystal-refraction",
+    "name": "Crystal Refraction",
+    "url": "shaders/crystal-refraction.wgsl",
+    "category": "image",
+    "description": "Interactive faceted crystal lens with physical light transmission. Features IOR-based chromatic dispersion, Fresnel reflection at edges, and variable crystal thickness affecting light path.",
+    "params": [
+      {
+        "id": "facetScale",
+        "name": "Facet Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Number of crystal facets around mouse"
+      },
+      {
+        "id": "dispersion",
+        "name": "IOR / Dispersion",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "description": "Refractive index affecting chromatic dispersion: Quartz to Diamond"
+      },
+      {
+        "id": "strength",
+        "name": "Refraction Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Amount of lens distortion"
+      },
+      {
+        "id": "thickness",
+        "name": "Crystal Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Physical thickness affecting light transmission and absorption"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "alpha-transmission",
+      "chromatic-aberration",
+      "physical-refraction",
+      "audio-reactive",
+      "audio-driven",
+      "advanced-alpha"
+    ],
+    "tags": [
+      "crystal",
+      "lens",
+      "refraction",
+      "dispersion",
+      "transmission",
+      "fresnel",
+      "audio",
+      "music",
+      "reactive",
+      "alpha",
+      "physical-transmittance"
+    ]
+  },
+  {
+    "id": "cyber-focus",
+    "name": "Cyber Focus",
+    "url": "shaders/cyber-focus.wgsl",
+    "category": "image",
+    "description": "High-tech focus mode where the area around the mouse is crisp, while the background suffers from digital interference and chromatic aberration.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Focus Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blur",
+        "name": "Blur Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitch Intensity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-glitch-hologram",
+    "name": "Cyber Glitch Hologram",
+    "url": "shaders/cyber-glitch-hologram.wgsl",
+    "category": "image",
+    "description": "A sci-fi holographic projection with interactive interference and chromatic aberration.",
+    "params": [
+      {
+        "id": "hologramIntensity",
+        "name": "Hologram Int.",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitchAmount",
+        "name": "Glitch Amt.",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanSpeed",
+        "name": "Scan Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "mouseRadius",
+        "name": "Mouse Inf.",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-hex-armor",
+    "name": "Cyber Hex Armor",
+    "url": "shaders/cyber-hex-armor.wgsl",
+    "category": "image",
+    "description": "A hexagonal tech armor overlay that retracts when the mouse approaches.",
+    "params": [
+      {
+        "id": "hex_size",
+        "name": "Hex Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Size of the hexagonal grid cells"
+      },
+      {
+        "id": "glow_intensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Intensity of the hex edge glow"
+      },
+      {
+        "id": "reveal_radius",
+        "name": "Reveal Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Radius around mouse where armor retracts"
+      },
+      {
+        "id": "border_thickness",
+        "name": "Border Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Thickness of hexagon borders"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "overlay"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-lattice",
+    "name": "Cyber Lattice",
+    "category": "image",
+    "url": "shaders/cyber-lattice.wgsl",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "description": "A dynamic holographic grid that reacts to mouse movement and clicks.",
+    "params": [
+      {
+        "name": "Grid Scale",
+        "id": "scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Distortion",
+        "id": "distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Glow",
+        "id": "glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Radius",
+        "id": "radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-organic",
+    "name": "Cyber Organic Scanner",
+    "url": "shaders/cyber-organic.wgsl",
+    "category": "image",
+    "description": "Scans the image to reveal a pulsating organic layer beneath.",
+    "params": [
+      {
+        "id": "scanSpeed",
+        "name": "Scan Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "organicScale",
+        "name": "Organic Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "revealRadius",
+        "name": "Reveal Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulseSpeed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-rain",
+    "name": "Cyber Rain",
+    "url": "shaders/cyber-rain.wgsl",
+    "category": "image",
+    "description": "Neon rain on wet glass with mouse wiper.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Rain Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blur",
+        "name": "Wet Blur",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bloom",
+        "name": "Neon Bloom",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "wiper",
+        "name": "Wiper Size",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "data-stream-corruption",
+    "name": "Data Stream Corruption",
+    "url": "shaders/data-stream-corruption.wgsl",
+    "category": "image",
+    "description": "Vertical data streams fall like rain; your mouse leaves a trail of corrupted code blocks.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Stream Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "brush",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Glitch Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "persistence",
+        "name": "Persistence",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "glitch"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "digital-compression",
+    "name": "Digital Compression",
+    "url": "shaders/digital-compression.wgsl",
+    "category": "image",
+    "description": "Simulates digital artifacts and compression blocks. Mouse controls the clear focus area.",
+    "params": [
+      {
+        "id": "blockSize",
+        "name": "Block Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorDepth",
+        "name": "Bit Crush",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "artifacts",
+        "name": "Artifacts",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "focus",
+        "name": "Focus Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "digital-haze",
+    "category": "image",
+    "url": "shaders/digital-haze.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "pixel_strength",
+        "name": "Pixel Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Controls grid size for pixelation"
+      },
+      {
+        "id": "clear_radius",
+        "name": "Clear Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Radius around mouse where fog clears"
+      },
+      {
+        "id": "noise_amount",
+        "name": "Noise Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Amount of digital noise in the haze"
+      },
+      {
+        "id": "haze_density",
+        "name": "Haze Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Density of the volumetric haze"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Digital Haze"
+  },
+  {
+    "id": "digital-mold",
+    "name": "Digital Mold",
+    "url": "shaders/digital-mold.wgsl",
+    "category": "image",
+    "description": "A digital decay effect that grows from the mouse cursor, eating away the image.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Noise Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spread",
+        "name": "Spread Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -17681,90 +8662,2486 @@
     ]
   },
   {
-    "id": "chromatic-crawler",
-    "name": "Chromatic Crawler",
-    "url": "shaders/chromatic-crawler.wgsl",
+    "id": "digital-reveal",
+    "name": "Digital Rain Reveal",
+    "url": "shaders/digital-reveal.wgsl",
     "category": "image",
-    "description": "Chaotic color-swapping regions that crawl across the screen with Voronoi-based patterns.",
+    "description": "Hides the image behind digital rain; move the mouse to reveal the content.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Rain Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "size",
+        "name": "Reveal Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fade",
+        "name": "Trail Fade",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Rain Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "artistic"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
     ]
   },
   {
-    "id": "mouse-pixel-sort",
-    "name": "Mouse Pixel Sort",
-    "url": "shaders/mouse-pixel-sort.wgsl",
+    "id": "double-exposure",
+    "name": "Double Exposure Zoom",
     "category": "image",
-    "description": "Luminance-based pixel sorting controlled by mouse proximity.",
+    "url": "shaders/double-exposure.wgsl",
+    "description": "Blends the image with a zoomed and rotated version of itself, pivoted around the mouse cursor. Reacts subtly to audio bass.",
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "audio-reactive"
     ],
+    "params": [
+      {
+        "name": "Zoom Level",
+        "id": "zoom",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Rotation",
+        "id": "rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Opacity",
+        "id": "opacity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Saturation",
+        "id": "saturation",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "zoom",
+      "overlay"
+    ]
+  },
+  {
+    "id": "echo-ripple",
+    "name": "Echo Ripple",
+    "url": "shaders/echo-ripple.wgsl",
+    "category": "image",
+    "description": "Mouse movement creates expanding ripples that echo and persist in time. Audio reactivity drives ripple amplitude and color splitting, while depth-aware parallax separates foreground and background distortion.",
+    "params": [
+      {
+        "id": "freq",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Echo Decay",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strength",
+        "name": "Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "audio-reactive",
+      "depth-aware",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio-reactive",
+      "ripple",
+      "feedback",
+      "interactive"
+    ]
+  },
+  {
+    "id": "edge-glow-mouse",
+    "name": "Edge Glow",
+    "url": "shaders/edge-glow-mouse.wgsl",
+    "category": "image",
+    "description": "Detects edges in the image which glow intensely when near the mouse cursor.",
     "params": [
       {
         "id": "threshold",
-        "name": "Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Edge Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "length",
-        "name": "Sort Length",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "glowRadius",
+        "name": "Glow Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "direction",
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorCycle",
+        "name": "Color Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "elastic-strip",
+    "name": "Elastic Strip",
+    "url": "shaders/elastic-strip.wgsl",
+    "category": "image",
+    "description": "Divides the image into strips that stretch elastically towards the mouse cursor.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Strip Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strength",
+        "name": "Stretch Strength",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "falloff",
+        "name": "Influence Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dir",
         "name": "Direction (V/H)",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "labels": [
+          "Vertical Strips",
+          "Horizontal Strips"
+        ]
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "entropy-grid",
+    "name": "Entropy Grid",
+    "url": "shaders/entropy-grid.wgsl",
+    "category": "image",
+    "description": "Scrambles the image into a chaotic grid. Mouse restores order (or creates chaos) with audio-reactive chaos.",
+    "params": [
+      {
+        "id": "gridSize",
+        "name": "Grid Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos Level",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "invert",
+        "name": "Invert Effect",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "fabric-zipper",
+    "name": "Fabric Zipper",
+    "url": "shaders/fabric-zipper.wgsl",
+    "category": "image",
+    "description": "Unzip the canvas to reveal the underlying image. Drag the mouse vertically to control the zipper.",
+    "params": [
+      {
+        "id": "teeth_density",
+        "name": "Teeth Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of zipper teeth"
+      },
+      {
+        "id": "spread",
+        "name": "Opening Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Width of the zipper opening"
+      },
+      {
+        "id": "weave_freq",
+        "name": "Weave Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Frequency of the fabric weave pattern"
+      },
+      {
+        "id": "jaggedness",
+        "name": "Tooth Jaggedness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Amplitude of tooth jaggedness"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ferrofluid",
+    "name": "Magnetic Ferrofluid",
+    "url": "shaders/ferrofluid.wgsl",
+    "category": "image",
+    "description": "Simulates magnetic ferrofluid spikes attracted to the mouse.",
+    "params": [
+      {
+        "id": "spikeScale",
+        "name": "Spike Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "attraction",
+        "name": "Attraction",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "fiber-optic-weave",
+    "name": "Fiber Optic Weave",
+    "url": "shaders/fiber-optic-weave.wgsl",
+    "category": "image",
+    "description": "Deconstructs image into glowing optical fibers that react to mouse movement.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Fiber Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Fiber Glow",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "force",
+        "name": "Mouse Force",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fray",
+        "name": "Weave Fray",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "flux-core",
+    "name": "Flux Core",
+    "category": "image",
+    "url": "shaders/flux-core.wgsl",
+    "description": "Energy arcs emit from the cursor, connecting to bright areas in the image.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "foil-impression",
+    "name": "Foil Impression",
+    "url": "shaders/foil-impression.wgsl",
+    "category": "image",
+    "description": "Simulates a metallic foil surface. Pressing with the mouse flattens the foil to reveal the image relief and color.",
+    "params": [
+      {
+        "id": "pressure_radius",
+        "name": "Pressure Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "foil_roughness",
+        "name": "Foil Crinkle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "relief_strength",
+        "name": "Image Emboss",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color_reveal",
+        "name": "Color Mix",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "glass-bead-curtain",
+    "name": "Glass Bead Curtain",
+    "url": "shaders/glass-bead-curtain.wgsl",
+    "category": "image",
+    "description": "A curtain of refractive glass beads that parts for the cursor.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Bead Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Size of glass beads"
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Refraction strength"
+      },
+      {
+        "id": "tension",
+        "name": "Interact Tension",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Curtain tension on interaction"
+      },
+      {
+        "id": "glass_density",
+        "name": "Glass Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Beer-Lambert density factor"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "glass-shatter",
+    "name": "Glass Shatter",
+    "url": "shaders/glass-shatter.wgsl",
+    "category": "image",
+    "description": "Interactive shattered glass effect where shards are pushed by the mouse.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Shard Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "displacement",
+        "name": "Displacement",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge",
+        "name": "Edge",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "glass-wall",
+    "url": "shaders/glass-wall.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Glass Wall",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "glitch-cathedral",
+    "name": "Glitch Cathedral",
+    "url": "shaders/glitch-cathedral.wgsl",
+    "category": "image",
+    "description": "Stained-glass geometric patterns with glitch artifacts; mouse triggers channel separation and pixel sorting.",
+    "params": [
+      {
+        "id": "cellSize",
+        "name": "Cell Size",
+        "default": 20,
+        "min": 2,
+        "max": 200
+      },
+      {
+        "id": "rgbSplit",
+        "name": "RGB Split",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.2
+      },
+      {
+        "id": "sortStrength",
+        "name": "Sort Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "patternSpeed",
+        "name": "Pattern Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 4
+      }
+    ],
+    "features": [
+      "interactive",
+      "glitch",
+      "geometric",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "gravity-lens",
+    "name": "Gravity Lens",
+    "category": "image",
+    "url": "shaders/gravity-lens.wgsl",
+    "params": [
+      {
+        "id": "mass",
+        "name": "Mass",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "horizon",
+        "name": "Horizon",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "accretion",
+        "name": "Accretion",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "hex-pulse",
+    "name": "Hex Pulse",
+    "url": "shaders/hex-pulse.wgsl",
+    "category": "image",
+    "description": "Hexagonal pixelation that pulses in size based on proximity to the mouse cursor.",
+    "params": [
+      {
+        "id": "baseSize",
+        "name": "Base Size",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulseStrength",
+        "name": "Pulse Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "holographic-edge-ripple",
+    "name": "Holographic Edge Ripple",
+    "url": "shaders/holographic-edge-ripple.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "description": "Edges ripple and split into RGB components based on mouse proximity.",
+    "params": [
+      {
+        "name": "Wave Speed",
+        "id": "wave-speed",
+        "default": 2,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "Frequency",
+        "id": "frequency",
+        "default": 20,
+        "min": 1,
+        "max": 100
+      },
+      {
+        "name": "Aberration",
+        "id": "aberration",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.1
+      },
+      {
+        "name": "Edge Threshold",
+        "id": "edge-threshold",
+        "default": 0.2,
+        "min": 0.01,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music"
+    ]
+  },
+  {
+    "id": "holographic-prism",
+    "name": "Holographic Prism",
+    "url": "shaders/holographic-prism.wgsl",
+    "category": "image",
+    "description": "Splits the image into spectral shards that rotate and shift, creating a holographic lens effect.",
+    "params": [
+      {
+        "id": "facets",
+        "name": "Facet Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dispersion",
+        "name": "Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Holo Glitch",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music"
+    ]
+  },
+  {
+    "id": "hyper-chromatic-delay",
+    "name": "Hyper-Chromatic Delay",
+    "url": "shaders/hyper-chromatic-delay.wgsl",
+    "category": "image",
+    "description": "Spectral Multi-Tap Echo with wavelength-dependent refraction, per-channel lens distortion, motion-aware temporal blur, and audio-reverb-inspired feedback echoes.",
+    "params": [
+      {
+        "id": "sepStrength",
+        "name": "RGB Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Shift Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mouseInf",
+        "name": "Mouse Influence",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "chromatic-aberration",
+      "spectral-dispersion",
+      "multi-tap-temporal",
+      "lens-distortion",
+      "motion-trails",
+      "audio-reverb"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "spectral",
+      "echo",
+      "reverb",
+      "distortion",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "hypnotic-spiral",
+    "name": "Hypnotic Spiral",
+    "url": "shaders/hypnotic-spiral.wgsl",
+    "category": "image",
+    "description": "Breathing, rotating spirals with color cycling; mouse warps and twists the spiral geometry.",
+    "params": [
+      {
+        "id": "arms",
+        "name": "Arms",
+        "default": 3,
+        "min": 1,
+        "max": 12
+      },
+      {
+        "id": "rotationSpeed",
+        "name": "Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "colorCycle",
+        "name": "Color Cycle",
+        "default": 0.2,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "warpIntensity",
+        "name": "Warp",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      }
+    ],
+    "features": [
+      "interactive",
+      "spiral",
+      "visual",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "impasto-swirl",
+    "name": "Impasto Swirl",
+    "url": "shaders/impasto-swirl.wgsl",
+    "category": "image",
+    "description": "Simulates wet oil paint mixing. Mouse acts as a smudge tool that stirs the image.",
+    "params": [
+      {
+        "id": "brush",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smudge",
+        "name": "Smudge Strength",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dry",
+        "name": "Paint Dry Speed",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noise",
+        "name": "Canvas Texture",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "infinite-fractal-feedback",
+    "name": "Infinite Fractal Feedback",
+    "url": "shaders/infinite-fractal-feedback.wgsl",
+    "category": "image",
+    "description": "Perpetual zoom tunnel with rotating mandala patterns. Mouse controls the zoom focal point and rotation speed.",
+    "params": [
+      {
+        "id": "zoomRate",
+        "name": "Zoom Rate",
+        "default": 0.8,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "spiralTightness",
+        "name": "Spiral Tightness",
+        "default": 0.6,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0.2,
+        "min": -1,
+        "max": 1
+      },
+      {
+        "id": "feedbackStrength",
+        "name": "Feedback",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "interactive",
+      "fractal",
+      "feedback",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "infinite-spiral-zoom",
+    "name": "Infinite Spiral Zoom",
+    "url": "shaders/infinite-spiral-zoom.wgsl",
+    "category": "image",
+    "description": "Applies a complex log-polar mapping to create an infinite spiral zoom into the mouse cursor.",
+    "params": [
+      {
+        "id": "zoom_speed",
+        "name": "Zoom Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spiral_angle",
+        "name": "Spiral Twist",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "branches",
+        "name": "Branches",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "center_offset",
+        "name": "Center Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "infinite-video-feedback",
+    "name": "Infinite Video Feedback",
+    "url": "shaders/infinite-video-feedback.wgsl",
+    "category": "image",
+    "description": "Create a feedback loop with the previous frame, applying zoom and rotation centered on the mouse.",
+    "params": [
+      {
+        "id": "feedback",
+        "name": "Feedback Decay",
+        "default": 0.9,
+        "min": 0,
+        "max": 0.99
+      },
+      {
+        "id": "zoom",
+        "name": "Zoom Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ink-bleed",
+    "name": "Ink Bleed",
+    "url": "shaders/ink-bleed.wgsl",
+    "category": "image",
+    "description": "Click to drop spreading ink that permanently stains the video feed.",
+    "params": [
+      {
+        "id": "inkHue",
+        "name": "Ink Hue",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spreadSpeed",
+        "name": "Spread Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fadeSpeed",
+        "name": "Fade Speed",
+        "default": 0.05,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Ink Density",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-emboss",
+    "name": "Interactive Emboss",
+    "url": "shaders/interactive-emboss.wgsl",
+    "category": "image",
+    "description": "Emboss effect where the light source follows the mouse cursor.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mix",
+        "name": "Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorMode",
+        "name": "Color Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "labels": [
+          "Gray",
+          "Color"
+        ]
+      },
+      {
+        "id": "emboss_depth",
+        "name": "Emboss Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Depth of emboss effect"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-film-burn",
+    "name": "Film Burn",
+    "url": "shaders/interactive-film-burn.wgsl",
+    "category": "image",
+    "description": "Simulates burning film reel with organic edges and grain, centered on the cursor.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Burn Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Burn Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "grain",
+        "name": "Grain Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Edge Glow",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "noise",
+      "texture"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-fisheye",
+    "name": "Interactive Fisheye",
+    "url": "shaders/interactive-fisheye.wgsl",
+    "category": "image",
+    "description": "Barrel distortion lens that magnifies the area under the mouse with audio-reactive radius and depth-aware alpha modulation.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "curve",
+        "name": "Bulge Curve",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "vignette",
+        "name": "Edge Vignette",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "geometry",
+      "audio-reactive",
+      "audio-driven",
+      "depth-aware"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "interactive-frost",
+    "name": "Interactive Frost",
+    "url": "shaders/frost-reveal.wgsl",
+    "category": "image",
+    "description": "Realistic frost grows over the image; use your mouse (warmth) to melt it away.",
+    "params": [
+      {
+        "id": "growth",
+        "name": "Growth Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Melt Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "opacity",
+        "name": "Frost Opacity",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-glitch-cubes",
+    "name": "Interactive Glitch Cubes",
+    "url": "shaders/interactive-glitch-cubes.wgsl",
+    "category": "image",
+    "description": "Image is mapped onto a grid of extruded cubes that react to mouse height.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Cube Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "extrusion",
+        "name": "Extrusion Height",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gap",
+        "name": "Grid Gap",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shadow",
+        "name": "Shadow Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "pseudo-3d"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-glitch",
+    "name": "Interactive Glitch",
+    "url": "shaders/interactive-glitch.wgsl",
+    "category": "image",
+    "description": "Digital glitch artifacts that intensify around the mouse cursor.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Base Intensity",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Influence Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Glitch Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blockScale",
+        "name": "Block Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-halftone-spin",
+    "name": "Interactive Halftone Spin",
+    "url": "shaders/interactive-halftone-spin.wgsl",
+    "category": "image",
+    "description": "CMYK halftone pattern where the grid rotation is driven by mouse proximity.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Dot Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "separation",
+        "name": "CMYK Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "halftone"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-kuwahara",
+    "name": "Oil Painting (Kuwahara)",
+    "url": "shaders/interactive-kuwahara.wgsl",
+    "category": "image",
+    "description": "Applies an oil painting effect using a Kuwahara filter. Mouse distance controls the detail level (focus area).",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "satBoost",
+        "name": "Saturation",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mouseFalloff",
+        "name": "Focus Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hardness",
+        "name": "Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "artistic"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-pixel-wind",
+    "name": "Pixel Wind",
+    "url": "shaders/interactive-pixel-wind.wgsl",
+    "category": "image",
+    "description": "Wind effect driven by cursor direction.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Wind Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "trails",
+        "name": "Trail Length",
+        "default": 0.7,
+        "min": 0,
+        "max": 0.99
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "feedback"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-ripple",
+    "name": "Interactive Ripple",
+    "url": "shaders/interactive-ripple.wgsl",
+    "category": "image",
+    "description": "Classic water ripple effect following cursor.",
+    "params": [
+      {
+        "id": "amplitude",
+        "name": "Wave Height",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "frequency",
+        "name": "Wave Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "wave"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-voronoi-lens",
+    "name": "Interactive Voronoi Lens",
+    "url": "shaders/interactive-voronoi-lens.wgsl",
+    "category": "image",
+    "description": "Breaks the image into Voronoi cells that act as lenses. Mouse proximity intensifies the effect.",
+    "params": [
+      {
+        "id": "cell_density",
+        "name": "Cell Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of Voronoi cells"
+      },
+      {
+        "id": "lens_strength",
+        "name": "Lens Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of the lens distortion"
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Randomness of cell point movement"
+      },
+      {
+        "id": "lens_curve",
+        "name": "Lens Curve",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Curvature of the lens bulge effect"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "interactive-voronoi-web",
+    "name": "Voronoi Web",
+    "url": "shaders/interactive-voronoi-web.wgsl",
+    "category": "image",
+    "description": "Dynamic voronoi web connected to the cursor.",
+    "params": [
+      {
+        "id": "thickness",
+        "name": "Web Thickness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Cell Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Glow Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulse",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "voronoi"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "knitted-fabric",
+    "name": "Knitted Fabric",
+    "url": "shaders/knitted-fabric.wgsl",
+    "category": "image",
+    "description": "Simulates a knitted wool texture. Mouse interaction pulls and stretches the fabric.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Stitch Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Pull Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Pull Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shadow",
+        "name": "Texture Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "light-leaks",
+    "name": "Light Leaks",
+    "url": "shaders/light-leaks.wgsl",
+    "category": "image",
+    "description": "Simulates film light leaks. Move the mouse to change the light source angle.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "warmth",
+        "name": "Warmth",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "size",
+        "name": "Leak Size",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Drift Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "overlay"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "lighthouse-reveal",
+    "name": "Lighthouse Reveal",
+    "url": "shaders/lighthouse-reveal.wgsl",
+    "category": "image",
+    "description": "A rotating beam of light that reveals the image, emanating from the mouse position.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "radius",
+        "name": "Beam Length",
+        "default": 0.8,
+        "min": 0,
+        "max": 1.5
+      },
+      {
+        "id": "width",
+        "name": "Beam Width",
+        "default": 0.2,
+        "min": 0.05,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "ambient",
+        "name": "Ambient Light",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "liquid-lens",
+    "name": "Liquid Lens",
+    "url": "shaders/liquid-lens.wgsl",
+    "category": "image",
+    "description": "Simulates a magnifying liquid lens at the mouse position with chromatic aberration.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "abberation",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge",
+        "name": "Edge Shade",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "liquid-volumetric-zoom",
+    "name": "Liquid Volumetric Zoom",
+    "url": "shaders/liquid-volumetric-zoom.wgsl",
+    "category": "image",
+    "description": "Unified 3D fluid zoom that merges parallax, vortex dynamics, plasma flow and chromatic aberration into a single volumetric zoom.",
+    "params": [
+      {
+        "id": "fg_speed",
+        "name": "Foreground Speed",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "bg_speed",
+        "name": "Background Speed",
+        "default": 0.8,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "parallax",
+        "name": "Parallax",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "fog_density",
+        "name": "Fog Density",
+        "default": 0.6,
+        "min": 0,
+        "max": 4
+      }
+    ],
+    "features": [
+      "volumetric",
+      "raymarched",
+      "depth",
+      "fluid",
+      "single-pass-multilayer",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "luma-force",
+    "name": "Luma Force",
+    "url": "shaders/luma-force.wgsl",
+    "category": "image",
+    "description": "Repels or attracts pixels based on mouse position and luminance weight.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
         "id": "mode",
-        "name": "Invert Sort",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Mode (Repel/Attract)",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 1
+      },
+      {
+        "id": "lumaWeight",
+        "name": "Luma Weight",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "luma-topography",
+    "name": "Luma Topography",
+    "url": "shaders/luma-topography.wgsl",
+    "category": "image",
+    "description": "Visualizes the image as a 3D terrain map where brightness determines height. The mouse controls a dynamic light source.",
+    "params": [
+      {
+        "id": "height",
+        "name": "Relief Height",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Light Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shininess",
+        "name": "Shininess",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ambient",
+        "name": "Ambient Light",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "lighting"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "magma-fissure",
+    "name": "Magma Fissure",
+    "url": "shaders/magma-fissure.wgsl",
+    "category": "image",
+    "description": "Burn glowing fissures into the image with the mouse.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Cooling Rate",
+        "default": 0.96,
+        "min": 0.9,
+        "max": 0.999
+      },
+      {
+        "id": "width",
+        "name": "Fissure Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Heat Haze",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "magnetic-interference",
+    "name": "Magnetic Interference",
+    "url": "shaders/magnetic-interference.wgsl",
+    "category": "image",
+    "description": "Simulates magnetic distortion on a CRT screen, pulling pixels and separating colors.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Strength",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanlines",
+        "name": "Scanlines",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "magnetic-luma-sort",
+    "name": "Magnetic Luma Sort",
+    "url": "shaders/magnetic-luma-sort.wgsl",
+    "category": "image",
+    "description": "Pixels are magnetically pulled by the cursor based on brightness, creating trails.",
+    "params": [
+      {
+        "id": "pullStrength",
+        "name": "Pull Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Luma Threshold",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "trailDecay",
+        "name": "Trail Decay",
+        "default": 0.9,
+        "min": 0.5,
+        "max": 0.99
+      },
+      {
+        "id": "mode",
+        "name": "Attract/Repel",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "magnetic-pixels",
+    "name": "Magnetic Pixels",
+    "url": "shaders/magnetic-pixels.wgsl",
+    "category": "image",
+    "description": "Pixels are magnetically repelled by the cursor, creating a void.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Force Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hardness",
+        "name": "Edge Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "magnetic-rgb",
+    "name": "Magnetic RGB",
+    "category": "image",
+    "url": "shaders/magnetic-rgb.wgsl",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "swirl",
+        "name": "Swirl",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "magnetic-ring",
+    "category": "image",
+    "url": "shaders/magnetic-ring.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "base_radius",
+        "name": "Base Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Base radius of the magnetic ring"
+      },
+      {
+        "id": "strength",
+        "name": "Distortion Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of the distortion effect"
+      },
+      {
+        "id": "pulse_speed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Speed of the ring pulse animation"
+      },
+      {
+        "id": "ring_thickness",
+        "name": "Ring Thickness",
+        "default": 0.3,
+        "min": 0.01,
+        "max": 0.3,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Thickness of the magnetic ring"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "name": "Magnetic Ring"
+  },
+  {
+    "id": "matrix-curtain",
+    "name": "Matrix Curtain",
+    "url": "shaders/matrix-curtain.wgsl",
+    "category": "image",
+    "description": "Digital rain streams that part horizontally based on mouse position.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Rain Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Column Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Curtain Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitchiness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "moire-interference",
+    "label": "Moiré Interference",
+    "name": "Moiré Interference",
+    "url": "shaders/moire-interference.wgsl",
+    "category": "image",
+    "icon": "wifi",
+    "description": "Generates dynamic interference patterns between the center and the mouse position.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "name": "Frequency",
+        "id": "x",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "name": "Distortion",
+        "id": "y",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "name": "Aberration",
+        "id": "z",
+        "min": 0,
+        "max": 1,
+        "default": 0.2
+      },
+      {
+        "name": "Complexity",
+        "id": "w",
+        "min": 0,
+        "max": 1,
+        "default": 0
       }
     ],
     "tags": [
@@ -17773,19 +11150,1461 @@
     ]
   },
   {
-    "id": "astral-kaleidoscope-grokcf1",
-    "name": "Astral Kaleidoscope grokcf1",
-    "url": "shaders/astral-kaleidoscope-grokcf1.wgsl",
+    "id": "molten-glass",
+    "name": "Molten Glass",
+    "url": "shaders/molten-glass.wgsl",
     "category": "image",
-    "description": "An enhanced cosmic kaleidoscope with astral color schemes, featuring dynamic, time-driven evolution and intricate, mouse-driven fractal details.",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Melts the image under the mouse cursor like hot glass.",
+    "params": [
+      {
+        "id": "heat-radius",
+        "name": "Heat Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "cooling-rate",
+        "name": "Cooling Rate",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "motion-heatmap",
+    "name": "Motion Heatmap",
+    "url": "shaders/motion-heatmap.wgsl",
+    "category": "image",
+    "description": "Visualizes video motion and mouse interaction as a heatmap.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Heat Decay",
+        "default": 0.05,
+        "min": 0.001,
+        "max": 0.3
+      },
+      {
+        "id": "sensitivity",
+        "name": "Motion Sens.",
+        "default": 2,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "id": "mouse_heat",
+        "name": "Mouse Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "mouse-gravity",
+    "name": "Interactive Gravity",
+    "url": "shaders/mouse-gravity.wgsl",
+    "category": "image",
+    "description": "Gravitational distortion field that follows the mouse cursor.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Gravity Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Event Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Chrom. Aberration",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "darkness",
+        "name": "Core Darkness",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
     "features": [
       "mouse-driven",
-      "time-driven"
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "nano-repair",
+    "name": "Nano-Tech Repair",
+    "url": "shaders/nano-repair.wgsl",
+    "category": "image",
+    "description": "The image is corrupted by digital rot. Use the mouse to deploy nano-bots that repair the image.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Repair Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "decay",
+        "name": "Decay Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitch Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanlines",
+        "name": "Scanlines",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "feedback"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "neon-contour-drag",
+    "name": "Neon Wake",
+    "url": "shaders/neon-contour-drag.wgsl",
+    "category": "image",
+    "description": "Detects edges and applies a neon glow that is warped by the mouse cursor like a magnetic field.",
+    "params": [
+      {
+        "id": "edgeStrength",
+        "name": "Edge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dragRadius",
+        "name": "Warp Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "image",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music"
+    ]
+  },
+  {
+    "id": "neon-cursor-trace",
+    "name": "Particle Physics Trace",
+    "url": "shaders/neon-cursor-trace.wgsl",
+    "category": "image",
+    "description": "Spring-mass cursor physics with persistent phosphor trails, electric arc jitter, audio-reactive particle spawning, and multi-point neon glow along a velocity-smoothed trajectory.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Trace Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Trace Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spring",
+        "name": "Spring Stiffness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Electric Chaos",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "audio-reactive",
+      "spring-physics",
+      "phosphor-decay",
+      "electric-arc",
+      "multi-point-trail",
+      "particle-spawn",
+      "velocity-smear",
+      "ripple-spark"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive",
+      "neon",
+      "particles",
+      "physics"
+    ]
+  },
+  {
+    "id": "neon-echo",
+    "name": "Neon Echo",
+    "url": "shaders/neon-echo.wgsl",
+    "category": "image",
+    "description": "Creates glowing trails from moving edges in the video, with colors influenced by mouse position.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Edge Sense",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hue",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mix",
+        "name": "Echo Mix",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-flashlight",
+    "name": "Neon Flashlight",
+    "url": "shaders/neon-flashlight.wgsl",
+    "category": "image",
+    "description": "Dark environment illuminated by a neon-edge detecting flashlight.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Beam Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Neon Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Edge Threshold",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ambient",
+        "name": "Ambient Light",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-fluid-warp",
+    "name": "Neon Fluid Warp",
+    "url": "shaders/neon-fluid-warp.wgsl",
+    "category": "image",
+    "description": "Distorts the image like a fluid around the mouse, adding neon edges.",
+    "params": [
+      {
+        "id": "warpStrength",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "liquidity",
+        "name": "Liquidity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-pulse",
+    "name": "Neon Pulse Distortion",
+    "url": "shaders/neon-pulse.wgsl",
+    "category": "image",
+    "description": "Distorts the image with a pulsating neon wave emanating from the cursor.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Neon Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-strings",
+    "name": "Neon Strings",
+    "url": "shaders/neon-strings.wgsl",
+    "category": "image",
+    "description": "Vibrating neon strings generated from edge detection, agitated by the mouse.",
+    "params": [
+      {
+        "id": "thickness",
+        "name": "Edge Threshold",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "vibration",
+        "name": "Vibration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "neon",
+        "name": "Neon Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-warp",
+    "name": "Neon Warp",
+    "url": "shaders/neon-warp.wgsl",
+    "category": "image",
+    "description": "Mouse movement warps the image fabric, revealing neon edges and glowing trails.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "neon",
+        "name": "Neon Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Color Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Warp Decay",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neural-nexus",
+    "name": "Neural Nexus",
+    "url": "shaders/neural-nexus.wgsl",
+    "category": "image",
+    "description": "Biological neural network simulation with pulsing electrical signals; mouse sends shockwaves through synapses.",
+    "params": [
+      {
+        "id": "networkDensity",
+        "name": "Density",
+        "default": 1,
+        "min": 0.1,
+        "max": 4
+      },
+      {
+        "id": "signalSpeed",
+        "name": "Signal Speed",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "decayRate",
+        "name": "Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "branchComplexity",
+        "name": "Branches",
+        "default": 2,
+        "min": 1,
+        "max": 8
+      }
+    ],
+    "features": [
+      "interactive",
+      "organic",
+      "network",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "night-vision-scope",
+    "name": "Night Vision Scope",
+    "url": "shaders/night-vision-scope.wgsl",
+    "category": "image",
+    "description": "Simulates a night vision intensifier tube with a high-clarity scope area following the mouse.",
+    "params": [
+      {
+        "id": "scopeSize",
+        "name": "Scope Size",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1
+      },
+      {
+        "id": "grainAmount",
+        "name": "Noise Grain",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "brightness",
+        "name": "Brightness",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "scanlineStrength",
+        "name": "Scanlines",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "image"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "optical-feedback",
+    "name": "Optical Feedback Loop",
+    "url": "shaders/optical-feedback.wgsl",
+    "category": "image",
+    "description": "Infinite video feedback loop centered on the mouse cursor.",
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Feedback Zoom",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Decay",
+        "default": 0.95,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Hue Shift",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "origami-fold",
+    "name": "Origami Fold",
+    "url": "shaders/origami-fold.wgsl",
+    "category": "image",
+    "description": "Simulates a paper fold effect where the image is creased and folded based on the mouse position.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Fold Radius",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "shadowStrength",
+        "name": "Shadow Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Fold Angle",
+        "default": 0,
+        "min": 0,
+        "max": 6.28
+      },
+      {
+        "id": "transparency",
+        "name": "Transparency",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "oscilloscope-overlay",
+    "name": "Oscilloscope Overlay",
+    "url": "shaders/oscilloscope-overlay.wgsl",
+    "category": "image",
+    "description": "Overlays a real-time luminance waveform of the image scanline at the mouse cursor's vertical position.",
+    "params": [
+      {
+        "id": "amplitude",
+        "name": "Amplitude",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "thickness",
+        "name": "Line Thickness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "opacity",
+        "name": "Wave Opacity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scan_alpha",
+        "name": "Scanline Alpha",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "overlay"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "paper-cutout",
+    "name": "Paper Cutout",
+    "url": "shaders/paper-cutout.wgsl",
+    "category": "image",
+    "description": "Quantizes the image into paper layers with drop shadows controlled by the mouse.",
+    "params": [
+      {
+        "id": "layers",
+        "name": "Layers",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shadowDist",
+        "name": "Shadow Dist",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Softness",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "separation",
+        "name": "Separation",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "parallax-glow-compositor",
+    "name": "Parallax Glow Compositor (Pass 2)",
+    "url": "shaders/parallax-glow-compositor.wgsl",
+    "category": "image",
+    "description": "Compositor that applies chromatic aberration, volumetric glow, and depth-aware compositing for volumetric zooms.",
+    "params": [
+      {
+        "id": "glowRadius",
+        "name": "Glow Radius",
+        "default": 1,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.2
+      },
+      {
+        "id": "bloomThreshold",
+        "name": "Bloom Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "volumetric",
+      "depth",
+      "composite"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "particle-disperse",
+    "name": "Particle Disperse",
+    "url": "shaders/particle-disperse.wgsl",
+    "category": "image",
+    "description": "Mouse blows particles away with wind physics. Particles return to original position with spring forces.",
+    "params": [
+      {
+        "id": "wind_force",
+        "name": "Wind Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "return_speed",
+        "name": "Spring Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Wind Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "physics",
+      "interactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "particle-swarm",
+    "name": "Particle Swarm",
+    "url": "shaders/particle-swarm.wgsl",
+    "category": "image",
+    "description": "Pixels behave like a swarm of particles attracted to the mouse, with spring physics returning them to their origin.",
+    "params": [
+      {
+        "id": "stiffness",
+        "name": "Spring Stiffness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "force",
+        "name": "Mouse Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Interact Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "physics"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "phosphor-magnifier",
+    "label": "Phosphor Magnifier",
+    "name": "Phosphor Magnifier",
+    "url": "shaders/phosphor-magnifier.wgsl",
+    "category": "image",
+    "icon": "search",
+    "description": "Simulates a CRT phosphor mask. Use mouse to magnify the screen pixels.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "name": "Zoom Level",
+        "id": "x",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "name": "Pixel Size",
+        "id": "y",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "name": "Glow",
+        "id": "z",
+        "min": 0,
+        "max": 1,
+        "default": 0.3
+      },
+      {
+        "name": "Lens Size",
+        "id": "w",
+        "min": 0,
+        "max": 1,
+        "default": 0.4
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-drag-smear",
+    "name": "Pixel Drag Smear",
+    "url": "shaders/pixel-drag-smear.wgsl",
+    "category": "image",
+    "description": "Smudge and drag pixels like wet paint, creating persistent trails.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Brush Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strength",
+        "name": "Drag Strength",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Decay Rate",
+        "default": 0.95,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-reveal",
+    "name": "Pixel Reveal",
+    "url": "shaders/pixel-reveal.wgsl",
+    "category": "image",
+    "description": "Pixelates the image, with a clear window (or obscuring block) around the mouse.",
+    "params": [
+      {
+        "id": "pixelSize",
+        "name": "Pixel Size",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "invert",
+        "name": "Invert Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-sort-explorer",
+    "name": "Pixel Sort Explorer",
+    "url": "shaders/pixel-sort-explorer.wgsl",
+    "category": "image",
+    "description": "Locally sorts pixels within a mouse-controlled spotlight radius.",
+    "params": [
+      {
+        "id": "thresh",
+        "name": "Sort Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Spot Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dir",
+        "name": "Direction (V/H)",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smooth",
+        "name": "Smoothness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-sort-radial",
+    "name": "Radial Pixel Stretch",
+    "url": "shaders/pixel-sort-radial.wgsl",
+    "category": "image",
+    "description": "Radially stretches pixels from the mouse position based on luminance.",
+    "params": [
+      {
+        "id": "stretch",
+        "name": "Stretch Amt",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "thresh",
+        "name": "Luma Thresh",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dir",
+        "name": "Direction",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-wind-chimes",
+    "name": "Pixel Wind Chimes",
+    "url": "shaders/pixel-wind-chimes.wgsl",
+    "category": "image",
+    "description": "Slices the image into hanging vertical strips that swing like wind chimes when pushed by the mouse.",
+    "params": [
+      {
+        "name": "Strip Count",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "strip_count"
+      },
+      {
+        "name": "Sway Amount",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "sway_amount"
+      },
+      {
+        "name": "Wind Speed",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "wind_speed"
+      },
+      {
+        "name": "Gap Size",
+        "type": "float",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "id": "gap_size"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "poly-art",
+    "name": "Poly Art",
+    "url": "shaders/poly-art.wgsl",
+    "category": "image",
+    "description": "Transforms the image into a low-poly Voronoi mosaic. Mouse interaction distorts the grid density.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Cell Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edges",
+        "name": "Edge Width",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "randomness",
+        "name": "Randomness",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "influence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "prismatic-3d-compositor",
+    "name": "Prismatic 3D Compositor (Pass 2)",
+    "url": "shaders/prismatic-3d-compositor.wgsl",
+    "category": "image",
+    "description": "Adds parallax shifting, volumetric glow, chromatic aberration and final composite with depth-aware blending.",
+    "params": [
+      {
+        "id": "glowRadius",
+        "name": "Glow Radius",
+        "default": 1,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "parallaxAmount",
+        "name": "Parallax",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.2
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "volumetric",
+      "depth",
+      "lighting",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "prismatic-feedback-loop",
+    "name": "Prismatic Feedback Loop (Pass 2)",
+    "url": "shaders/prismatic-feedback-loop.wgsl",
+    "category": "image",
+    "description": "Consumes displacement from Pass 1 to create chromatic aberration, temporal feedback, and glowing halos.",
+    "params": [
+      {
+        "id": "feedbackAmount",
+        "name": "Feedback",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blurRadius",
+        "name": "Blur Radius",
+        "default": 1,
+        "min": 0,
+        "max": 10
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "chromaticSpread",
+        "name": "Chromatic Spread",
+        "default": 0.02,
+        "min": 0,
+        "max": 0.2
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "feedback",
+      "chromatic",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "quantized-ripples",
+    "name": "Quantized Ripples",
+    "url": "shaders/quantized-ripples.wgsl",
+    "category": "image",
+    "description": "Quantizes the image (posterization) with levels that ripple out from the mouse position.",
+    "params": [
+      {
+        "id": "frequency",
+        "name": "Ripple Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amplitude",
+        "name": "Ripple Amplitude",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Ripple Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "depth",
+        "name": "Color Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "quantum-prism",
+    "url": "shaders/quantum-prism.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
     ],
+    "name": "Quantum Prism",
     "params": [
       {
         "id": "param1",
@@ -17822,11 +12641,635 @@
     ]
   },
   {
-    "id": "neural-dreamscape",
-    "name": "Neural Dreamscape",
-    "url": "shaders/neural-dreamscape.wgsl",
+    "id": "quantum-ripples",
+    "name": "Quantum Ripples",
+    "url": "shaders/quantum-ripples.wgsl",
     "category": "image",
-    "description": "Neural network-inspired dreamlike visuals.",
+    "description": "Mouse-driven quantum interference waves with FBM turbulence, multi-source superposition, and audio reactivity.",
+    "params": [
+      {
+        "id": "waveFreq",
+        "name": "Wave Freq",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "waveSpeed",
+        "name": "Propagate Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortionStr",
+        "name": "Distortion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "interactive",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "waves",
+      "interference",
+      "turbulence"
+    ]
+  },
+  {
+    "id": "quantum-superposition",
+    "name": "Quantum Superposition",
+    "url": "shaders/quantum-superposition.wgsl",
+    "category": "image",
+    "description": "Image vibrates between states, stabilizing when observed (mouse hover).",
+    "params": [
+      {
+        "id": "chaos_speed",
+        "name": "Oscillation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos_amount",
+        "name": "Chaos Probability",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "stability_radius",
+        "name": "Observation Radius",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rgb_split",
+        "name": "RGB Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "radial-hex-lens",
+    "name": "Radial Hex Lens",
+    "url": "shaders/radial-hex-lens.wgsl",
+    "category": "image",
+    "description": "A hexagonal mosaic that distorts and magnifies around the mouse position.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "scale",
+        "name": "Hex Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Size of hexagonal pixels"
+      },
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Radius of the lens effect"
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Amount of magnification distortion"
+      },
+      {
+        "id": "edge_hardness",
+        "name": "Hex Edge Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Hardness of hexagon cell edges"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "radial-slit-scan",
+    "name": "Radial Slit Scan",
+    "url": "shaders/radial-slit-scan.wgsl",
+    "category": "image",
+    "description": "A time-displacement effect that radiates from the cursor.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Scan Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Scan Width",
+        "default": 0.2,
+        "min": 0.01,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Fade to Now",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "feedback"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rain-lens-wipe",
+    "name": "Rain Lens Wipe",
+    "url": "shaders/rain-lens-wipe.wgsl",
+    "category": "image",
+    "description": "Simulates raindrops on a lens. Use the mouse to wipe them away.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Rain Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Re-fog Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Wipe Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Rain Density",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rainbow-vector-field",
+    "name": "Rainbow Vector Field (Pass 1)",
+    "url": "shaders/rainbow-vector-field.wgsl",
+    "category": "image",
+    "description": "Generates a base rainbow pattern and computes a displacement field (stored to depth) for a follow-up prismatic feedback pass.",
+    "params": [
+      {
+        "id": "frequency",
+        "name": "Frequency",
+        "default": 4,
+        "min": 0.1,
+        "max": 12
+      },
+      {
+        "id": "saturation",
+        "name": "Saturation",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "brightness",
+        "name": "Brightness",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "displacementScale",
+        "name": "Displacement Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "mouse-driven",
+      "color"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "raindrop-ripples",
+    "name": "Raindrop Ripples",
+    "url": "shaders/raindrop-ripples.wgsl",
+    "category": "image",
+    "description": "Raindrops fall creating ripples, but the mouse cursor acts as a shield.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Rain Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shield",
+        "name": "Shield Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "reactive-glass-grid",
+    "name": "Reactive Glass Grid",
+    "url": "shaders/reactive-glass-grid.wgsl",
+    "category": "image",
+    "description": "A grid of refractive glass tiles that light up and distort based on mouse proximity.",
+    "params": [
+      {
+        "id": "tile_size",
+        "name": "Tile Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge_smooth",
+        "name": "Edge Smoothness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "refraction-shards",
+    "name": "Refraction Shards",
+    "url": "shaders/refraction-shards.wgsl",
+    "category": "image",
+    "description": "Splits the image into glass-like shards that refract light based on mouse position.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Shard Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "roughness",
+        "name": "Roughness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chromatic",
+        "name": "Prism Effect",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "refractive-bubbles",
+    "name": "Refractive Bubbles",
+    "url": "shaders/refractive-bubbles.wgsl",
+    "category": "image",
+    "description": "Floating bubbles around the cursor that distort the background like glass.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Bubble Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refraction",
+        "name": "Refraction Index",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "count",
+        "name": "Bubble Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "wobble",
+        "name": "Wobble Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rgb-delay-brush",
+    "name": "RGB Delay Brush",
+    "url": "shaders/rgb-delay-brush.wgsl",
+    "category": "image",
+    "description": "Reveals past frames in RGB channels. Painting with the mouse creates colorful time-delayed trails.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Persistence",
+        "default": 0.9,
+        "min": 0.5,
+        "max": 0.99,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "How long trails persist over time"
+      },
+      {
+        "id": "split",
+        "name": "Time Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Amount of RGB channel time separation"
+      },
+      {
+        "id": "radius",
+        "name": "Brush Size",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Size of the brush around the mouse"
+      },
+      {
+        "id": "alpha_scale",
+        "name": "Alpha Absorption Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Scale of wavelength-dependent alpha absorption"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rgb-fluid",
+    "name": "RGB Fluidity",
+    "url": "shaders/rgb-fluid.wgsl",
+    "category": "image",
+    "description": "Image behaves like a fluid, stirred by the mouse cursor.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "force",
+        "name": "Mouse Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rgb-iso-lines",
+    "name": "RGB Iso Lines",
+    "url": "shaders/rgb-iso-lines.wgsl",
+    "category": "image",
+    "description": "Visualizes the R, G, and B channels as separated contour maps. Mouse controls the parallax separation.",
+    "params": [
+      {
+        "id": "thickness",
+        "name": "Line Thickness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Thickness of contour lines"
+      },
+      {
+        "id": "frequency",
+        "name": "Contour Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Density of contour lines"
+      },
+      {
+        "id": "parallax",
+        "name": "Parallax Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Amount of RGB channel parallax separation"
+      },
+      {
+        "id": "bg_opacity",
+        "name": "Background Opacity",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.5,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Opacity of the original image behind contours"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rgb-ripple-waves",
+    "name": "RGB Ripple Waves",
+    "url": "shaders/rgb-ripple-waves.wgsl",
+    "category": "image",
+    "description": "Separates RGB channels into distinct ripple waves emanating from the mouse cursor.",
     "features": [
       "mouse-driven"
     ],
@@ -17870,108 +13313,1530 @@
     ]
   },
   {
-    "id": "astral-kaleidoscope-gemini",
-    "name": "Astral Kaleidoscope Gemini",
-    "url": "shaders/astral-kaleidoscope-gemini.wgsl",
+    "id": "rgb-shift-brush",
+    "name": "RGB Shift Brush",
+    "url": "shaders/rgb-shift-brush.wgsl",
     "category": "image",
-    "description": "An enhanced cosmic kaleidoscope with astral color schemes, featuring dynamic, time-driven evolution and intricate, mouse-driven fractal details.",
+    "description": "Paint with RGB channel separation trails using the mouse.",
+    "params": [
+      {
+        "id": "shift",
+        "name": "Shift Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "size",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hue",
+        "name": "Hue Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
     "features": [
       "mouse-driven",
-      "time-driven"
+      "temporal-persistence"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
     ]
   },
   {
-    "id": "quantum-foam",
-    "name": "Quantum Foam",
-    "url": "shaders/quantum-foam.wgsl",
+    "id": "rgb-split-glitch",
+    "name": "RGB Split Glitch",
+    "url": "shaders/rgb-split-glitch.wgsl",
     "category": "image",
-    "description": "Quantum foam texture with spacetime fluctuations.",
+    "description": "Splits RGB channels based on mouse proximity.",
+    "params": [
+      {
+        "id": "split",
+        "name": "Split Dist",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Angle Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noise",
+        "name": "Jitter Noise",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "chromatic-aberration"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "scanline-sorting",
+    "name": "Scanline Sorting",
+    "url": "shaders/scanline-sorting.wgsl",
+    "category": "image",
+    "description": "Sorts pixels by luminance within a moving scanline band controlled by the mouse. Reacts to audio bass for intensified sorting.",
+    "params": [
+      {
+        "id": "thresh",
+        "name": "Sort Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Scan Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Auto Speed",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dir",
+        "name": "Dir (H/V)",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "labels": [
+          "Horizontal",
+          "Vertical"
+        ]
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "sorting",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "selective-color",
+    "name": "Voronoi Multi-Focal Selective",
+    "url": "shaders/selective-color.wgsl",
+    "category": "image",
+    "description": "Voronoi multi-focal selective desaturation with chromatic aberration, fractal noise masking, polar sectors, SDF shapes, ripple propagation, and depth-aware edge detection.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "desat",
+        "name": "Desat. Strength",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mask_feather",
+        "name": "Mask Feather",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Softness exponent for the mask edge"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "depth-aware",
+      "temporal"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "sequin-flip",
+    "name": "Sequin Flip",
+    "url": "shaders/sequin-flip.wgsl",
+    "category": "image",
+    "description": "Simulates reversible sequins that flip to reveal a metallic back when brushed by the mouse.",
+    "params": [
+      {
+        "id": "grid_size",
+        "name": "Grid Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "flip_radius",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "specular",
+        "name": "Shine",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "back_color",
+        "name": "Gold/Silver",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
     "features": [
       "mouse-driven"
     ],
     "tags": [
       "filter",
       "image-processing"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
     ]
   },
   {
-    "id": "neon-edge-diffusion",
-    "name": "Neon Edge Diffusion",
-    "url": "shaders/neon-edge-diffusion.wgsl",
+    "id": "signal-tuner",
+    "name": "Signal Tuner",
+    "url": "shaders/signal-tuner.wgsl",
     "category": "image",
-    "description": "Sobel edge detection with neon-diffusion and color bleeding.",
+    "description": "Applies TV-style signal interference and wave distortion localized around the mouse.",
+    "params": [
+      {
+        "id": "frequency",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amplitude",
+        "name": "Interference",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Drift Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noise",
+        "name": "Static Noise",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "sketch-reveal",
+    "name": "Sketch Reveal",
+    "url": "shaders/sketch-reveal.wgsl",
+    "category": "image",
+    "description": "Transforms the world into a pencil sketch, allowing you to 'paint' the reality back in with your mouse.",
+    "params": [
+      {
+        "id": "brushSize",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edgeStrength",
+        "name": "Edge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Sketch Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Brush Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "sliding-tile-glitch",
+    "name": "Sliding Tile Glitch",
+    "category": "image",
+    "url": "shaders/sliding-tile-glitch.wgsl",
+    "description": "Grid tiles slide and glitch when touched by the mouse.",
+    "params": [
+      {
+        "id": "gridDensity",
+        "name": "Grid Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "slideSpeed",
+        "name": "Slide Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Restoration",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "slinky-distort",
+    "name": "Slinky Distortion",
+    "url": "shaders/slinky-distort.wgsl",
+    "category": "image",
+    "description": "Slices the image into horizontal bands that shift back and forth like a slinky.",
+    "params": [
+      {
+        "id": "slices",
+        "name": "Slice Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strength",
+        "name": "Sway Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "phase",
+        "name": "Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smooth",
+        "name": "Smoothness",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "solarize-warp",
+    "name": "Solarize Warp",
+    "url": "shaders/solarize-warp.wgsl",
+    "category": "image",
+    "description": "Twists the image around the mouse cursor while applying a solarization effect.",
+    "params": [
+      {
+        "id": "twist",
+        "name": "Twist Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Solarize Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "unused",
+        "name": "Unused",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "sonic-distortion",
+    "name": "Sonic Distortion",
+    "url": "shaders/sonic-distortion.wgsl",
+    "category": "image",
+    "description": "Superellipse-masked sonic distortion with Lissajous wave interference, FBM domain warping, rose curve modulation, and alpha-ghosted echo trails.",
+    "params": [
+      {
+        "id": "freq",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amp",
+        "name": "Amplitude",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion",
+      "superellipse",
+      "lissajous",
+      "fbm",
+      "temporal",
+      "echo-trails"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "spectral-brush",
+    "name": "Spectral Brush",
+    "url": "shaders/spectral-brush.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "temporal"
+    ],
+    "description": "Reveals a spectral dimension where you paint with the mouse. Reacts to audio bass.",
+    "params": [
+      {
+        "id": "brush-size",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spectral-shift",
+        "name": "Spectral Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "persistence",
+        "name": "Persistence",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge-hardness",
+        "name": "Edge Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "spectral-smear",
+    "name": "Spectral Smear",
+    "url": "shaders/spectral-smear.wgsl",
+    "category": "image",
+    "description": "Leaves a colorful spectral trail that follows the mouse.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Brush Radius",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
+      },
+      {
+        "id": "speed",
+        "name": "Color Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "history"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "sphere-projection",
+    "name": "Sphere Projection",
+    "url": "shaders/sphere-projection.wgsl",
+    "category": "image",
+    "description": "Projects the image onto a 3D sphere that can be rotated with the mouse.",
+    "features": [
+      "mouse-driven",
+      "3d"
+    ],
+    "params": [
+      {
+        "id": "zoom",
+        "name": "Sphere Zoom",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Zoom level of the sphere projection"
+      },
+      {
+        "id": "rotation",
+        "name": "Spin Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Auto-rotation speed of the sphere"
+      },
+      {
+        "id": "light",
+        "name": "Lighting",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Amount of directional lighting"
+      },
+      {
+        "id": "ambient",
+        "name": "Ambient Light",
+        "default": 0.3,
+        "min": 0,
+        "max": 0.6,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Ambient light level on the sphere"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "spirograph-reveal",
+    "name": "Spirograph Reveal",
+    "url": "shaders/spirograph-reveal.wgsl",
+    "category": "image",
+    "description": "Reveals the image through a complex, rotating spirograph pattern centered on the mouse.",
+    "params": [
+      {
+        "id": "petals",
+        "name": "Petals",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "complexity",
+        "name": "Complexity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "thickness",
+        "name": "Line Thickness",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "split-dimension",
+    "name": "Split Dimension",
+    "url": "shaders/split-dimension.wgsl",
+    "category": "image",
+    "description": "Splits the screen into two dimensions. One side is normal, the other is a glitched negative. The split follows the mouse.",
+    "features": [
+      "mouse-driven",
+      "glitch"
+    ],
+    "params": [
+      {
+        "id": "glitch",
+        "name": "Glitch Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "negative",
+        "name": "Negative Str",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Split Angle",
+        "default": 0,
+        "min": -1,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "stipple-engraving",
+    "name": "Stipple Engraving",
+    "category": "image",
+    "url": "shaders/stipple-engraving.wgsl",
+    "description": "Converts the image into a vintage stipple engraving. Mouse proximity acts as a spotlight, revealing details by increasing luminance.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "name": "Density",
+        "id": "density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Contrast",
+        "id": "contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Spot Radius",
+        "id": "radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Spot Brightness",
+        "id": "intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "strip-scan-glitch",
+    "name": "Strip Scan Glitch",
+    "url": "shaders/strip-scan-glitch.wgsl",
+    "category": "image",
+    "description": "Slices the image into vertical strips that drift and jitter, controlled by mouse position.",
+    "params": [
+      {
+        "id": "strips",
+        "name": "Strip Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Scroll Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "jitter",
+        "name": "Glitch Jitter",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rgb",
+        "name": "RGB Split",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "swirling-void",
+    "name": "Swirling Void",
+    "url": "shaders/swirling-void.wgsl",
+    "category": "image",
+    "description": "A powerful vortex that twists the image around the mouse cursor, simulating a black hole accretion disk with audio-reactive strength.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Vortex Strength",
+        "default": 0.5,
+        "min": -1,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Event Horizon",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "darkness",
+        "name": "Void Darkness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "audioReact",
+        "name": "Audio Reactivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "temporal-rift",
+    "name": "Temporal Rift",
+    "url": "shaders/temporal-rift.wgsl",
+    "category": "image",
+    "description": "Creates temporal echoes and time-smearing trails where the mouse moves.",
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "width",
+        "name": "Rift Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chroma",
+        "name": "Chroma Split",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mix",
+        "name": "Echo Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "thermal-touch",
+    "name": "Thermal Touch",
+    "url": "shaders/thermal-touch.wgsl",
+    "category": "image",
+    "description": "False-color thermal vision where the mouse acts as a heat source.",
+    "params": [
+      {
+        "id": "heatIntensity",
+        "name": "Heat Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ambientTemp",
+        "name": "Ambient Temp",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorMode",
+        "name": "Color Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "tile-twist",
+    "name": "Tile Twist",
+    "url": "shaders/tile-twist.wgsl",
+    "category": "image",
+    "description": "Grid tiles twist and rotate based on mouse proximity, enhanced with FBM domain warping, hash-jittered organic tiling, and SDF edge masking.",
+    "params": [
+      {
+        "id": "tileSize",
+        "name": "Tile Size",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "twist",
+        "name": "Twist Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Influence Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge_smoothness",
+        "name": "Edge Smoothness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "SDF edge softness for tile boundary alpha mask"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "geometry",
+      "temporal",
+      "upgraded-rgba",
+      "audio-reactive",
+      "depth-aware"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "organic",
+      "abstract"
+    ]
+  },
+  {
+    "id": "vaporwave-horizon",
+    "name": "Vaporwave Horizon",
+    "url": "shaders/vaporwave-horizon.wgsl",
+    "category": "image",
+    "description": "Transforms the image into a retro-futuristic landscape with a mouse-controlled horizon and grid.",
+    "params": [
+      {
+        "id": "gridSpeed",
+        "name": "Grid Speed",
+        "default": 0.5,
+        "min": -2,
+        "max": 2
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow",
+        "default": 0.8,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "gridScale",
+        "name": "Grid Scale",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 2
+      },
+      {
+        "id": "warpAmount",
+        "name": "Curve Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "image"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "velvet-vortex",
+    "name": "Velvet Vortex",
+    "url": "shaders/velvet-vortex.wgsl",
+    "category": "image",
+    "description": "A spiraling, velvety distortion that swirls video content around the mouse cursor.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Vortex Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strength",
+        "name": "Swirl Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulse",
+        "name": "Pulse Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "venetian-blinds",
+    "name": "Venetian Blinds",
+    "url": "shaders/venetian-blinds.wgsl",
+    "category": "image",
+    "description": "Interactive venetian blinds effect. Mouse Y controls the openness of the slats.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Slat Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "openness",
+        "name": "Base Openness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color",
+        "name": "Slat Brightness",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "phase",
+        "name": "Phase Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "vhs-jog",
+    "name": "VHS Jog Wheel",
+    "url": "shaders/vhs-jog.wgsl",
+    "category": "image",
+    "description": "Simulate VHS tracking and jogging. Mouse X controls distortion (jog), Mouse Y controls tracking.",
+    "params": [
+      {
+        "id": "noise",
+        "name": "Static Noise",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distFreq",
+        "name": "Dist. Freq",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bleed",
+        "name": "Color Bleed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanlines",
+        "name": "Scanlines",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "virtual-lens",
+    "name": "Virtual Lens",
+    "url": "shaders/virtual-lens.wgsl",
+    "category": "image",
+    "description": "A virtual magnifying glass with chromatic aberration and audio-reactive pulse.",
+    "params": [
+      {
+        "id": "mag",
+        "name": "Magnification",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Lens Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "volumetric-depth-zoom",
+    "name": "Volumetric Depth Zoom (Pass 1)",
+    "url": "shaders/volumetric-depth-zoom.wgsl",
+    "category": "image",
+    "description": "Raymarched volumetric zoom using multiple depth slices, DOF, parallax and edge specular lighting.",
+    "params": [
+      {
+        "id": "fg_speed",
+        "name": "Foreground Speed",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "bg_speed",
+        "name": "Background Speed",
+        "default": 0.8,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "parallax_str",
+        "name": "Parallax",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "fog_density",
+        "name": "Fog Density",
+        "default": 0.8,
+        "min": 0,
+        "max": 4
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "volumetric",
+      "depth",
+      "mouse-driven",
+      "advanced-alpha"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "alpha",
+      "depth-layered"
+    ]
+  },
+  {
+    "id": "volumetric-rainbow-clouds",
+    "name": "Volumetric Rainbow Clouds (Pass 1)",
+    "url": "shaders/volumetric-rainbow-clouds.wgsl",
+    "category": "image",
+    "description": "Generates 3D noise clouds with normals, lighting, and depth-aware rainbow coloring for a volumetric prismatic effect.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Scale",
+        "default": 1,
+        "min": 0.1,
+        "max": 5
+      },
+      {
+        "id": "flowSpeed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.8,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "lightIntensity",
+        "name": "Light Intensity",
+        "default": 1,
+        "min": 0,
+        "max": 4
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "volumetric",
+      "depth",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "voronoi-glass",
+    "name": "Voronoi Glass",
+    "url": "shaders/voronoi-glass.wgsl",
+    "category": "image",
+    "description": "Refractive glass cells based on Voronoi patterns that shift with the mouse.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Cell Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "refract",
+        "name": "Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "border",
+        "name": "Border Width",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "attract",
+        "name": "Mouse Attract",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "geometry",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "voronoi-light",
+    "name": "Voronoi Light",
+    "url": "shaders/voronoi-light.wgsl",
+    "category": "image",
+    "description": "Voronoi cells light up and react when the mouse is near.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Cell Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Light Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Mode (Tech/Glass)",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "voronoi-shatter",
+    "name": "Voronoi Shatter",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Shard Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "force",
+        "name": "Shatter Force",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Rotation",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "gaps",
+        "name": "Shard Gaps",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "url": "shaders/voronoi-shatter.wgsl",
+    "description": "Breaks the image into crystalline shards that react to mouse movement.",
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "vortex-drag",
+    "name": "Vortex Drag",
+    "url": "shaders/vortex-drag.wgsl",
+    "category": "image",
+    "description": "Twisting vortex distortion that follows the mouse cursor.",
+    "params": [
+      {
+        "id": "twist",
+        "name": "Twist Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Vortex Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pinch",
+        "name": "Pinch/Bulge",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hardness",
+        "name": "Edge Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -17982,88 +14847,54 @@
       "image-processing",
       "audio",
       "music"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
-      },
-      {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
-      }
     ]
   },
   {
-    "id": "halftone-reveal",
-    "name": "Halftone Reveal",
+    "id": "x-ray-reveal",
+    "name": "X-Ray Reveal",
+    "url": "shaders/x-ray-reveal.wgsl",
     "category": "image",
-    "url": "shaders/halftone-reveal.wgsl",
-    "description": "Renders the image as a coarse halftone pattern that resolves into a clear image near the mouse.",
+    "description": "Interactive X-Ray lens that reveals an inverted, edge-enhanced internal structure.",
     "params": [
       {
-        "name": "Dot Size",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "id": "dot_size"
-      },
-      {
-        "name": "Angle",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "angle"
-      },
-      {
-        "name": "Reveal Size",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
+        "id": "lens_size",
+        "name": "Lens Size",
         "default": 0.4,
-        "id": "reveal_size"
-      },
-      {
-        "name": "Magnify",
-        "type": "f32",
         "min": 0,
         "max": 1,
-        "default": 0.3,
-        "id": "magnify"
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Radius of the X-ray lens"
+      },
+      {
+        "id": "edge_strength",
+        "name": "Edge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of edge enhancement"
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Contrast of the X-ray effect"
+      },
+      {
+        "id": "lens_softness",
+        "name": "Lens Edge Softness",
+        "default": 0.075,
+        "min": 0,
+        "max": 0.15,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Softness of the lens edge falloff"
       }
     ],
     "features": [
@@ -18075,11 +14906,295 @@
     ]
   },
   {
-    "id": "rainbow-cloud",
-    "name": "Rainbow Cloud",
-    "url": "shaders/rainbow-cloud.wgsl",
+    "id": "divine-light",
+    "name": "Divine Light",
+    "url": "shaders/divine-light.wgsl",
     "category": "image",
-    "description": "Colorful cloud formations with rainbow gradients.",
+    "description": "Volumetric god rays emanating from cursor position. Creates cinematic light beam effects.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Ray Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Ray Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Ray Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Brightness Filter",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "volumetric",
+      "atmospheric"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "dynamic-lens-flares",
+    "name": "Dynamic Lens Flares",
+    "url": "shaders/dynamic-lens-flares.wgsl",
+    "category": "image",
+    "description": "Cinematic lens flare following cursor. Generates ghost elements and chromatic artifacts.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Flare Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Brightness Filter",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spread",
+        "name": "Ghost Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ghost_count",
+        "name": "Ghost Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "optical",
+      "cinematic"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "lens-flare-brush",
+    "name": "Lens Flare Brush",
+    "url": "shaders/lens-flare-brush.wgsl",
+    "category": "image",
+    "description": "Generates anamorphic lens flares from bright pixels near the mouse.",
+    "params": [
+      {
+        "name": "Threshold",
+        "type": "float",
+        "default": 0.8,
+        "min": 0.5,
+        "max": 1,
+        "id": "threshold"
+      },
+      {
+        "name": "Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "intensity"
+      },
+      {
+        "name": "Stretch",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "stretch"
+      },
+      {
+        "name": "Color Shift",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "id": "color_shift"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "neon-light",
+    "name": "Neon Light",
+    "url": "shaders/neon-light.wgsl",
+    "category": "image",
+    "description": "Neon glow and bloom effect.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Glow Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "saturation",
+        "name": "Color Boost",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bloom",
+        "name": "Bloom Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "glow",
+      "neon",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-pulse-edge",
+    "name": "Neon Pulse Edge",
+    "url": "shaders/neon-pulse-edge.wgsl",
+    "category": "image",
+    "description": "Edge detection with neon glow that reveals near the mouse.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "threshold",
+        "name": "Edge Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "glass-wipes",
+    "name": "Rainy Window",
+    "url": "shaders/glass-wipes.wgsl",
+    "category": "image",
+    "description": "Simulates rain on a window that distorts the view. Use the mouse to wipe the glass clean.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Rain Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "wiper",
+        "name": "Wiper Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dry_speed",
+        "name": "Drying Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ink-marbling",
+    "name": "Ink Marbling",
+    "url": "shaders/ink-marbling.wgsl",
+    "category": "image",
+    "description": "Distorts the image with fluid, ink-like domain warping.",
     "features": [
       "mouse-driven"
     ],
@@ -18120,6 +15235,2891 @@
         "max": 1,
         "step": 0.01
       }
+    ]
+  },
+  {
+    "id": "liquid-fast",
+    "name": "Liquid Fast",
+    "url": "shaders/liquid-fast.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-glitch",
+    "name": "Liquid Glitch",
+    "url": "shaders/liquid-glitch.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-jelly",
+    "name": "Liquid Jelly",
+    "url": "shaders/liquid-jelly.wgsl",
+    "category": "image",
+    "description": "Elastic liquid effect with subsurface scattering and alpha physics",
+    "features": [
+      "upgraded-rgba",
+      "depth-aware",
+      "elastic-bounce",
+      "volume-shading",
+      "subsurface-scattering",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "liquid"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ]
+  },
+  {
+    "id": "liquid-metal",
+    "name": "Liquid Metal",
+    "url": "shaders/liquid-metal.wgsl",
+    "category": "image",
+    "description": "",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-mirror",
+    "name": "Liquid Mirror",
+    "url": "shaders/liquid-mirror.wgsl",
+    "category": "image",
+    "description": "Metallic liquid surface that reflects the image and ripples under the mouse.",
+    "params": [
+      {
+        "id": "distort",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smooth",
+        "name": "Smoothness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "reflect",
+        "name": "Reflectivity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "push",
+        "name": "Push Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "liquid-oil",
+    "name": "Liquid Oil",
+    "url": "shaders/liquid-oil.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-pass1",
+    "name": "Liquid (Pass 1)",
+    "url": "shaders/liquid-pass1.wgsl",
+    "category": "image",
+    "description": "Capillary wave physics pass: surface tension simulation with Laplacian and biharmonic operators, gravity waves, ripple sources, and ambient micro-ripples. Outputs persistent height field to dataTextureA.",
+    "tags": [
+      "liquid",
+      "capillary-waves",
+      "physics",
+      "multi-pass"
+    ],
+    "features": [
+      "multi-pass-1",
+      "mouse-driven"
+    ],
+    "multipass": {
+      "pass": 1,
+      "totalPasses": 2,
+      "nextShader": "liquid-pass2"
+    },
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-pass2",
+    "name": "Liquid (Pass 2)",
+    "url": "shaders/liquid-pass2.wgsl",
+    "category": "image",
+    "description": "Fluid rendering pass: surface normal calculation, Snell's law refraction, Fresnel reflection, Beer-Lambert wavelength-dependent absorption, specular highlights, and physics-based alpha blending.",
+    "tags": [
+      "liquid",
+      "refraction",
+      "fresnel",
+      "beer-lambert",
+      "multi-pass"
+    ],
+    "features": [
+      "multi-pass-2",
+      "mouse-driven"
+    ],
+    "multipass": {
+      "pass": 2,
+      "totalPasses": 2
+    },
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-perspective",
+    "name": "Liquid Perspective",
+    "url": "shaders/liquid-perspective.wgsl",
+    "category": "image",
+    "description": "",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "liquid-rainbow",
+    "name": "Liquid Rainbow",
+    "url": "shaders/liquid-rainbow.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-rgb",
+    "name": "Liquid RGB",
+    "url": "shaders/liquid-rgb.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-smear",
+    "name": "Liquid Smear",
+    "url": "shaders/liquid-smear.wgsl",
+    "category": "image",
+    "description": "Smudge pixels like wet paint with your mouse.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Smear Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "size",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Persistence",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mix",
+        "name": "Mix Strength",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "liquid-v1",
+    "name": "Liquid (Ambient)",
+    "url": "shaders/liquid-v1.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-viscous-grokcf1",
+    "name": "Liquid Viscous Nebula grokcf1",
+    "url": "shaders/liquid-viscous-grokcf1.wgsl",
+    "category": "image",
+    "description": "Enhanced viscous liquid with nebula glow, multi-layer flow, and cosmic viscosity.",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-viscous-simple",
+    "name": "Liquid Viscous (Simple)",
+    "url": "shaders/liquid-viscous-simple.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-viscous",
+    "name": "Liquid Viscous",
+    "url": "shaders/liquid-viscous.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "liquid-zoom",
+    "name": "Liquid Zoom",
+    "url": "shaders/liquid-zoom.wgsl",
+    "category": "image",
+    "description": "",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid",
+    "name": "Liquid (Interactive)",
+    "url": "shaders/liquid.wgsl",
+    "category": "image",
+    "description": "",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "luma-velocity-melt",
+    "name": "Luma Velocity Melt",
+    "url": "shaders/luma-velocity-melt.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Image melts downwards based on brightness. Mouse heat speeds up the melting.",
+    "params": [
+      {
+        "name": "Melt Speed",
+        "id": "melt-speed",
+        "default": 0.005,
+        "min": 0,
+        "max": 0.02
+      },
+      {
+        "name": "Heat Intensity",
+        "id": "heat-intensity",
+        "default": 2,
+        "min": 0,
+        "max": 5
+      },
+      {
+        "name": "Persistence",
+        "id": "persistence",
+        "default": 0.95,
+        "min": 0.5,
+        "max": 0.999
+      },
+      {
+        "name": "Luma Threshold",
+        "id": "luma-threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rain-ripples",
+    "name": "Rain Ripples",
+    "url": "shaders/rain-ripples.wgsl",
+    "category": "image",
+    "description": "Interactive water ripples and raindrops.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "byte-mosh",
+    "name": "Byte-Mosh Glitch",
+    "url": "shaders/byte-mosh.wgsl",
+    "category": "image",
+    "description": "Bitwise XOR, AND, shift, and rotate operations creating digital corruption effects.",
+    "params": [
+      {
+        "id": "operationMix",
+        "name": "Operation Mix",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bitShift",
+        "name": "Bit Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "errorRate",
+        "name": "Error Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blockSize",
+        "name": "Block Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "interactive",
+      "chromatic-aberration",
+      "glitch",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "cyber-terminal-ascii",
+    "name": "Cyber Terminal ASCII",
+    "category": "image",
+    "url": "shaders/cyber-terminal-ascii.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Grid Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of the ASCII character grid"
+      },
+      {
+        "id": "color_mode",
+        "name": "Color Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Blend between monochrome and full color"
+      },
+      {
+        "id": "glow_strength",
+        "name": "Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Glow strength of the ASCII characters"
+      },
+      {
+        "id": "decoder_radius",
+        "name": "Decoder Radius",
+        "default": 0.3,
+        "min": 0.05,
+        "max": 0.4,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Radius of the binary decoder lens around the mouse"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "datamosh-brush",
+    "name": "Datamosh Brush",
+    "url": "shaders/datamosh-brush.wgsl",
+    "category": "image",
+    "description": "Interactive datamosh effect. Mouse drags and corrupts pixels like P-frame compression artifacts.",
+    "params": [
+      {
+        "id": "brush_size",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "block_size",
+        "name": "Block Crush",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Effect Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "stateful"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "digital-decay",
+    "name": "Digital Decay",
+    "url": "shaders/digital-decay.wgsl",
+    "category": "image",
+    "description": "",
+    "params": [
+      {
+        "id": "decayIntensity",
+        "name": "Decay Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blockSize",
+        "name": "Block Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "corruptionSpeed",
+        "name": "Corruption Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "depthFocus",
+        "name": "Depth Focus",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "digital-glitch-pass1",
+    "name": "Digital Glitch (Pass 1)",
+    "url": "shaders/digital-glitch-pass1.wgsl",
+    "category": "image",
+    "description": "Glitch field generation: block displacement, scanline tearing, bitwise corruption seeds, and per-pixel corruption masks. Outputs glitch field to dataTextureA.",
+    "tags": [
+      "glitch",
+      "bitwise",
+      "corruption",
+      "multi-pass",
+      "digital"
+    ],
+    "features": [
+      "multi-pass-1",
+      "mouse-driven"
+    ],
+    "multipass": {
+      "pass": 1,
+      "totalPasses": 2,
+      "nextShader": "digital-glitch-pass2"
+    },
+    "params": [
+      {
+        "id": "corruption_intensity",
+        "name": "Corruption Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "bit_manipulation",
+        "name": "Bit Manipulation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "error_propagation",
+        "name": "Error Propagation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "decay_rate",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "digital-glitch-pass2",
+    "name": "Digital Glitch (Pass 2)",
+    "url": "shaders/digital-glitch-pass2.wgsl",
+    "category": "image",
+    "description": "Error propagation and compositing pass: neighbor error spreading, digital decay with bit-depth reduction, chromatic aberration, scanline artifacts, and block inversion. Reads glitch field from dataTextureC.",
+    "tags": [
+      "glitch",
+      "decay",
+      "chromatic-aberration",
+      "multi-pass"
+    ],
+    "features": [
+      "multi-pass-2",
+      "mouse-driven"
+    ],
+    "multipass": {
+      "pass": 2,
+      "totalPasses": 2
+    },
+    "params": [
+      {
+        "id": "corruption_intensity",
+        "name": "Corruption Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "bit_manipulation",
+        "name": "Bit Manipulation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "error_propagation",
+        "name": "Error Propagation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "decay_rate",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "digital-glitch",
+    "name": "Digital Glitch",
+    "url": "shaders/digital-glitch.wgsl",
+    "category": "image",
+    "description": "",
+    "params": [
+      {
+        "id": "corruption_intensity",
+        "name": "Corruption Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Intensity of digital corruption effects"
+      },
+      {
+        "id": "bit_manipulation",
+        "name": "Bit Manipulation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Type and amount of bitwise corruption"
+      },
+      {
+        "id": "error_propagation",
+        "name": "Error Propagation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Spread of corruption to neighboring pixels"
+      },
+      {
+        "id": "decay_rate",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Rate of digital bit-depth decay"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "digital-waves",
+    "name": "Digital Waves",
+    "url": "shaders/digital-waves.wgsl",
+    "category": "image",
+    "description": "Digital wave interference patterns.",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "holographic-glitch",
+    "name": "Holographic Glitch",
+    "url": "shaders/holographic-glitch.wgsl",
+    "category": "image",
+    "description": "Futuristic holographic projection with RGB chromatic aberration, scanlines, digital artifacts, and unstable flickering. Perfect for sci-fi aesthetics.",
+    "params": [
+      {
+        "id": "glitchIntensity",
+        "name": "Glitch Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanlineSpeed",
+        "name": "Scanline Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rgbShift",
+        "name": "RGB Shift",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "flicker",
+        "name": "Flicker",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "chromatic-aberration",
+      "sci-fi",
+      "audio-reactive",
+      "audio-driven",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "neon-edges",
+    "name": "Neon Edges",
+    "url": "shaders/neon-edges.wgsl",
+    "category": "image",
+    "description": "",
+    "params": [
+      {
+        "id": "min_speed",
+        "name": "Min Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Minimum layer animation speed"
+      },
+      {
+        "id": "max_speed",
+        "name": "Max Speed",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Maximum layer animation speed"
+      },
+      {
+        "id": "edge_threshold",
+        "name": "Edge Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Edge detection threshold"
+      },
+      {
+        "id": "neon_intensity",
+        "name": "Neon Intensity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Intensity of the neon glow effect"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "features": [
+      "audio-reactive",
+      "audio-driven",
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "pixel-rain",
+    "name": "Pixel Rain",
+    "url": "shaders/pixel-rain.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Matrix-style digital rain. Mouse repels and highlights drops.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Rain Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitch / Tint",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "trail_fade",
+        "name": "Trail Fade",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Trail persistence/fade rate"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixelation-drift",
+    "name": "Pixelation Drift",
+    "url": "shaders/pixelation-drift.wgsl",
+    "category": "image",
+    "description": "Dynamic pixelated mosaic with organic drifting motion and depth-aware pixel sizing. Watch as chunky pixels slowly morph and flow across the image.",
+    "params": [
+      {
+        "id": "pixelSize",
+        "name": "Pixel Size",
+        "default": 0.15,
+        "min": 0.01,
+        "max": 1
+      },
+      {
+        "id": "driftSpeed",
+        "name": "Drift Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorBleed",
+        "name": "Color Bleed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "depthInfluence",
+        "name": "Depth Influence",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "organic-motion",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "rgb-glitch-trail",
+    "name": "RGB Glitch Trail",
+    "url": "shaders/rgb-glitch-trail.wgsl",
+    "category": "image",
+    "description": "Mouse leaves chromatic aberration trails. Creates retro TV glitch artifacts with RGB split.",
+    "params": [
+      {
+        "id": "decay_rate",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift_strength",
+        "name": "RGB Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chaos",
+        "name": "Chaos / Noise",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "chromatic",
+      "trail",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "scan-distort",
+    "name": "Scan Distort",
+    "url": "shaders/scan-distort.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "block_size",
+        "name": "Block Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Size of distortion blocks"
+      },
+      {
+        "id": "quant_level",
+        "name": "Quantization Levels",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Color quantization levels"
+      },
+      {
+        "id": "mv_visibility",
+        "name": "MV Visibility",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Motion vector visibility"
+      },
+      {
+        "id": "glitch_freq",
+        "name": "Glitch Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Frequency of glitch pulses"
+      }
+    ]
+  },
+  {
+    "id": "spectrum-bleed",
+    "name": "Spectrum Bleed",
+    "url": "shaders/spectrum-bleed.wgsl",
+    "category": "image",
+    "description": "Color channel separation and bleeding effects.",
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "vhs-tracking",
+    "name": "VHS Tracking Error",
+    "url": "shaders/vhs-tracking.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Simulates VCR tracking errors with scanline tearing and chromatic aberration.",
+    "params": [
+      {
+        "name": "Tracking Error",
+        "id": "zoomParam1",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Noise Level",
+        "id": "zoomParam2",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Color Drift",
+        "id": "zoomParam3",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Scanlines",
+        "id": "zoomParam4",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "vinyl-scratch",
+    "name": "Vinyl Scratch",
+    "url": "shaders/vinyl-scratch.wgsl",
+    "category": "image",
+    "description": "Vintage vinyl record scratch effect.",
+    "params": [
+      {
+        "id": "scratch_density",
+        "name": "Scratch Amount",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dust",
+        "name": "Dust Particles",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "warping",
+        "name": "Record Warp",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sepia",
+        "name": "Vintage Tone",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "retro",
+      "texture",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "digital-moss",
+    "name": "Digital Moss",
+    "category": "image",
+    "url": "shaders/digital-moss.wgsl",
+    "description": "Digital moss grows on dark areas. Use the mouse to clean it.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "flow-sort",
+    "name": "Streamline Pixel Sort",
+    "url": "shaders/flow-sort.wgsl",
+    "category": "image",
+    "description": "Pixel sorting along vector field lines derived from luminance gradients.",
+    "params": [
+      {
+        "id": "flowStrength",
+        "name": "Flow Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sortPasses",
+        "name": "Sort Passes",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "strandPersist",
+        "name": "Trail Persistence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Sort Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "temporal-persistence",
+      "interactive",
+      "depth-aware",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "galaxy-compute",
+    "name": "Galaxy Compute",
+    "url": "shaders/galaxy-compute.wgsl",
+    "category": "image",
+    "description": "Volumetric spiral galaxy with logarithmic spiral SDF, procedural nebula clouds, Keplerian orbital mechanics, and stellar particle glow.",
+    "params": [
+      {
+        "id": "gravity",
+        "name": "Gravity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "particle_size",
+        "name": "Star Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pattern_opacity",
+        "name": "Pattern Opacity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "simulation",
+      "procedural",
+      "volumetric",
+      "spiral-galaxy"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "photonic-caustics",
+    "name": "Photonic Caustics",
+    "url": "shaders/photonic-caustics.wgsl",
+    "category": "image",
+    "description": "Light caustics simulation with chromatic dispersion, Fresnel reflections, and refractive surfaces.",
+    "params": [
+      {
+        "id": "ior",
+        "name": "Index of Refraction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "lightSize",
+        "name": "Light Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dispersion",
+        "name": "Chromatic Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "interactive",
+      "chromatic-aberration",
+      "mouse-driven",
+      "advanced-alpha"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "alpha",
+      "luminance-key"
+    ]
+  },
+  {
+    "id": "split-flap-display",
+    "name": "Split Flap Display",
+    "url": "shaders/split-flap-display.wgsl",
+    "category": "image",
+    "features": [
+      "interactive",
+      "simulation",
+      "mouse-driven"
+    ],
+    "description": "Simulates a mechanical split-flap display where the image is made of rotating tiles.",
+    "params": [
+      {
+        "id": "rows",
+        "name": "Grid Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of the split-flap grid"
+      },
+      {
+        "id": "radius",
+        "name": "Mouse Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Radius of mouse interaction"
+      },
+      {
+        "id": "auto_speed",
+        "name": "Auto Flip Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Speed of automatic idle flipping"
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0.8,
+        "max": 0.99,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Physics damping for tile rotation"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "wave-equation",
+    "name": "Wave Tank",
+    "url": "shaders/wave-equation.wgsl",
+    "category": "image",
+    "description": "2D wave equation simulation with ripple physics, refraction effects, and rainbow phase coloring.",
+    "params": [
+      {
+        "id": "waveSpeed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "sourceStrength",
+        "name": "Source Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "boundaryReflect",
+        "name": "Boundary Reflect",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "interactive",
+      "physics",
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "ascii-shockwave",
+    "name": "ASCII Shockwave",
+    "url": "shaders/ascii-shockwave.wgsl",
+    "category": "image",
+    "description": "A matrix-style digital shockwave that quantizes the image into procedural characters.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "breathing-kaleidoscope",
+    "name": "Breathing Kaleidoscope",
+    "url": "shaders/breathing-kaleidoscope.wgsl",
+    "category": "image",
+    "description": "Smoothly folds and unfolds the image into mirrored segments with a breathing animation; center and rotation are controllable.",
+    "params": [
+      {
+        "id": "cycleSpeed",
+        "name": "Cycle Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "segments",
+        "name": "Segments",
+        "default": 6,
+        "min": 2,
+        "max": 16
+      },
+      {
+        "id": "rotationSpeed",
+        "name": "Rotation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 4
+      },
+      {
+        "id": "maxRotationPercent",
+        "name": "Max Rotation",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "kaleidoscope",
+      "animated",
+      "visual-effects",
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "cyber-physical-portal",
+    "name": "Cyber Physical Portal",
+    "url": "shaders/cyber-physical-portal.wgsl",
+    "category": "image",
+    "description": "Reveals a cybernetic wireframe world through a glitchy portal at your mouse cursor.",
+    "params": [
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Base radius of the portal"
+      },
+      {
+        "id": "glitch_speed",
+        "name": "Glitch Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Speed of portal edge glitch jitter"
+      },
+      {
+        "id": "glow_sharpness",
+        "name": "Glow Sharpness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Sharpness of the portal edge glow"
+      },
+      {
+        "id": "grid_density",
+        "name": "Grid Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Density of the cyber grid inside the portal"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "electric-contours",
+    "name": "Electric Contours",
+    "url": "shaders/electric-contours.wgsl",
+    "category": "image",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Edge detection with electric glowing contours that react to mouse proximity.",
+    "params": [
+      {
+        "id": "edge_threshold",
+        "name": "Edge Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Base threshold for edge detection"
+      },
+      {
+        "id": "glow_intensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Intensity multiplier for the electric glow"
+      },
+      {
+        "id": "threshold_range",
+        "name": "Edge Threshold Range",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Range of the adaptive edge threshold"
+      },
+      {
+        "id": "spark_speed",
+        "name": "Spark Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Speed of electric spark animation"
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "glitch-pixel-sort",
+    "name": "Glitch Pixel Sort",
+    "url": "shaders/glitch-pixel-sort.wgsl",
+    "category": "image",
+    "description": "Luminance-based pixel stretching controlled by mouse position.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "hyper-space-jump",
+    "name": "Hyper Space Jump",
+    "url": "shaders/hyper-space-jump.wgsl",
+    "category": "image",
+    "description": "Streaks the image radially from the mouse position, simulating a hyperspace jump.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "interactive-pcb-traces",
+    "name": "Interactive PCB Traces",
+    "url": "shaders/interactive-pcb-traces.wgsl",
+    "category": "image",
+    "description": "Simulates a circuit board where traces light up with data pulses driven by the mouse.",
+    "params": [
+      {
+        "name": "Grid Scale",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "grid_scale"
+      },
+      {
+        "name": "Pulse Speed",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "pulse_speed"
+      },
+      {
+        "name": "Glow",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "glow"
+      },
+      {
+        "name": "Background",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "background"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "luma-smear-interactive",
+    "name": "Kinetic Echo",
+    "url": "shaders/luma-smear-interactive.wgsl",
+    "category": "image",
+    "description": "Creates a motion trail based on brightness. Bright objects leave trails that decay over time. Mouse clears the trails.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Luma Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Eraser Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "neon-edge-reveal",
+    "name": "Neon Edge Reveal",
+    "url": "shaders/neon-edge-reveal.wgsl",
+    "category": "image",
+    "description": "Neon edge detection with interactive flashlight reveal.",
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "phantom-lag",
+    "name": "Phantom Lag",
+    "url": "shaders/phantom-lag.wgsl",
+    "category": "image",
+    "features": [],
+    "description": "Creates trailing echoes of movement by blending past frames with spatial offsets.",
+    "params": [
+      {
+        "name": "Decay Rate",
+        "id": "zoomParam1",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Echo X",
+        "id": "zoomParam2",
+        "default": 0.55,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Echo Y",
+        "id": "zoomParam3",
+        "default": 0.55,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Hue Shift",
+        "id": "zoomParam4",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "pixel-sorter",
+    "name": "Pixel Sorter",
+    "url": "shaders/pixel-sorter.wgsl",
+    "category": "image",
+    "description": "Glitch art pixel sorting effect.",
+    "params": [
+      {
+        "id": "direction",
+        "name": "Sort Direction",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "reverse",
+        "name": "Reverse Sort",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensityScale",
+        "name": "Intensity Scale",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "threshold",
+        "name": "Sort Threshold Luma",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "signal-modulation",
+    "name": "Signal Modulation",
+    "category": "image",
+    "url": "shaders/signal-modulation.wgsl",
+    "description": "Simulates AM/FM signal distortion with mouse-controlled frequency and amplitude.",
+    "features": [
+      "mouse-driven",
+      "visual-effect"
+    ],
+    "params": [
+      {
+        "id": "freq",
+        "name": "Base Frequency",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amp",
+        "name": "Distortion Amt",
+        "type": "float",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Scroll Speed",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shift",
+        "name": "Color Split",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "warp-drive",
+    "name": "Warp Drive",
+    "category": "image",
+    "url": "shaders/warp_drive.wgsl",
+    "description": "Intense radial blur and chromatic aberration centered on the mouse.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Warp Speed",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Prism Split",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "brightness",
+        "name": "Core Glow",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "samples",
+        "name": "Blur Quality",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
+    ]
+  },
+  {
+    "id": "zipper-reveal",
+    "name": "Zipper Reveal",
+    "url": "shaders/zipper-reveal.wgsl",
+    "category": "image",
+    "description": "Unzips the image to reveal darkness, controlled by the mouse position.",
+    "params": [
+      {
+        "id": "zipper_width",
+        "name": "Spread",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Width of the zipper V-shape opening"
+      },
+      {
+        "id": "tooth_size",
+        "name": "Tooth Size",
+        "default": 0.02,
+        "min": 0.005,
+        "max": 0.1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Size of zipper teeth"
+      },
+      {
+        "id": "angle",
+        "name": "Angle",
+        "default": 0,
+        "min": -1.57,
+        "max": 1.57,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Rotation angle of the zipper"
+      },
+      {
+        "id": "tooth_amplitude",
+        "name": "Tooth Amplitude",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Amplitude of the tooth protrusion"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "filter",
+      "image-processing"
     ]
   }
 ]

--- a/public/shader-lists/interactive-mouse.json
+++ b/public/shader-lists/interactive-mouse.json
@@ -1,965 +1,103 @@
 [
   {
-    "id": "vertical-slice-wave",
-    "name": "Vertical Slice Wave",
-    "url": "shaders/vertical-slice-wave.wgsl",
+    "id": "interactive_neural_swarm",
+    "name": "Neural Swarm",
+    "url": "shaders/interactive_neural_swarm.wgsl",
     "category": "interactive-mouse",
-    "description": "Splits the image into vertical strips that oscillate. Mouse X controls frequency, Mouse Y controls amplitude. Audio-reactive via bass modulation.",
-    "params": [
-      {
-        "id": "strips",
-        "name": "Strip Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "split",
-        "name": "RGB Split",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "jitter",
-        "name": "Jitter",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
+    "description": "Agent-based neural network visualization with signal propagation, connection weights, and emergent activation patterns",
     "tags": [
-      "mouse-driven",
-      "interactive",
-      "audio-reactive",
-      "distortion"
-    ]
-  },
-  {
-    "id": "mouse-mandelbrot-zoom-portal",
-    "name": "Mandelbrot Zoom Portal",
-    "url": "shaders/mouse-mandelbrot-zoom-portal.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "raymarched"
-    ],
-    "description": "Navigate the infinite Mandelbrot set with mouse position. Click to create nested zoom portals that reveal deeper fractal levels.",
-    "params": [
-      {
-        "id": "zoomLevel",
-        "name": "Zoom Level",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "maxIter",
-        "name": "Iteration Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "paletteSpeed",
-        "name": "Palette Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "portalBlend",
-        "name": "Portal Blend",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "fractal",
-      "psychedelic",
-      "zoom"
-    ]
-  },
-  {
-    "id": "quantum-tunnel-interactive",
-    "name": "Quantum Tunnel",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "tunnel_strength",
-        "name": "Tunnel Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulse_speed",
-        "name": "Pulse Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "twist",
-        "name": "Twist",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "url": "shaders/quantum-tunnel-interactive.wgsl",
-    "description": "Interactive radial distortion with chromatic aberration, pulsing effects, and audio-reactive glow.",
-    "tags": [
-      "filter",
-      "image-processing",
-      "distortion",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "data-slicer-interactive",
-    "name": "Data Slicer",
-    "url": "shaders/data-slicer-interactive.wgsl",
-    "category": "interactive-mouse",
-    "description": "Glitchy horizontal slicing with FBM-warped torn edges, click-triggered slice bursts from ripple history, bass-modulated slice count, and semantic alpha at slice boundaries.",
-    "params": [
-      {
-        "id": "slice_count",
-        "name": "Slice Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "slice_width",
-        "name": "Slice Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fbm_warp",
-        "name": "FBM Warp",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "audio-reactive",
-      "temporal",
-      "upgraded-rgba"
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "audio-reactive",
-      "glitch",
-      "feedback",
-      "temporal",
-      "fbm",
-      "slice"
-    ]
-  },
-  {
-    "id": "cyber-ripples",
-    "name": "Cyber Ripples",
-    "url": "shaders/cyber-ripples.wgsl",
-    "category": "interactive-mouse",
-    "description": "Digital ripples with chromatic aberration and pixelation emanating from cursor. Audio-reactive bass boost.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Ripple Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pixelation",
-        "name": "Block Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Chromatic Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "frequency",
-        "name": "Wave Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "wave",
-      "neon",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "focal-pixelate",
-    "name": "Focal Pixelate",
-    "url": "shaders/focal-pixelate.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Applies pixelation that varies based on distance from the mouse cursor, creating a focal point effect.",
-    "params": [
-      {
-        "id": "pixel_strength",
-        "name": "Pixel Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "focus_radius",
-        "name": "Focus Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "focus_falloff",
-        "name": "Focus Softness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "invert",
-        "name": "Invert Focus",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "mouse-hyperbolic-navigator",
-    "name": "Hyperbolic Navigator",
-    "url": "shaders/mouse-hyperbolic-navigator.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Navigate an infinitely tiling hyperbolic plane via M\u00f6bius transformations driven by mouse position. The image maps onto a Poincar\u00e9 disk with tiles shrinking toward the boundary.",
-    "params": [
-      {
-        "id": "navigationSpeed",
-        "name": "Navigation Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "tileCount",
-        "name": "Tiling Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edgeGlow",
-        "name": "Boundary Glow",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "zoomFactor",
-        "name": "Zoom",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "geometric",
-      "hyperbolic",
-      "infinite",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "neon-ripple-split",
-    "name": "Neon Ripple Split",
-    "url": "shaders/neon-ripple-split.wgsl",
-    "category": "interactive-mouse",
-    "description": "A reactive ripple effect that separates RGB channels and adds a neon glow based on mouse movement and clicks.",
-    "params": [
-      {
-        "name": "Ripple Speed",
-        "type": "float",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "ripple_speed"
-      },
-      {
-        "name": "Color Split",
-        "type": "float",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "color_split"
-      },
-      {
-        "name": "Glow Intensity",
-        "type": "float",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "glow_intensity"
-      },
-      {
-        "name": "Frequency",
-        "type": "float",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "frequency"
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "vhs-tracking-mouse",
-    "name": "VHS Tracking",
-    "category": "interactive-mouse",
-    "url": "shaders/vhs-tracking-mouse.wgsl",
-    "description": "A vertical tracking bar distortion controlled by mouse height with audio-reactive intensity.",
-    "params": [
-      {
-        "id": "barHeight",
-        "name": "Bar Height",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "noise",
-        "name": "Static Noise",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Split",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "vhs",
-      "glitch",
-      "retro"
-    ]
-  },
-  {
-    "id": "sonar-pulse",
-    "name": "Sonar Pulse",
-    "url": "shaders/sonar-pulse.wgsl",
-    "category": "interactive-mouse",
-    "description": "Radial sonar waves emitting from the cursor that distort and scan the image. Now with audio reactivity.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "freq",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "width",
-        "name": "Wave Width",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "sonar",
-      "pulse",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "interactive-glitch-brush",
-    "name": "Glitch Brush",
-    "url": "shaders/interactive-glitch-brush.wgsl",
-    "category": "interactive-mouse",
-    "description": "Paint digital glitches onto the screen with audio-reactive intensity.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Glitch Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "block_scale",
-        "name": "Block Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color_split",
-        "name": "Color Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "audio-reactive"
-    ],
-    "tags": [
-      "glitch",
-      "interactive",
-      "brush",
-      "mouse-driven",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "mouse-neural-dreamscape",
-    "name": "Neural Dreamscape",
-    "url": "shaders/mouse-neural-dreamscape.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "temporal"
-    ],
-    "description": "A virtual neural network grid activates around the mouse. Neurons glow and synapse connections pulse with activation. Click ripples send waves through the network.",
-    "params": [
-      {
-        "id": "networkDensity",
-        "name": "Network Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "activationRadius",
-        "name": "Activation Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulseSpeed",
-        "name": "Pulse Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "synapseStrength",
-        "name": "Synapse Strength",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
       "neural",
       "network",
-      "psychedelic",
-      "generative"
-    ]
-  },
-  {
-    "id": "chroma-kinetic",
-    "name": "Chroma Kinetic",
-    "url": "shaders/chroma-kinetic.wgsl",
-    "category": "interactive-mouse",
-    "description": "Mouse-driven chromatic aberration modulated by image luminance and audio bass.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Distortion Str",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "luma_inf",
-        "name": "Luma Influence",
-        "default": 1.0,
-        "min": -2.0,
-        "max": 2.0
-      },
-      {
-        "id": "rotation",
-        "name": "Direction Rot",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
+      "swarm",
+      "interactive",
+      "neon",
+      "biological"
     ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "chromatic-aberration",
-      "kinetic",
-      "mouse"
-    ]
-  },
-  {
-    "id": "cyber-trace",
-    "name": "Cyber Trace",
-    "url": "shaders/cyber-trace.wgsl",
-    "category": "interactive-mouse",
-    "description": "A glowing neon trail that follows your mouse cursor and reacts to clicks, overlaid on the video feed.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "min": 0.8,
-        "max": 0.99,
-        "default": 0.96
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "min": 0.0,
-        "max": 3.0,
-        "default": 1.5
-      },
-      {
-        "id": "color",
-        "name": "Color Shift",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0
-      },
-      {
-        "id": "size",
-        "name": "Brush Size",
-        "min": 0.005,
-        "max": 0.2,
-        "default": 0.05
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "pixel-repel",
-    "category": "interactive-mouse",
-    "url": "shaders/pixel-repel.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
-      "audio-driven"
+      "agent-based",
+      "signal-propagation",
+      "neon"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Repel Radius",
-        "default": 0.2,
-        "min": 0.05,
-        "max": 0.5
-      },
-      {
-        "id": "param2",
-        "name": "Repel Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Aberration",
-        "default": 0.05,
-        "min": 0.0,
-        "max": 0.2
-      },
-      {
-        "id": "param4",
-        "name": "Smoothing",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "name": "Pixel Repeller"
-  },
-  {
-    "id": "polar-warp-interactive",
-    "name": "Polar Warp",
-    "url": "shaders/polar-warp-interactive.wgsl",
-    "category": "interactive-mouse",
-    "description": "Maps the image to polar coordinates centered on the mouse with bass-driven warp strength, spiral twist, click-triggered ripple bursts, and depth-aware fading.",
-    "features": [
-      "mouse-driven",
-      "upgraded-rgba",
-      "audio-reactive",
-      "depth-aware",
-      "multi-ripple"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Spiral Amount",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Ripple Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Pinch/Expand",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "interactive",
-      "polar",
-      "warp",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "liquid-time-warp",
-    "url": "shaders/liquid-time-warp.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "webcam"
-    ],
-    "description": "Fluid feedback loop where time is distorted by mouse movement.",
-    "params": [
-      {
-        "name": "Distortion",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "distortion"
-      },
-      {
-        "name": "Flow Speed",
-        "type": "float",
+        "name": "Connection Threshold",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "flow_speed"
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       },
       {
-        "name": "Scale",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "scale"
+        "id": "param2",
+        "name": "Signal Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       },
       {
-        "name": "Decay",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "decay"
+        "id": "param3",
+        "name": "Glow Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Network Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
       }
     ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Liquid Time Warp"
+    "target_rating": 4.8
   },
   {
-    "id": "liquid-warp",
-    "name": "Liquid Warp",
-    "url": "shaders/liquid-warp.wgsl",
+    "id": "ascii-decode",
+    "name": "ASCII Decode",
+    "url": "shaders/ascii-decode.wgsl",
     "category": "interactive-mouse",
     "features": [
       "mouse-driven"
     ],
-    "description": "Fluid-like distortion where mouse movement pushes and swirls pixels.",
+    "description": "Renders the view as a digital ASCII matrix. Mouse movement acts as a decoding lens.",
     "params": [
+      {
+        "id": "gridSize",
+        "name": "Grid Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
       {
         "id": "radius",
-        "name": "Brush Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "strength",
-        "name": "Push Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Flow Decay",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "swirl",
-        "name": "Swirl Factor",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "luma-echo-warp",
-    "category": "interactive-mouse",
-    "url": "shaders/luma-echo-warp.wgsl",
-    "description": "Distorts the image based on pixel brightness and mouse position, creating a warping echo effect.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Warp Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Echo Decay",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Luma Weight",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Luma Echo Warp"
-  },
-  {
-    "id": "mouse-electromagnetic-aurora",
-    "name": "Electromagnetic Aurora",
-    "url": "shaders/mouse-electromagnetic-aurora.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "multi-pass-1"
-    ],
-    "description": "The mouse acts as a moving electric charge generating flowing EM field lines that distort UVs and rotate hue. Click ripples spawn orbiting opposite-polarity charges.",
-    "params": [
-      {
-        "id": "chargeStrength",
-        "name": "Charge Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fieldVis",
-        "name": "Field Visibility",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortionStrength",
-        "name": "Distortion Strength",
+        "name": "Decode Radius",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "colorRotation",
-        "name": "Color Rotation",
+        "id": "speed",
+        "name": "Matrix Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mix",
+        "name": "Effect Strength",
+        "default": 1,
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
-      "interactive",
       "mouse-driven",
-      "field-simulation",
-      "chromatic",
-      "psychedelic"
+      "interactive"
     ]
   },
   {
@@ -973,29 +111,29 @@
         "id": "radius",
         "name": "Glow Radius",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "density",
         "name": "Cell Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "shift",
         "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "default": 0,
+        "min": 0,
+        "max": 1
       },
       {
         "id": "speed",
         "name": "Pulse Speed",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -1012,1644 +150,49 @@
     ]
   },
   {
-    "id": "psychedelic-noise-flow",
-    "name": "Psychedelic Noise Flow",
-    "url": "shaders/psychedelic-noise-flow.wgsl",
+    "id": "block-distort-interactive",
+    "url": "shaders/block-distort-interactive.wgsl",
     "category": "interactive-mouse",
-    "description": "Applies a liquid-like noise flow where RGB channels are separated by phase, creating colorful swirls. Mouse controls flow speed and direction.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scale",
-        "name": "Noise Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion",
-        "name": "Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "separation",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "neon-edge-radar",
-    "name": "Neon Edge Radar",
-    "url": "shaders/neon-edge-radar.wgsl",
-    "category": "interactive-mouse",
-    "description": "A rotating radar scanner that highlights edges in neon colors as it passes, centered on the mouse.",
-    "params": [
-      {
-        "id": "speed",
-        "name": "Beam Speed",
-        "default": 1.0,
-        "min": 0.1,
-        "max": 5.0
-      },
-      {
-        "id": "width",
-        "name": "Beam Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Edge Sensitivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Neon Intensity",
-        "default": 2.0,
-        "min": 0.0,
-        "max": 5.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "dynamic-halftone",
-    "name": "Dynamic Halftone",
-    "url": "shaders/dynamic-halftone.wgsl",
-    "category": "interactive-mouse",
-    "description": "Halftone pattern that reacts to mouse proximity with size and contrast changes. Audio-reactive radius expansion via bass input.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Dot Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Mouse Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge_sharpness",
-        "name": "Edge Sharpness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Halftone dot edge sharpness (wired to zoom_params.w)"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "halftone",
-      "filter",
-      "image-processing",
-      "interactive",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "mirror-drag",
-    "name": "Mirror Drag",
-    "url": "shaders/mirror-drag.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Mirrors the image across an axis defined by the mouse position.",
-    "params": [
-      {
-        "id": "side",
-        "name": "Flip Side",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "flipY",
-        "name": "Mirror Y",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "smoothness",
-        "name": "Edge Smoothness",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mode",
-        "name": "Mode",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "pixel-explode",
-    "category": "interactive-mouse",
-    "url": "shaders/pixel-explode.wgsl",
+    "icon": "grid",
+    "description": "Image is divided into blocks that are pushed away by the mouse, creating a pixelated distortion field.",
     "features": [
       "mouse-driven"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
+        "id": "x",
+        "name": "Block Size",
+        "default": 0.2,
         "min": 0,
-        "max": 1,
-        "step": 0.01
+        "max": 1
       },
       {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Pixel Explode"
-  },
-  {
-    "id": "velocity-field-paint",
-    "category": "interactive-mouse",
-    "url": "shaders/velocity-field-paint.wgsl",
-    "description": "Uses mouse movement to paint a velocity field that distorts the image like fluid.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Dissipation",
-        "default": 0.9,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param2",
-        "name": "Brush Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param3",
-        "name": "Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Audio Reactivity",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "name": "Velocity Field Paint"
-  },
-  {
-    "id": "scan-slice",
-    "name": "Scan Slice",
-    "url": "shaders/scan-slice.wgsl",
-    "category": "interactive-mouse",
-    "description": "Mouse X selects a vertical slice; Mouse Y offsets it with chromatic aberration. Audio-reactive edge glow pulses to bass.",
-    "params": [
-      {
-        "id": "width",
-        "name": "Slice Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "offset_scale",
-        "name": "Offset Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dimming",
-        "name": "Bg Dimming",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "slice",
-      "chromatic",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "mouse-paint-splatter",
-    "name": "Paint Splatter",
-    "url": "shaders/mouse-paint-splatter.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "temporal"
-    ],
-    "description": "Mouse drags leave colorful paint splatters sampled from the image. Paint spreads, mixes, and dries over time. Click ripples create explosive paint bursts.",
-    "params": [
-      {
-        "id": "splatterSize",
-        "name": "Brush Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dryRate",
-        "name": "Dry Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spreadAmount",
-        "name": "Paint Spread",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorIntensity",
-        "name": "Color Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "paint",
-      "temporal",
-      "artistic"
-    ]
-  },
-  {
-    "id": "laser-burn",
-    "name": "Laser Burn",
-    "url": "shaders/laser-burn.wgsl",
-    "category": "interactive-mouse",
-    "description": "Interactive laser that burns the image permanently (or heals slowly).",
-    "params": [
-      {
-        "id": "beamSize",
-        "name": "Beam Size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "burnSpeed",
-        "name": "Burn Intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "healRate",
-        "name": "Heal Rate",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "heatMode",
-        "name": "Heat Glow",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "laser",
-      "burn",
-      "interactive",
-      "fire"
-    ]
-  },
-  {
-    "id": "magnetic-edge",
-    "url": "shaders/magnetic-edge.wgsl",
-    "icon": "edgesensor_high",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Pull Strength",
+        "id": "y",
+        "name": "Push Strength",
         "default": 0.5,
         "min": 0,
         "max": 1
       },
       {
-        "id": "param2",
+        "id": "z",
+        "name": "RGB Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
         "name": "Radius",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param3",
-        "name": "Edge Threshold",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param4",
-        "name": "Glow",
-        "default": 0.2,
+        "default": 0.4,
         "min": 0,
         "max": 1
       }
     ],
-    "category": "interactive-mouse",
     "tags": [
       "mouse-driven",
       "interactive"
     ],
-    "name": "Magnetic Edge"
-  },
-  {
-    "id": "mouse-kaleidoscope-tunnel",
-    "name": "Kaleidoscope Tunnel",
-    "url": "shaders/mouse-kaleidoscope-tunnel.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Infinite kaleidoscope tunnel centered on the mouse. Moving creates spiraling mirrors with perspective depth. Click ripples send kaleidoscope bursts through the tunnel.",
-    "params": [
-      {
-        "id": "tunnelSpeed",
-        "name": "Tunnel Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "segmentBase",
-        "name": "Mirror Count",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spiralTwist",
-        "name": "Spiral Twist",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "zoomDepth",
-        "name": "Tunnel Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "kaleidoscope",
-      "tunnel",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "spectral-waves",
-    "name": "Luma Ripple",
-    "url": "shaders/spectral-waves.wgsl",
-    "category": "interactive-mouse",
-    "description": "Luminance-reactive waves ripple out from the mouse cursor, displacing the image with chromatic aberration. Audio bass boosts wave amplitude.",
-    "params": [
-      {
-        "id": "frequency",
-        "name": "Ripple Freq",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amplitude",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Chromatic Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "image"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "ripple",
-      "chromatic",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "mouse-chromatic-explosion",
-    "name": "Chromatic Explosion",
-    "url": "shaders/mouse-chromatic-explosion.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "description": "The mouse acts as a prism separating R, G, B channels by wavelength. Click ripples launch chromatic shockwaves. Creates rainbow halos and spectral fan-outs.",
-    "params": [
-      {
-        "id": "prismStrength",
-        "name": "Prism Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "dispersion",
-        "name": "Dispersion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rippleStrength",
-        "name": "Ripple Chromatics",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "saturationBoost",
-        "name": "Saturation Boost",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "chromatic",
-      "prism",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "scanline-wave",
-    "name": "Scanline Wave",
-    "url": "shaders/scanline-wave.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "upgraded-rgba",
-      "depth-aware",
-      "audio-reactive"
-    ],
-    "description": "Sine-wave horizontal scanline distortion with HDR bloom, atmospheric depth fog, and warm highlight grading. Mouse modulates wave intensity by vertical proximity.",
-    "params": [
-      {
-        "id": "frequency",
-        "name": "Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "amplitude",
-        "name": "Amplitude",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Wave Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mouse_influence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "distortion",
-      "scanlines",
-      "hdr",
-      "bloom",
-      "atmospheric"
-    ]
-  },
-  {
-    "id": "luma-slice-interactive",
-    "name": "Luma Slice Interactive",
-    "url": "shaders/luma-slice-interactive.wgsl",
-    "category": "interactive-mouse",
-    "description": "Slices the image horizontally, displacing strips based on their luminance and mouse position. Audio-reactive intensity via bass.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Displace Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "slices",
-        "name": "Slice Density",
-        "default": 0.5,
-        "min": 0.1,
-        "max": 1.0
-      },
-      {
-        "id": "rgb_shift",
-        "name": "RGB Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "phase",
-        "name": "Phase Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "interactive",
-      "slice",
-      "luma"
-    ]
-  },
-  {
-    "id": "paper-burn",
-    "name": "Paper Burn",
-    "url": "shaders/paper-burn.wgsl",
-    "category": "interactive-mouse",
-    "description": "Interactive paper burn effect that spreads from mouse cursor with realistic charring and ash.",
-    "features": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "mouse-synesthetic-sound-paint",
-    "name": "Synesthetic Sound Paint",
-    "url": "shaders/mouse-synesthetic-sound-paint.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "temporal"
-    ],
-    "description": "Mouse becomes a conductor directing a visual orchestra. Screen regions map to bass blobs, mid waves, and treble sparkles. Without audio, falls back to mouse-driven generative color synthesis.",
-    "params": [
-      {
-        "id": "audioSensitivity",
-        "name": "Audio Sensitivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "patternScale",
-        "name": "Pattern Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "energyDecay",
-        "name": "Energy Decay",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShiftSpeed",
-        "name": "Color Shift Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "audio-reactive",
-      "synesthesia",
-      "generative",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "luma-magnetism",
-    "url": "shaders/luma-magnetism.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "strength",
-        "name": "Magnet Strength",
-        "type": "float",
-        "default": 0.5,
-        "min": -1.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Effect Radius",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hardness",
-        "name": "Edge Hardness",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Luma Threshold",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "description": "Bright pixels are magnetically attracted to the mouse cursor.",
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Luma Magnetism"
-  },
-  {
-    "id": "cursor-aura",
-    "name": "Cursor Aura",
-    "url": "shaders/cursor-aura.wgsl",
-    "category": "interactive-mouse",
-    "description": "Glowing aura around cursor with customizable colors, edge detection, and audio-reactive bass pulsing.",
-    "params": [
-      {
-        "id": "size",
-        "name": "Aura Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "intensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "softness",
-        "name": "Edge Softness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hue",
-        "name": "Color Hue",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glow",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "interactive",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "mouse-magnetic-pixel-sand",
-    "name": "Magnetic Pixel Sand",
-    "url": "shaders/mouse-magnetic-pixel-sand.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Pixels behave as iron filings attracted or repelled by the mouse magnet based on their brightness. Creates flowing metallic grain patterns with ripple magnetic pulses.",
-    "params": [
-      {
-        "id": "magnetStrength",
-        "name": "Magnet Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "magneticRange",
-        "name": "Field Range",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "polarity",
-        "name": "Polarity",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "grainSize",
-        "name": "Grain Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "magnetic",
-      "particles",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "energy-shield",
-    "name": "Energy Shield",
-    "url": "shaders/energy-shield.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "A hexagonal energy grid that lights up and ripples upon mouse interaction.",
-    "params": [
-      {
-        "id": "hexScale",
-        "name": "Hex Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rippleSpeed",
-        "name": "Ripple Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "impactStrength",
-        "name": "Impact Strength",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.95,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "reality-tear",
-    "name": "Reality Tear",
-    "url": "shaders/reality-tear.wgsl",
-    "category": "interactive-mouse",
-    "description": "Rips a hole in the image to reveal a static void underneath.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "name": "Tear Size",
-        "id": "size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Jaggedness",
-        "id": "jagged",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Burn Edge",
-        "id": "border",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Static Noise",
-        "id": "static",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "interactive-magnetic-ripple",
-    "name": "Magnetic Ripple",
-    "url": "shaders/interactive-magnetic-ripple.wgsl",
-    "category": "interactive-mouse",
-    "description": "Magnetic field distortion with curl-noise field lines, all 50 ripple point accumulation, FBM domain warping, chromatic split, and glow-alpha at ripple peaks.",
-    "params": [
-      {
-        "id": "ripple_freq",
-        "name": "Ripple Frequency",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ripple_decay",
-        "name": "Ripple Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "field_strength",
-        "name": "Field Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chromatic_split",
-        "name": "Chromatic Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion",
-      "audio-reactive",
-      "upgraded-rgba"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "fbm",
-      "curl-noise",
-      "worley",
-      "domain-warp",
-      "fractal",
-      "magnetic",
-      "field-lines"
-    ]
-  },
-  {
-    "id": "pixel-stretch-cross",
-    "name": "Pixel Stretch Cross",
-    "url": "shaders/pixel-stretch-cross.wgsl",
-    "category": "interactive-mouse",
-    "description": "Multi-direction pixel stretch using Fibonacci disk sampling, depth-aware attenuation, bass-driven magnitude, and effect-masked alpha transparency.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware",
-      "upgraded-rgba"
-    ],
-    "params": [
-      {
-        "id": "h_stretch",
-        "name": "H Stretch",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "v_stretch",
-        "name": "V Stretch",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "depth_influence",
-        "name": "Depth Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "fibonacci",
-      "depth-aware",
-      "stretch",
-      "distortion"
-    ]
-  },
-  {
-    "id": "spectral-distortion",
-    "name": "Spectral Distortion",
-    "url": "shaders/spectral-distortion.wgsl",
-    "category": "interactive-mouse",
-    "description": "RGB channels split and warp based on noise, mouse proximity, and bass-driven audio reactivity.",
-    "params": [
-      {
-        "id": "separation",
-        "name": "RGB Separation",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "warpScale",
-        "name": "Warp Scale",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mouseInfluence",
-        "name": "Mouse Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Speed",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence",
-      "glitch",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "chromatic",
-      "warp",
-      "noise"
-    ]
-  },
-  {
-    "id": "mouse-voronoi-mosaic",
-    "name": "Voronoi Mosaic",
-    "url": "shaders/mouse-voronoi-mosaic.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Click positions seed Voronoi cells that rotate, shift, and scale independently. Stained-glass edge effects with per-cell color tinting create an evolving mosaic.",
-    "params": [
-      {
-        "id": "shatterStrength",
-        "name": "Shatter Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edgeThickness",
-        "name": "Edge Thickness",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glassOpacity",
-        "name": "Glass Opacity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "voronoi",
-      "mosaic",
-      "stained-glass"
-    ]
-  },
-  {
-    "id": "ascii-decode",
-    "name": "ASCII Decode",
-    "url": "shaders/ascii-decode.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Renders the view as a digital ASCII matrix. Mouse movement acts as a decoding lens.",
-    "params": [
-      {
-        "id": "gridSize",
-        "name": "Grid Size",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Decode Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "speed",
-        "name": "Matrix Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mix",
-        "name": "Effect Strength",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "kimi-spotlight",
-    "name": "Kimi Spotlight",
-    "url": "shaders/kimi_spotlight.wgsl",
-    "category": "interactive-mouse",
-    "description": "Flashlight effect that reveals full color under the beam while surroundings are desaturated and darkened. Audio-reactive spotlight size pulses with bass.",
-    "features": [
-      "mouse-driven",
-      "interactive",
-      "spotlight",
-      "reveal",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "spotSize",
-        "name": "Spotlight Size",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "step": 0.01
-      },
-      {
-        "id": "spotSoftness",
-        "name": "Edge Softness",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "step": 0.01
-      },
-      {
-        "id": "edgeDarkness",
-        "name": "Edge Darkness",
-        "min": 0,
-        "max": 1,
-        "default": 0.7,
-        "step": 0.01
-      },
-      {
-        "id": "saturationBoost",
-        "name": "Color Boost",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "spotlight",
-      "reveal",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "hex-mosaic",
-    "name": "Hexagon Mosaic",
-    "url": "shaders/hex-mosaic.wgsl",
-    "category": "interactive-mouse",
-    "description": "Hexagonal tiling effect that reveals the clear image around the mouse cursor. Bass audio reactivity boosts saturation.",
-    "params": [
-      {
-        "id": "scale",
-        "name": "Tile Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Reveal Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "hardness",
-        "name": "Edge Hardness",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "saturation",
-        "name": "Sat Boost",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "hexagon",
-      "mosaic",
-      "interactive"
-    ]
-  },
-  {
-    "id": "cyber-slit-scan",
-    "url": "shaders/cyber-slit-scan.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "webcam"
-    ],
-    "description": "Slit-scan effect with cyberpunk artifacts controlled by mouse position.",
-    "params": [
-      {
-        "name": "Scan Speed",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "scan_speed"
-      },
-      {
-        "name": "Bit Crush",
-        "type": "float",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "bit_crush"
-      },
-      {
-        "name": "Hue Shift",
-        "type": "float",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "hue_shift"
-      },
-      {
-        "name": "Unused",
-        "type": "float",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "id": "unused"
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Cyber Slit Scan"
-  },
-  {
-    "id": "mouse-fluid-coupling",
-    "name": "Fluid Coupling",
-    "url": "shaders/mouse-fluid-coupling.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "temporal"
-    ],
-    "description": "The mouse drags a viscous fluid over the image, creating vortex streets and color absorption. Click ripples inject fluid bursts.",
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "mouseRadius",
-        "name": "Stir Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Absorption",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "vortexStrength",
-        "name": "Vortex Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "fluid-simulation",
-      "temporal",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "mouse-polarized-light-field",
-    "name": "Polarized Light Field",
-    "url": "shaders/mouse-polarized-light-field.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Mouse controls polarization angle and birefringence over the image. Creates interference fringes, Malus-law filtering, and moir\u00e9 patterns. Click ripples spawn polarization vortices.",
-    "params": [
-      {
-        "id": "polarizationAngle",
-        "name": "Polarization Angle",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "birefringence",
-        "name": "Birefringence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fringeDensity",
-        "name": "Fringe Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorMode",
-        "name": "Color Shift",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "polarization",
-      "interference",
-      "optics",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "volumetric-god-rays",
-    "name": "Volumetric God Rays",
-    "url": "shaders/volumetric-god-rays.wgsl",
-    "category": "interactive-mouse",
-    "description": "Generates volumetric light rays emanating from the mouse position, using image highlights as the source. Audio-reactive weight modulation enhances the rays with bass frequencies.",
-    "params": [
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Decay",
-        "default": 0.95,
-        "min": 0.8,
-        "max": 1.0
-      },
-      {
-        "id": "weight",
-        "name": "Weight",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "exposure",
-        "name": "Exposure",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "lighting",
-      "rays",
-      "volumetric"
-    ]
-  },
-  {
-    "id": "stereoscopic-3d",
-    "name": "Stereoscopic 3D",
-    "url": "shaders/stereoscopic-3d.wgsl",
-    "category": "interactive-mouse",
-    "description": "Interactive Anaglyph 3D effect. Mouse movement controls separation depth and focal plane distortion. Audio bass adds separation pulse.",
-    "params": [
-      {
-        "id": "separation",
-        "name": "Max Separation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "focus",
-        "name": "Focus Offset",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch Jitter",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rotation",
-        "name": "Lens Rotation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive",
-      "audio-reactive",
-      "anaglyph",
-      "3d"
-    ]
+    "name": "Block Distort"
   },
   {
     "id": "chroma-depth-tunnel",
@@ -2662,29 +205,29 @@
         "id": "speed",
         "name": "Tunnel Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "density",
         "name": "Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "chromaSep",
         "name": "Chroma Sep",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "centerFade",
         "name": "Center Fog",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -2700,92 +243,91 @@
     ]
   },
   {
-    "id": "cyber-magnifier",
-    "name": "Cyber Magnifier",
-    "url": "shaders/cyber-magnifier.wgsl",
+    "id": "chroma-kinetic",
+    "name": "Chroma Kinetic",
+    "url": "shaders/chroma-kinetic.wgsl",
     "category": "interactive-mouse",
-    "description": "High-tech magnifying lens with chromatic aberration and HUD overlay.",
+    "description": "Mouse-driven chromatic aberration modulated by image luminance and audio bass.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Distortion Str",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "luma_inf",
+        "name": "Luma Influence",
+        "default": 1,
+        "min": -2,
+        "max": 2
+      },
+      {
+        "id": "rotation",
+        "name": "Direction Rot",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "chromatic-aberration",
+      "kinetic",
+      "mouse"
+    ]
+  },
+  {
+    "id": "circuit-breaker",
+    "name": "Circuit Breaker",
+    "url": "shaders/circuit-breaker.wgsl",
+    "category": "interactive-mouse",
+    "description": "Transforms image into a circuit board. Mouse interaction overloads the circuits.",
     "features": [
       "mouse-driven"
     ],
     "params": [
       {
-        "id": "magnification",
-        "name": "Magnification",
-        "type": "float",
+        "name": "Grid Scale",
+        "id": "scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "lens_size",
-        "name": "Lens Size",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "aberration",
-        "name": "Aberration",
-        "type": "float",
+        "name": "Overload",
+        "id": "intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "grid_opacity",
-        "name": "Grid Opacity",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "quantum-flux",
-    "name": "Quantum Flux",
-    "url": "shaders/quantum-flux.wgsl",
-    "category": "interactive-mouse",
-    "description": "Simulates quantum instability and probability waves emanating from the mouse cursor, causing jitter and color drift.",
-    "params": [
-      {
+        "name": "Jitter",
         "id": "jitter",
-        "name": "Flux Jitter",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "frequency",
-        "name": "Wave Freq",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "drift",
-        "name": "Color Drift",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "radius",
-        "name": "Flux Radius",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Edge Threshold",
+        "id": "threshold",
+        "default": 0.1,
+        "min": 0,
+        "max": 0.5
       }
-    ],
-    "features": [
-      "mouse-driven",
-      "distortion"
     ],
     "tags": [
       "mouse-driven",
@@ -2793,49 +335,47 @@
     ]
   },
   {
-    "id": "motion-revealer",
-    "name": "Motion Revealer",
-    "url": "shaders/motion-revealer.wgsl",
+    "id": "codebreaker-reveal",
     "category": "interactive-mouse",
-    "description": "The screen is dark by default; use the mouse as a brush to paint the live video feed onto the canvas with trailing fades.",
+    "url": "shaders/codebreaker-reveal.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
     "params": [
       {
-        "id": "size",
-        "name": "Brush Size",
+        "id": "param1",
+        "name": "Reveal Radius",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "fade",
-        "name": "Fade Speed",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param2",
+        "name": "Rain Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "softness",
-        "name": "Edge Softness",
+        "id": "param3",
+        "name": "Code Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "opacity",
-        "name": "Brush Opacity",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param4",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal-persistence"
     ],
     "tags": [
       "mouse-driven",
       "interactive"
-    ]
+    ],
+    "name": "Codebreaker Reveal"
   },
   {
     "id": "cross-mouse-spec-dispersion-lens",
@@ -2862,34 +402,884 @@
         "id": "lensRadius",
         "name": "Lens Radius",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "dispersionScale",
         "name": "Dispersion Scale",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "lensStrength",
         "name": "Lens Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "rotationSpeed",
         "name": "Rotation Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
+    ]
+  },
+  {
+    "id": "crystal-illuminator",
+    "name": "Crystal Illuminator",
+    "url": "shaders/crystal-illuminator.wgsl",
+    "category": "interactive-mouse",
+    "description": "Faceted glass/gemstone surface with physical light transmission. Features Voronoi-based facets with mouse-controlled lighting, Fresnel reflection, and purity-based scattering for realistic crystal appearance.",
+    "features": [
+      "mouse-driven",
+      "alpha-transmission",
+      "physical-refraction"
+    ],
+    "params": [
+      {
+        "id": "crystal_size",
+        "name": "Crystal Size",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "description": "Size of Voronoi crystal facets"
+      },
+      {
+        "id": "ior",
+        "name": "Refractive Index",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "description": "IOR: Quartz (1.54) to Diamond (2.42)"
+      },
+      {
+        "id": "light_intensity",
+        "name": "Light Intensity",
+        "type": "float",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "description": "Mouse light brightness"
+      },
+      {
+        "id": "purity",
+        "name": "Crystal Purity",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "description": "Crystal clarity: Pure transmits more, impure scatters more"
+      }
+    ],
+    "tags": [
+      "crystal",
+      "gemstone",
+      "transmission",
+      "fresnel",
+      "voronoi",
+      "physical",
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "cursor-aura",
+    "name": "Cursor Aura",
+    "url": "shaders/cursor-aura.wgsl",
+    "category": "interactive-mouse",
+    "description": "Glowing aura around cursor with customizable colors, edge detection, and audio-reactive bass pulsing.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Aura Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hue",
+        "name": "Color Hue",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glow",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "interactive",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "cyber-magnifier",
+    "name": "Cyber Magnifier",
+    "url": "shaders/cyber-magnifier.wgsl",
+    "category": "interactive-mouse",
+    "description": "High-tech magnifying lens with chromatic aberration and HUD overlay.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "magnification",
+        "name": "Magnification",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "lens_size",
+        "name": "Lens Size",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "grid_opacity",
+        "name": "Grid Opacity",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "cyber-ripples",
+    "name": "Cyber Ripples",
+    "url": "shaders/cyber-ripples.wgsl",
+    "category": "interactive-mouse",
+    "description": "Digital ripples with chromatic aberration and pixelation emanating from cursor. Audio-reactive bass boost.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Ripple Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pixelation",
+        "name": "Block Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Chromatic Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "frequency",
+        "name": "Wave Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "wave",
+      "neon",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "cyber-slit-scan",
+    "url": "shaders/cyber-slit-scan.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "webcam"
+    ],
+    "description": "Slit-scan effect with cyberpunk artifacts controlled by mouse position.",
+    "params": [
+      {
+        "name": "Scan Speed",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "id": "scan_speed"
+      },
+      {
+        "name": "Bit Crush",
+        "type": "float",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "id": "bit_crush"
+      },
+      {
+        "name": "Hue Shift",
+        "type": "float",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "id": "hue_shift"
+      },
+      {
+        "name": "Unused",
+        "type": "float",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "id": "unused"
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Cyber Slit Scan"
+  },
+  {
+    "id": "cyber-trace",
+    "name": "Cyber Trace",
+    "url": "shaders/cyber-trace.wgsl",
+    "category": "interactive-mouse",
+    "description": "A glowing neon trail that follows your mouse cursor and reacts to clicks, overlaid on the video feed.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "min": 0.8,
+        "max": 0.99,
+        "default": 0.96
+      },
+      {
+        "id": "glow",
+        "name": "Glow Intensity",
+        "min": 0,
+        "max": 3,
+        "default": 1.5
+      },
+      {
+        "id": "color",
+        "name": "Color Shift",
+        "min": 0,
+        "max": 1,
+        "default": 0
+      },
+      {
+        "id": "size",
+        "name": "Brush Size",
+        "min": 0.005,
+        "max": 0.2,
+        "default": 0.05
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "data-slicer-interactive",
+    "name": "Data Slicer",
+    "url": "shaders/data-slicer-interactive.wgsl",
+    "category": "interactive-mouse",
+    "description": "Glitchy horizontal slicing with FBM-warped torn edges, click-triggered slice bursts from ripple history, bass-modulated slice count, and semantic alpha at slice boundaries.",
+    "params": [
+      {
+        "id": "slice_count",
+        "name": "Slice Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "slice_width",
+        "name": "Slice Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fbm_warp",
+        "name": "FBM Warp",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "audio-reactive",
+      "temporal",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive",
+      "audio-reactive",
+      "glitch",
+      "feedback",
+      "temporal",
+      "fbm",
+      "slice"
+    ]
+  },
+  {
+    "id": "data-stream",
+    "name": "Digital Stream",
+    "url": "shaders/data-stream.wgsl",
+    "category": "interactive-mouse",
+    "description": "Digital matrix-style data stream disrupted by mouse interaction. Audio-reactive bass pulses accelerate the flow.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow",
+        "name": "Digital Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "audio-reactive"
+    ],
+    "tags": [
+      "digital",
+      "matrix",
+      "green",
+      "data",
+      "stream",
+      "glitch",
+      "interactive",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "directional-glitch",
+    "name": "Directional Glitch",
+    "url": "shaders/directional-glitch.wgsl",
+    "category": "interactive-mouse",
+    "description": "Glitch artifacts radiate from the mouse position with audio-reactive displacement.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Glitch strength"
+      },
+      {
+        "id": "radius",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Radius of glitch effect"
+      },
+      {
+        "id": "scatter",
+        "name": "Scatter",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Scatter and noise amount"
+      },
+      {
+        "id": "angle_bias",
+        "name": "Angle Bias",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Directional rotation bias"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "glitch",
+      "interactive",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "dynamic-halftone",
+    "name": "Dynamic Halftone",
+    "url": "shaders/dynamic-halftone.wgsl",
+    "category": "interactive-mouse",
+    "description": "Halftone pattern that reacts to mouse proximity with size and contrast changes. Audio-reactive radius expansion via bass input.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Dot Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Mouse Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge_sharpness",
+        "name": "Edge Sharpness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Halftone dot edge sharpness (wired to zoom_params.w)"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "halftone",
+      "filter",
+      "image-processing",
+      "interactive",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "energy-shield",
+    "name": "Energy Shield",
+    "url": "shaders/energy-shield.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "A hexagonal energy grid that lights up and ripples upon mouse interaction.",
+    "params": [
+      {
+        "id": "hexScale",
+        "name": "Hex Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rippleSpeed",
+        "name": "Ripple Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "impactStrength",
+        "name": "Impact Strength",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.95,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "focal-pixelate",
+    "name": "Focal Pixelate",
+    "url": "shaders/focal-pixelate.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Applies pixelation that varies based on distance from the mouse cursor, creating a focal point effect.",
+    "params": [
+      {
+        "id": "pixel_strength",
+        "name": "Pixel Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "focus_radius",
+        "name": "Focus Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "focus_falloff",
+        "name": "Focus Softness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "invert",
+        "name": "Invert Focus",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "hex-mosaic",
+    "name": "Hexagon Mosaic",
+    "url": "shaders/hex-mosaic.wgsl",
+    "category": "interactive-mouse",
+    "description": "Hexagonal tiling effect that reveals the clear image around the mouse cursor. Bass audio reactivity boosts saturation.",
+    "params": [
+      {
+        "id": "scale",
+        "name": "Tile Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Reveal Radius",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hardness",
+        "name": "Edge Hardness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "saturation",
+        "name": "Sat Boost",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "hexagon",
+      "mosaic",
+      "interactive"
+    ]
+  },
+  {
+    "id": "interactive-glitch-brush",
+    "name": "Glitch Brush",
+    "url": "shaders/interactive-glitch-brush.wgsl",
+    "category": "interactive-mouse",
+    "description": "Paint digital glitches onto the screen with audio-reactive intensity.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Brush Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Glitch Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "block_scale",
+        "name": "Block Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color_split",
+        "name": "Color Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "glitch",
+      "audio-reactive"
+    ],
+    "tags": [
+      "glitch",
+      "interactive",
+      "brush",
+      "mouse-driven",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "interactive-magnetic-ripple",
+    "name": "Magnetic Ripple",
+    "url": "shaders/interactive-magnetic-ripple.wgsl",
+    "category": "interactive-mouse",
+    "description": "Magnetic field distortion with curl-noise field lines, all 50 ripple point accumulation, FBM domain warping, chromatic split, and glow-alpha at ripple peaks.",
+    "params": [
+      {
+        "id": "ripple_freq",
+        "name": "Ripple Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ripple_decay",
+        "name": "Ripple Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "field_strength",
+        "name": "Field Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chromatic_split",
+        "name": "Chromatic Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion",
+      "audio-reactive",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "fbm",
+      "curl-noise",
+      "worley",
+      "domain-warp",
+      "fractal",
+      "magnetic",
+      "field-lines"
+    ]
+  },
+  {
+    "id": "kaleido-portal-interactive",
+    "url": "shaders/kaleido-portal-interactive.wgsl",
+    "category": "interactive-mouse",
+    "icon": "circle",
+    "description": "A circular portal that reveals a kaleidoscopic view of the video, controlled by the mouse.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "x",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "y",
+        "name": "Segments",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "z",
+        "name": "Rotation",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "w",
+        "name": "Hardness",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Kaleido Portal"
+  },
+  {
+    "id": "kimi-chromatic-warp",
+    "name": "Kimi Chromatic Warp",
+    "url": "shaders/kimi_chromatic_warp.wgsl",
+    "category": "interactive-mouse",
+    "description": "RGB channel separation and prismatic distortion effects that intensify near the cursor with swirling motion.",
+    "features": [
+      "mouse-driven",
+      "interactive",
+      "chromatic",
+      "prism",
+      "warp"
+    ],
+    "params": [
+      {
+        "id": "warpRadius",
+        "name": "Warp Radius",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "step": 0.01
+      },
+      {
+        "id": "warpStrength",
+        "name": "Warp Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01
+      },
+      {
+        "id": "chromaticSpread",
+        "name": "RGB Spread",
+        "min": 0,
+        "max": 1,
+        "default": 0.4,
+        "step": 0.01
+      },
+      {
+        "id": "rotationSpeed",
+        "name": "Twist Speed",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
     ]
   },
   {
@@ -2948,99 +1338,58 @@
     ]
   },
   {
-    "id": "mouse-wormhole-lens",
-    "name": "Wormhole Lens",
-    "url": "shaders/mouse-wormhole-lens.wgsl",
+    "id": "kimi-spotlight",
+    "name": "Kimi Spotlight",
+    "url": "shaders/kimi_spotlight.wgsl",
     "category": "interactive-mouse",
+    "description": "Flashlight effect that reveals full color under the beam while surroundings are desaturated and darkened. Audio-reactive spotlight size pulses with bass.",
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "interactive",
+      "spotlight",
+      "reveal",
+      "audio-reactive"
     ],
-    "description": "A wormhole portal at the mouse position inverts, spirals, and color-shifts the image inside. Dragging stretches the portal. Event-horizon glow and gravitational lensing at the edge.",
     "params": [
       {
-        "id": "portalRadius",
-        "name": "Portal Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "spiralStrength",
-        "name": "Spiral Strength",
+        "id": "spotSize",
+        "name": "Spotlight Size",
+        "min": 0,
+        "max": 1,
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "step": 0.01
       },
       {
-        "id": "colorShiftAmt",
-        "name": "Color Shift",
+        "id": "spotSoftness",
+        "name": "Edge Softness",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "step": 0.01
+      },
+      {
+        "id": "edgeDarkness",
+        "name": "Edge Darkness",
+        "min": 0,
+        "max": 1,
+        "default": 0.7,
+        "step": 0.01
+      },
+      {
+        "id": "saturationBoost",
+        "name": "Color Boost",
+        "min": 0,
+        "max": 1,
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "lensStrength",
-        "name": "Lens Strength",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
+        "step": 0.01
       }
     ],
     "tags": [
+      "mouse-driven",
       "interactive",
-      "mouse-driven",
-      "portal",
-      "wormhole",
-      "psychedelic"
-    ]
-  },
-  {
-    "id": "mouse-time-crystal",
-    "name": "Time Crystal",
-    "url": "shaders/mouse-time-crystal.wgsl",
-    "category": "interactive-mouse",
-    "features": [
-      "mouse-driven",
-      "temporal"
-    ],
-    "description": "Mouse clicks seed crystal growth via diffusion-limited aggregation. Crystals grow along image gradients, aging and cooling over time. Creates organic mineral formations.",
-    "params": [
-      {
-        "id": "growthRate",
-        "name": "Growth Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "crystalDensity",
-        "name": "Crystal Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "ageColorSpeed",
-        "name": "Age Color Speed",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "crystal",
-      "temporal",
-      "growth",
-      "psychedelic"
+      "spotlight",
+      "reveal",
+      "audio-reactive"
     ]
   },
   {
@@ -3059,28 +1408,28 @@
         "name": "Sensitivity",
         "default": 0.5,
         "min": 0.1,
-        "max": 1.0
+        "max": 1
       },
       {
         "id": "param2",
         "name": "Scatter Amount",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "param3",
         "name": "Aberration",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "param4",
         "name": "Block Size",
         "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
@@ -3090,6 +1439,105 @@
       "dispersion",
       "glitch"
     ]
+  },
+  {
+    "id": "laser-burn",
+    "name": "Laser Burn",
+    "url": "shaders/laser-burn.wgsl",
+    "category": "interactive-mouse",
+    "description": "Interactive laser that burns the image permanently (or heals slowly).",
+    "params": [
+      {
+        "id": "beamSize",
+        "name": "Beam Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "burnSpeed",
+        "name": "Burn Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "healRate",
+        "name": "Heal Rate",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "heatMode",
+        "name": "Heat Glow",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "laser",
+      "burn",
+      "interactive",
+      "fire"
+    ]
+  },
+  {
+    "id": "liquid-time-warp",
+    "url": "shaders/liquid-time-warp.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "webcam"
+    ],
+    "description": "Fluid feedback loop where time is distorted by mouse movement.",
+    "params": [
+      {
+        "name": "Distortion",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "id": "distortion"
+      },
+      {
+        "name": "Flow Speed",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "id": "flow_speed"
+      },
+      {
+        "name": "Scale",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "id": "scale"
+      },
+      {
+        "name": "Decay",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1,
+        "id": "decay"
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Liquid Time Warp"
   },
   {
     "id": "liquid-touch",
@@ -3104,29 +1552,29 @@
         "id": "viscosity",
         "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "brush",
         "name": "Brush Size",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "refract",
         "name": "Refraction",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "tint",
         "name": "Tint",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
@@ -3135,39 +1583,175 @@
     ]
   },
   {
-    "id": "data-stream",
-    "name": "Digital Stream",
-    "url": "shaders/data-stream.wgsl",
+    "id": "liquid-warp",
+    "name": "Liquid Warp",
+    "url": "shaders/liquid-warp.wgsl",
     "category": "interactive-mouse",
-    "description": "Digital matrix-style data stream disrupted by mouse interaction. Audio-reactive bass pulses accelerate the flow.",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Fluid-like distortion where mouse movement pushes and swirls pixels.",
     "params": [
       {
-        "id": "speed",
-        "name": "Flow Speed",
+        "id": "radius",
+        "name": "Brush Radius",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "density",
-        "name": "Density",
+        "id": "strength",
+        "name": "Push Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "turbulence",
-        "name": "Turbulence",
+        "id": "decay",
+        "name": "Flow Decay",
+        "default": 0.9,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "swirl",
+        "name": "Swirl Factor",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "luma-echo-warp",
+    "category": "interactive-mouse",
+    "url": "shaders/luma-echo-warp.wgsl",
+    "description": "Distorts the image based on pixel brightness and mouse position, creating a warping echo effect.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Echo Decay",
         "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "glow",
-        "name": "Digital Glow",
+        "id": "param3",
+        "name": "Radius",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Luma Weight",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Luma Echo Warp"
+  },
+  {
+    "id": "luma-magnetism",
+    "url": "shaders/luma-magnetism.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "strength",
+        "name": "Magnet Strength",
+        "type": "float",
+        "default": 0.5,
+        "min": -1,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Effect Radius",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "hardness",
+        "name": "Edge Hardness",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Luma Threshold",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "description": "Bright pixels are magnetically attracted to the mouse cursor.",
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Luma Magnetism"
+  },
+  {
+    "id": "luma-slice-interactive",
+    "name": "Luma Slice Interactive",
+    "url": "shaders/luma-slice-interactive.wgsl",
+    "category": "interactive-mouse",
+    "description": "Slices the image horizontally, displacing strips based on their luminance and mouse position. Audio-reactive intensity via bass.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Displace Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "slices",
+        "name": "Slice Density",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1
+      },
+      {
+        "id": "rgb_shift",
+        "name": "RGB Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "phase",
+        "name": "Phase Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -3176,14 +1760,336 @@
       "audio-reactive"
     ],
     "tags": [
-      "digital",
-      "matrix",
-      "green",
-      "data",
-      "stream",
-      "glitch",
+      "filter",
+      "image-processing",
       "interactive",
-      "audio-reactive"
+      "slice",
+      "luma"
+    ]
+  },
+  {
+    "id": "magnetic-edge",
+    "url": "shaders/magnetic-edge.wgsl",
+    "icon": "edgesensor_high",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Pull Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Edge Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Glow",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "category": "interactive-mouse",
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Magnetic Edge"
+  },
+  {
+    "id": "mirror-drag",
+    "name": "Mirror Drag",
+    "url": "shaders/mirror-drag.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Mirrors the image across an axis defined by the mouse position.",
+    "params": [
+      {
+        "id": "side",
+        "name": "Flip Side",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "flipY",
+        "name": "Mirror Y",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "smoothness",
+        "name": "Edge Smoothness",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mode",
+        "name": "Mode",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "motion-revealer",
+    "name": "Motion Revealer",
+    "url": "shaders/motion-revealer.wgsl",
+    "category": "interactive-mouse",
+    "description": "The screen is dark by default; use the mouse as a brush to paint the live video feed onto the canvas with trailing fades.",
+    "params": [
+      {
+        "id": "size",
+        "name": "Brush Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fade",
+        "name": "Fade Speed",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "softness",
+        "name": "Edge Softness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "opacity",
+        "name": "Brush Opacity",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence"
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "mouse-chromatic-explosion",
+    "name": "Chromatic Explosion",
+    "url": "shaders/mouse-chromatic-explosion.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "description": "The mouse acts as a prism separating R, G, B channels by wavelength. Click ripples launch chromatic shockwaves. Creates rainbow halos and spectral fan-outs.",
+    "params": [
+      {
+        "id": "prismStrength",
+        "name": "Prism Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dispersion",
+        "name": "Dispersion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rippleStrength",
+        "name": "Ripple Chromatics",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "saturationBoost",
+        "name": "Saturation Boost",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "chromatic",
+      "prism",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-electromagnetic-aurora",
+    "name": "Electromagnetic Aurora",
+    "url": "shaders/mouse-electromagnetic-aurora.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "multi-pass-1"
+    ],
+    "description": "The mouse acts as a moving electric charge generating flowing EM field lines that distort UVs and rotate hue. Click ripples spawn orbiting opposite-polarity charges.",
+    "params": [
+      {
+        "id": "chargeStrength",
+        "name": "Charge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fieldVis",
+        "name": "Field Visibility",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortionStrength",
+        "name": "Distortion Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorRotation",
+        "name": "Color Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "field-simulation",
+      "chromatic",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-fluid-coupling",
+    "name": "Fluid Coupling",
+    "url": "shaders/mouse-fluid-coupling.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "temporal"
+    ],
+    "description": "The mouse drags a viscous fluid over the image, creating vortex streets and color absorption. Click ripples inject fluid bursts.",
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mouseRadius",
+        "name": "Stir Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Absorption",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "vortexStrength",
+        "name": "Vortex Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "fluid-simulation",
+      "temporal",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-hyperbolic-navigator",
+    "name": "Hyperbolic Navigator",
+    "url": "shaders/mouse-hyperbolic-navigator.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Navigate an infinitely tiling hyperbolic plane via Möbius transformations driven by mouse position. The image maps onto a Poincaré disk with tiles shrinking toward the boundary.",
+    "params": [
+      {
+        "id": "navigationSpeed",
+        "name": "Navigation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "tileCount",
+        "name": "Tiling Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edgeGlow",
+        "name": "Boundary Glow",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "zoomFactor",
+        "name": "Zoom",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "geometric",
+      "hyperbolic",
+      "infinite",
+      "psychedelic"
     ]
   },
   {
@@ -3200,29 +2106,29 @@
         "id": "zoom",
         "name": "Zoom",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "maxIter",
         "name": "Iteration Depth",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "morphSpeed",
         "name": "Auto Morph Speed",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "rippleInfluence",
         "name": "Ripple Blend",
         "default": 0.7,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
@@ -3234,300 +2140,677 @@
     ]
   },
   {
-    "id": "kimi-chromatic-warp",
-    "name": "Kimi Chromatic Warp",
-    "url": "shaders/kimi_chromatic_warp.wgsl",
+    "id": "mouse-kaleidoscope-tunnel",
+    "name": "Kaleidoscope Tunnel",
+    "url": "shaders/mouse-kaleidoscope-tunnel.wgsl",
     "category": "interactive-mouse",
-    "description": "RGB channel separation and prismatic distortion effects that intensify near the cursor with swirling motion.",
-    "features": [
-      "mouse-driven",
-      "interactive",
-      "chromatic",
-      "prism",
-      "warp"
-    ],
-    "params": [
-      {
-        "id": "warpRadius",
-        "name": "Warp Radius",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "step": 0.01
-      },
-      {
-        "id": "warpStrength",
-        "name": "Warp Strength",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "step": 0.01
-      },
-      {
-        "id": "chromaticSpread",
-        "name": "RGB Spread",
-        "min": 0,
-        "max": 1,
-        "default": 0.4,
-        "step": 0.01
-      },
-      {
-        "id": "rotationSpeed",
-        "name": "Twist Speed",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "directional-glitch",
-    "name": "Directional Glitch",
-    "url": "shaders/directional-glitch.wgsl",
-    "category": "interactive-mouse",
-    "description": "Glitch artifacts radiate from the mouse position with audio-reactive displacement.",
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Glitch strength"
-      },
-      {
-        "id": "radius",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Radius of glitch effect"
-      },
-      {
-        "id": "scatter",
-        "name": "Scatter",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Scatter and noise amount"
-      },
-      {
-        "id": "angle_bias",
-        "name": "Angle Bias",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Directional rotation bias"
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "glitch",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "glitch",
-      "interactive",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "circuit-breaker",
-    "name": "Circuit Breaker",
-    "url": "shaders/circuit-breaker.wgsl",
-    "category": "interactive-mouse",
-    "description": "Transforms image into a circuit board. Mouse interaction overloads the circuits.",
     "features": [
       "mouse-driven"
     ],
+    "description": "Infinite kaleidoscope tunnel centered on the mouse. Moving creates spiraling mirrors with perspective depth. Click ripples send kaleidoscope bursts through the tunnel.",
     "params": [
       {
-        "name": "Grid Scale",
-        "id": "scale",
+        "id": "tunnelSpeed",
+        "name": "Tunnel Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "name": "Overload",
-        "id": "intensity",
+        "id": "segmentBase",
+        "name": "Mirror Count",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "name": "Jitter",
-        "id": "jitter",
+        "id": "spiralTwist",
+        "name": "Spiral Twist",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "name": "Edge Threshold",
+        "id": "zoomDepth",
+        "name": "Tunnel Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "kaleidoscope",
+      "tunnel",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-magnetic-pixel-sand",
+    "name": "Magnetic Pixel Sand",
+    "url": "shaders/mouse-magnetic-pixel-sand.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Pixels behave as iron filings attracted or repelled by the mouse magnet based on their brightness. Creates flowing metallic grain patterns with ripple magnetic pulses.",
+    "params": [
+      {
+        "id": "magnetStrength",
+        "name": "Magnet Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "magneticRange",
+        "name": "Field Range",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "polarity",
+        "name": "Polarity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "grainSize",
+        "name": "Grain Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "magnetic",
+      "particles",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-mandelbrot-zoom-portal",
+    "name": "Mandelbrot Zoom Portal",
+    "url": "shaders/mouse-mandelbrot-zoom-portal.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "raymarched"
+    ],
+    "description": "Navigate the infinite Mandelbrot set with mouse position. Click to create nested zoom portals that reveal deeper fractal levels.",
+    "params": [
+      {
+        "id": "zoomLevel",
+        "name": "Zoom Level",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "maxIter",
+        "name": "Iteration Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "paletteSpeed",
+        "name": "Palette Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "portalBlend",
+        "name": "Portal Blend",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "fractal",
+      "psychedelic",
+      "zoom"
+    ]
+  },
+  {
+    "id": "mouse-neural-dreamscape",
+    "name": "Neural Dreamscape",
+    "url": "shaders/mouse-neural-dreamscape.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "temporal"
+    ],
+    "description": "A virtual neural network grid activates around the mouse. Neurons glow and synapse connections pulse with activation. Click ripples send waves through the network.",
+    "params": [
+      {
+        "id": "networkDensity",
+        "name": "Network Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "activationRadius",
+        "name": "Activation Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulseSpeed",
+        "name": "Pulse Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "synapseStrength",
+        "name": "Synapse Strength",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "neural",
+      "network",
+      "psychedelic",
+      "generative"
+    ]
+  },
+  {
+    "id": "mouse-paint-splatter",
+    "name": "Paint Splatter",
+    "url": "shaders/mouse-paint-splatter.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "temporal"
+    ],
+    "description": "Mouse drags leave colorful paint splatters sampled from the image. Paint spreads, mixes, and dries over time. Click ripples create explosive paint bursts.",
+    "params": [
+      {
+        "id": "splatterSize",
+        "name": "Brush Size",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dryRate",
+        "name": "Dry Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spreadAmount",
+        "name": "Paint Spread",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorIntensity",
+        "name": "Color Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "paint",
+      "temporal",
+      "artistic"
+    ]
+  },
+  {
+    "id": "mouse-polarized-light-field",
+    "name": "Polarized Light Field",
+    "url": "shaders/mouse-polarized-light-field.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Mouse controls polarization angle and birefringence over the image. Creates interference fringes, Malus-law filtering, and moiré patterns. Click ripples spawn polarization vortices.",
+    "params": [
+      {
+        "id": "polarizationAngle",
+        "name": "Polarization Angle",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "birefringence",
+        "name": "Birefringence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fringeDensity",
+        "name": "Fringe Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorMode",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "polarization",
+      "interference",
+      "optics",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-synesthetic-sound-paint",
+    "name": "Synesthetic Sound Paint",
+    "url": "shaders/mouse-synesthetic-sound-paint.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "temporal"
+    ],
+    "description": "Mouse becomes a conductor directing a visual orchestra. Screen regions map to bass blobs, mid waves, and treble sparkles. Without audio, falls back to mouse-driven generative color synthesis.",
+    "params": [
+      {
+        "id": "audioSensitivity",
+        "name": "Audio Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "patternScale",
+        "name": "Pattern Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "energyDecay",
+        "name": "Energy Decay",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShiftSpeed",
+        "name": "Color Shift Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "audio-reactive",
+      "synesthesia",
+      "generative",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-time-crystal",
+    "name": "Time Crystal",
+    "url": "shaders/mouse-time-crystal.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "temporal"
+    ],
+    "description": "Mouse clicks seed crystal growth via diffusion-limited aggregation. Crystals grow along image gradients, aging and cooling over time. Creates organic mineral formations.",
+    "params": [
+      {
+        "id": "growthRate",
+        "name": "Growth Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "crystalDensity",
+        "name": "Crystal Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "ageColorSpeed",
+        "name": "Age Color Speed",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "crystal",
+      "temporal",
+      "growth",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "mouse-voronoi-mosaic",
+    "name": "Voronoi Mosaic",
+    "url": "shaders/mouse-voronoi-mosaic.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Click positions seed Voronoi cells that rotate, shift, and scale independently. Stained-glass edge effects with per-cell color tinting create an evolving mosaic.",
+    "params": [
+      {
+        "id": "shatterStrength",
+        "name": "Shatter Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edgeThickness",
+        "name": "Edge Thickness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glassOpacity",
+        "name": "Glass Opacity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "voronoi",
+      "mosaic",
+      "stained-glass"
+    ]
+  },
+  {
+    "id": "mouse-wormhole-lens",
+    "name": "Wormhole Lens",
+    "url": "shaders/mouse-wormhole-lens.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "A wormhole portal at the mouse position inverts, spirals, and color-shifts the image inside. Dragging stretches the portal. Event-horizon glow and gravitational lensing at the edge.",
+    "params": [
+      {
+        "id": "portalRadius",
+        "name": "Portal Radius",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spiralStrength",
+        "name": "Spiral Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShiftAmt",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "lensStrength",
+        "name": "Lens Strength",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "portal",
+      "wormhole",
+      "psychedelic"
+    ]
+  },
+  {
+    "id": "neon-edge-radar",
+    "name": "Neon Edge Radar",
+    "url": "shaders/neon-edge-radar.wgsl",
+    "category": "interactive-mouse",
+    "description": "A rotating radar scanner that highlights edges in neon colors as it passes, centered on the mouse.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Beam Speed",
+        "default": 1,
+        "min": 0.1,
+        "max": 5
+      },
+      {
+        "id": "width",
+        "name": "Beam Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
         "id": "threshold",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 0.5
+        "name": "Edge Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "intensity",
+        "name": "Neon Intensity",
+        "default": 2,
+        "min": 0,
+        "max": 5
       }
     ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ]
-  },
-  {
-    "id": "kaleido-portal-interactive",
-    "url": "shaders/kaleido-portal-interactive.wgsl",
-    "category": "interactive-mouse",
-    "icon": "circle",
-    "description": "A circular portal that reveals a kaleidoscopic view of the video, controlled by the mouse.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Segments",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "Rotation",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Hardness",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Kaleido Portal"
-  },
-  {
-    "id": "block-distort-interactive",
-    "url": "shaders/block-distort-interactive.wgsl",
-    "category": "interactive-mouse",
-    "icon": "grid",
-    "description": "Image is divided into blocks that are pushed away by the mouse, creating a pixelated distortion field.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "x",
-        "name": "Block Size",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "y",
-        "name": "Push Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "z",
-        "name": "RGB Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "w",
-        "name": "Radius",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "mouse-driven",
-      "interactive"
-    ],
-    "name": "Block Distort"
-  },
-  {
-    "id": "sonar-reveal",
-    "name": "Sonar Reveal",
-    "category": "interactive-mouse",
-    "url": "shaders/sonar-reveal.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
       "audio-driven"
     ],
-    "description": "Reveals the original image in a radius around the mouse, with a scanning radar ring. Reactive to audio.",
-    "params": [
-      {
-        "name": "Reveal Size",
-        "id": "size",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Ring Intensity",
-        "id": "intensity",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Edge Softness",
-        "id": "softness",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Color Mode",
-        "id": "color",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
     "tags": [
-      "filter",
-      "image-processing",
+      "mouse-driven",
+      "interactive",
       "audio",
       "music",
       "reactive"
     ]
+  },
+  {
+    "id": "neon-ripple-split",
+    "name": "Neon Ripple Split",
+    "url": "shaders/neon-ripple-split.wgsl",
+    "category": "interactive-mouse",
+    "description": "A reactive ripple effect that separates RGB channels and adds a neon glow based on mouse movement and clicks.",
+    "params": [
+      {
+        "name": "Ripple Speed",
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "ripple_speed"
+      },
+      {
+        "name": "Color Split",
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "color_split"
+      },
+      {
+        "name": "Glow Intensity",
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "glow_intensity"
+      },
+      {
+        "name": "Frequency",
+        "type": "float",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "frequency"
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "paper-burn",
+    "name": "Paper Burn",
+    "url": "shaders/paper-burn.wgsl",
+    "category": "interactive-mouse",
+    "description": "Interactive paper burn effect that spreads from mouse cursor with realistic charring and ash.",
+    "features": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "pixel-explode",
+    "category": "interactive-mouse",
+    "url": "shaders/pixel-explode.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ],
+    "name": "Pixel Explode"
   },
   {
     "id": "pixel-focus",
@@ -3540,29 +2823,29 @@
         "id": "mosaicSize",
         "name": "Block Size",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "radius",
         "name": "Focus Radius",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "hardness",
         "name": "Edge Hardness",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "chromatic",
         "name": "Aberration",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "default": 0,
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -3580,105 +2863,202 @@
     ]
   },
   {
-    "id": "codebreaker-reveal",
+    "id": "pixel-repel",
     "category": "interactive-mouse",
-    "url": "shaders/codebreaker-reveal.wgsl",
+    "url": "shaders/pixel-repel.wgsl",
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Reveal Radius",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Repel Radius",
+        "default": 0.2,
+        "min": 0.05,
+        "max": 0.5
       },
       {
         "id": "param2",
-        "name": "Rain Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Repel Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
         "id": "param3",
-        "name": "Code Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "name": "Aberration",
+        "default": 0.05,
+        "min": 0,
+        "max": 0.2
       },
       {
         "id": "param4",
-        "name": "Glow Intensity",
+        "name": "Smoothing",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "name": "Pixel Repeller"
+  },
+  {
+    "id": "pixel-stretch-cross",
+    "name": "Pixel Stretch Cross",
+    "url": "shaders/pixel-stretch-cross.wgsl",
+    "category": "interactive-mouse",
+    "description": "Multi-direction pixel stretch using Fibonacci disk sampling, depth-aware attenuation, bass-driven magnitude, and effect-masked alpha transparency.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware",
+      "upgraded-rgba"
+    ],
+    "params": [
+      {
+        "id": "h_stretch",
+        "name": "H Stretch",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "v_stretch",
+        "name": "V Stretch",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "depth_influence",
+        "name": "Depth Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "fibonacci",
+      "depth-aware",
+      "stretch",
+      "distortion"
+    ]
+  },
+  {
+    "id": "polar-warp-interactive",
+    "name": "Polar Warp",
+    "url": "shaders/polar-warp-interactive.wgsl",
+    "category": "interactive-mouse",
+    "description": "Maps the image to polar coordinates centered on the mouse with bass-driven warp strength, spiral twist, click-triggered ripple bursts, and depth-aware fading.",
+    "features": [
+      "mouse-driven",
+      "upgraded-rgba",
+      "audio-reactive",
+      "depth-aware",
+      "multi-ripple"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Warp Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Spiral Amount",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Ripple Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Pinch/Expand",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "interactive",
+      "polar",
+      "warp",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "psychedelic-noise-flow",
+    "name": "Psychedelic Noise Flow",
+    "url": "shaders/psychedelic-noise-flow.wgsl",
+    "category": "interactive-mouse",
+    "description": "Applies a liquid-like noise flow where RGB channels are separated by phase, creating colorful swirls. Mouse controls flow speed and direction.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Flow Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scale",
+        "name": "Noise Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "separation",
+        "name": "Color Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
     ],
     "tags": [
       "mouse-driven",
       "interactive"
-    ],
-    "name": "Codebreaker Reveal"
-  },
-  {
-    "id": "crystal-illuminator",
-    "name": "Crystal Illuminator",
-    "url": "shaders/crystal-illuminator.wgsl",
-    "category": "interactive-mouse",
-    "description": "Faceted glass/gemstone surface with physical light transmission. Features Voronoi-based facets with mouse-controlled lighting, Fresnel reflection, and purity-based scattering for realistic crystal appearance.",
-    "features": [
-      "mouse-driven",
-      "alpha-transmission",
-      "physical-refraction"
-    ],
-    "params": [
-      {
-        "id": "crystal_size",
-        "name": "Crystal Size",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Size of Voronoi crystal facets"
-      },
-      {
-        "id": "ior",
-        "name": "Refractive Index",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "IOR: Quartz (1.54) to Diamond (2.42)"
-      },
-      {
-        "id": "light_intensity",
-        "name": "Light Intensity",
-        "type": "float",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Mouse light brightness"
-      },
-      {
-        "id": "purity",
-        "name": "Crystal Purity",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "description": "Crystal clarity: Pure transmits more, impure scatters more"
-      }
-    ],
-    "tags": [
-      "crystal",
-      "gemstone",
-      "transmission",
-      "fresnel",
-      "voronoi",
-      "physical",
-      "mouse-driven"
     ]
   },
   {
@@ -3692,29 +3072,29 @@
         "id": "radius",
         "name": "Field Radius",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "mosaic_size",
         "name": "Block Size",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "aberration",
         "name": "Aberration",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "chaos",
         "name": "Chaos",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -3731,60 +3111,680 @@
     ]
   },
   {
-    "id": "interactive_neural_swarm",
-    "name": "Neural Swarm",
-    "url": "shaders/interactive_neural_swarm.wgsl",
+    "id": "quantum-flux",
+    "name": "Quantum Flux",
+    "url": "shaders/quantum-flux.wgsl",
     "category": "interactive-mouse",
-    "description": "Agent-based neural network visualization with signal propagation, connection weights, and emergent activation patterns",
+    "description": "Simulates quantum instability and probability waves emanating from the mouse cursor, causing jitter and color drift.",
+    "params": [
+      {
+        "id": "jitter",
+        "name": "Flux Jitter",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "frequency",
+        "name": "Wave Freq",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "drift",
+        "name": "Color Drift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Flux Radius",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "distortion"
+    ],
     "tags": [
-      "neural",
-      "network",
-      "swarm",
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "quantum-tunnel-interactive",
+    "name": "Quantum Tunnel",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "tunnel_strength",
+        "name": "Tunnel Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulse_speed",
+        "name": "Pulse Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "twist",
+        "name": "Twist",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "url": "shaders/quantum-tunnel-interactive.wgsl",
+    "description": "Interactive radial distortion with chromatic aberration, pulsing effects, and audio-reactive glow.",
+    "tags": [
+      "filter",
+      "image-processing",
+      "distortion",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "reality-tear",
+    "name": "Reality Tear",
+    "url": "shaders/reality-tear.wgsl",
+    "category": "interactive-mouse",
+    "description": "Rips a hole in the image to reveal a static void underneath.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "name": "Tear Size",
+        "id": "size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Jaggedness",
+        "id": "jagged",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Burn Edge",
+        "id": "border",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Static Noise",
+        "id": "static",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive"
+    ]
+  },
+  {
+    "id": "scan-slice",
+    "name": "Scan Slice",
+    "url": "shaders/scan-slice.wgsl",
+    "category": "interactive-mouse",
+    "description": "Mouse X selects a vertical slice; Mouse Y offsets it with chromatic aberration. Audio-reactive edge glow pulses to bass.",
+    "params": [
+      {
+        "id": "width",
+        "name": "Slice Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "offset_scale",
+        "name": "Offset Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Aberration",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "dimming",
+        "name": "Bg Dimming",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "slice",
+      "chromatic",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "scanline-wave",
+    "name": "Scanline Wave",
+    "url": "shaders/scanline-wave.wgsl",
+    "category": "interactive-mouse",
+    "features": [
+      "mouse-driven",
+      "upgraded-rgba",
+      "depth-aware",
+      "audio-reactive"
+    ],
+    "description": "Sine-wave horizontal scanline distortion with HDR bloom, atmospheric depth fog, and warm highlight grading. Mouse modulates wave intensity by vertical proximity.",
+    "params": [
+      {
+        "id": "frequency",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amplitude",
+        "name": "Amplitude",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mouse_influence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "mouse-driven",
       "interactive",
-      "neon",
-      "biological"
+      "distortion",
+      "scanlines",
+      "hdr",
+      "bloom",
+      "atmospheric"
+    ]
+  },
+  {
+    "id": "sonar-pulse",
+    "name": "Sonar Pulse",
+    "url": "shaders/sonar-pulse.wgsl",
+    "category": "interactive-mouse",
+    "description": "Radial sonar waves emitting from the cursor that distort and scan the image. Now with audio reactivity.",
+    "params": [
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "freq",
+        "name": "Frequency",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "width",
+        "name": "Wave Width",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "sonar",
+      "pulse",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "sonar-reveal",
+    "name": "Sonar Reveal",
+    "category": "interactive-mouse",
+    "url": "shaders/sonar-reveal.wgsl",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "description": "Reveals the original image in a radius around the mouse, with a scanning radar ring. Reactive to audio.",
+    "params": [
+      {
+        "name": "Reveal Size",
+        "id": "size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Ring Intensity",
+        "id": "intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Edge Softness",
+        "id": "softness",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Color Mode",
+        "id": "color",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "spectral-distortion",
+    "name": "Spectral Distortion",
+    "url": "shaders/spectral-distortion.wgsl",
+    "category": "interactive-mouse",
+    "description": "RGB channels split and warp based on noise, mouse proximity, and bass-driven audio reactivity.",
+    "params": [
+      {
+        "id": "separation",
+        "name": "RGB Separation",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "warpScale",
+        "name": "Warp Scale",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "mouseInfluence",
+        "name": "Mouse Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Speed",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal-persistence",
+      "glitch",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "chromatic",
+      "warp",
+      "noise"
+    ]
+  },
+  {
+    "id": "spectral-waves",
+    "name": "Luma Ripple",
+    "url": "shaders/spectral-waves.wgsl",
+    "category": "interactive-mouse",
+    "description": "Luminance-reactive waves ripple out from the mouse cursor, displacing the image with chromatic aberration. Audio bass boosts wave amplitude.",
+    "params": [
+      {
+        "id": "frequency",
+        "name": "Ripple Freq",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "amplitude",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "aberration",
+        "name": "Chromatic Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
     ],
     "features": [
       "mouse-driven",
       "audio-reactive",
-      "agent-based",
-      "signal-propagation",
-      "neon"
+      "image"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "ripple",
+      "chromatic",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "stereoscopic-3d",
+    "name": "Stereoscopic 3D",
+    "url": "shaders/stereoscopic-3d.wgsl",
+    "category": "interactive-mouse",
+    "description": "Interactive Anaglyph 3D effect. Mouse movement controls separation depth and focal plane distortion. Audio bass adds separation pulse.",
+    "params": [
+      {
+        "id": "separation",
+        "name": "Max Separation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "focus",
+        "name": "Focus Offset",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitch Jitter",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rotation",
+        "name": "Lens Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive",
+      "audio-reactive",
+      "anaglyph",
+      "3d"
+    ]
+  },
+  {
+    "id": "velocity-field-paint",
+    "category": "interactive-mouse",
+    "url": "shaders/velocity-field-paint.wgsl",
+    "description": "Uses mouse movement to paint a velocity field that distorts the image like fluid.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven",
+      "temporal"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Connection Threshold",
-        "default": 0.3,
+        "name": "Dissipation",
+        "default": 0.9,
         "min": 0,
-        "max": 1,
-        "step": 0.1
+        "max": 1
       },
       {
         "id": "param2",
-        "name": "Signal Speed",
+        "name": "Brush Size",
         "default": 0.5,
         "min": 0,
-        "max": 1,
-        "step": 0.1
+        "max": 1
       },
       {
         "id": "param3",
-        "name": "Glow Radius",
-        "default": 0.3,
+        "name": "Force",
+        "default": 0.5,
         "min": 0,
-        "max": 1,
-        "step": 0.1
+        "max": 1
       },
       {
         "id": "param4",
-        "name": "Network Density",
-        "default": 0.5,
+        "name": "Audio Reactivity",
+        "default": 0,
         "min": 0,
-        "max": 1,
-        "step": 0.1
+        "max": 1
       }
     ],
-    "target_rating": 4.8
+    "tags": [
+      "mouse-driven",
+      "interactive",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "name": "Velocity Field Paint"
+  },
+  {
+    "id": "vertical-slice-wave",
+    "name": "Vertical Slice Wave",
+    "url": "shaders/vertical-slice-wave.wgsl",
+    "category": "interactive-mouse",
+    "description": "Splits the image into vertical strips that oscillate. Mouse X controls frequency, Mouse Y controls amplitude. Audio-reactive via bass modulation.",
+    "params": [
+      {
+        "id": "strips",
+        "name": "Strip Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Wave Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "split",
+        "name": "RGB Split",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "jitter",
+        "name": "Jitter",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "mouse-driven",
+      "interactive",
+      "audio-reactive",
+      "distortion"
+    ]
+  },
+  {
+    "id": "vhs-tracking-mouse",
+    "name": "VHS Tracking",
+    "category": "interactive-mouse",
+    "url": "shaders/vhs-tracking-mouse.wgsl",
+    "description": "A vertical tracking bar distortion controlled by mouse height with audio-reactive intensity.",
+    "params": [
+      {
+        "id": "barHeight",
+        "name": "Bar Height",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion",
+        "name": "Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noise",
+        "name": "Static Noise",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Split",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "vhs",
+      "glitch",
+      "retro"
+    ]
+  },
+  {
+    "id": "volumetric-god-rays",
+    "name": "Volumetric God Rays",
+    "url": "shaders/volumetric-god-rays.wgsl",
+    "category": "interactive-mouse",
+    "description": "Generates volumetric light rays emanating from the mouse position, using image highlights as the source. Audio-reactive weight modulation enhances the rays with bass frequencies.",
+    "params": [
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Decay",
+        "default": 0.95,
+        "min": 0.8,
+        "max": 1
+      },
+      {
+        "id": "weight",
+        "name": "Weight",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "exposure",
+        "name": "Exposure",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "lighting",
+      "rays",
+      "volumetric"
+    ]
   }
 ]

--- a/public/shader-lists/lighting-effects.json
+++ b/public/shader-lists/lighting-effects.json
@@ -1,56 +1,224 @@
 [
   {
-    "id": "aurora-rift-pass2",
-    "name": "Aurora Rift (Pass 2: Atmospheric Scattering)",
-    "url": "shaders/aurora-rift-pass2.wgsl",
+    "id": "atmos_volumetric_fog",
+    "name": "Volumetric Fog",
+    "url": "shaders/atmos_volumetric_fog.wgsl",
     "category": "lighting-effects",
-    "description": "Atmospheric scattering, color grading, and tone mapping. Second pass of 2-pass system.",
-    "features": [
-      "multi-pass-2",
-      "compute-shader",
-      "post-processing",
-      "tone-mapping"
-    ],
-    "multipass": {
-      "pass": 2,
-      "totalPasses": 2,
-      "prevShader": "aurora-rift-pass1"
-    },
+    "description": "Volumetric fog with ray marching, Mie/Rayleigh scattering, height-based density, god rays, and mouse-controlled light source",
     "tags": [
-      "aurora",
+      "volumetric",
+      "fog",
+      "god-rays",
       "scattering",
-      "grading",
-      "post-processing"
+      "atmosphere"
+    ],
+    "features": [
+      "ray-marching",
+      "mouse-control",
+      "audio-reactive",
+      "temporal"
     ],
     "params": [
       {
         "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
+        "name": "Fog Density",
+        "default": 0.3,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.1
       },
       {
         "id": "param2",
-        "name": "Speed",
+        "name": "Light Intensity",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.1
       },
       {
         "id": "param3",
-        "name": "Scale",
+        "name": "Scattering",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "God Rays",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
+    "id": "gen-velocity-bloom",
+    "name": "Velocity Bloom",
+    "url": "shaders/gen-velocity-bloom.wgsl",
+    "category": "lighting-effects",
+    "description": "Velocity-sensitive bloom effect that intensifies on motion, creating multi-octave glow with white core and colored aura based on velocity",
+    "tags": [
+      "temporal",
+      "bloom",
+      "velocity",
+      "motion",
+      "glow",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "temporal",
+      "motion-aware",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "threshold",
+        "name": "Velocity Threshold",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "intensity",
+        "name": "Bloom Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "radius",
+        "name": "Bloom Radius",
         "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param4",
-        "name": "Detail",
+        "id": "decay",
+        "name": "Decay Rate",
+        "default": 0.85,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "holographic_interference",
+    "name": "Holographic Interference",
+    "url": "shaders/holographic_interference.wgsl",
+    "category": "lighting-effects",
+    "description": "Holographic rainbow patterns with interference fringes, multi-layer ghosting with staggered alpha, and wavelength-dependent diffraction",
+    "tags": [
+      "holographic",
+      "interference",
+      "rainbow",
+      "ghosting",
+      "diffraction"
+    ],
+    "features": [
+      "rgba",
+      "interference",
+      "diffraction",
+      "hologram",
+      "rainbow"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Layers",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Rainbow Spread",
         "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Coherence",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Ghost Offset",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "alpha-aurora-bands",
+    "name": "Alpha Aurora Bands",
+    "url": "shaders/alpha-aurora-bands.wgsl",
+    "category": "lighting-effects",
+    "description": "Physically-motivated aurora borealis simulation with emission-line spectral decomposition. RGB stores oxygen green, oxygen red, and nitrogen blue emission intensities. Alpha tracks altitude layer index. Mouse controls solar wind direction; ripples trigger magnetic reconnection substorms.",
+    "tags": [
+      "aurora",
+      "borealis",
+      "lighting",
+      "spectral",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "atmospheric"
+    ],
+    "features": [
+      "mouse-driven",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Aurora Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "curtainFreq",
+        "name": "Curtain Frequency",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "speed",
+        "name": "Wind Speed",
+        "type": "float",
+        "default": 0.4,
         "min": 0,
         "max": 1,
         "step": 0.01
@@ -116,53 +284,61 @@
     ]
   },
   {
-    "id": "divine-light-gpt52",
-    "name": "Divine Light Cathedral gpt52",
-    "url": "shaders/divine-light-gpt52.wgsl",
+    "id": "aurora-rift-2-pass2",
+    "name": "Aurora Rift 2 (Pass 2: Enhanced Scattering)",
+    "url": "shaders/aurora-rift-2-pass2.wgsl",
     "category": "lighting-effects",
-    "description": "Expanded volumetric rays with dust motes and warm cinematic bloom.",
+    "description": "Enhanced atmospheric scattering with richer color grading. Second pass of 2-pass system.",
+    "features": [
+      "multi-pass-2",
+      "compute-shader",
+      "post-processing",
+      "tone-mapping"
+    ],
+    "multipass": {
+      "pass": 2,
+      "totalPasses": 2,
+      "prevShader": "aurora-rift-2-pass1"
+    },
+    "tags": [
+      "aurora",
+      "scattering",
+      "grading",
+      "enhanced"
+    ],
     "params": [
       {
-        "id": "intensity",
-        "name": "Ray Intensity",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Ray Decay",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "density",
-        "name": "Ray Density",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "threshold",
-        "name": "Brightness Filter",
-        "default": 0.45,
-        "min": 0.0,
-        "max": 1.0
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
       }
-    ],
-    "features": [
-      "mouse-driven",
-      "volumetric",
-      "atmospheric",
-      "audio-reactive"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "audio-reactive",
-      "god-rays",
-      "cinematic"
     ]
   },
   {
@@ -224,86 +400,11 @@
     ]
   },
   {
-    "id": "sim-volumetric-fake-em",
-    "name": "Volumetric Fake + EM Field",
-    "url": "shaders/sim-volumetric-fake-em.wgsl",
+    "id": "aurora-rift-pass2",
+    "name": "Aurora Rift (Pass 2: Atmospheric Scattering)",
+    "url": "shaders/aurora-rift-pass2.wgsl",
     "category": "lighting-effects",
-    "description": "God rays with mouse electromagnetic field distortion. Electric field bends light rays; magnetic field causes chromatic RGB separation. Click ripples spawn secondary light charges.",
-    "features": [
-      "simulation",
-      "fake-volumetrics",
-      "mouse-driven",
-      "electromagnetic",
-      "interactive",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "light_intensity",
-        "name": "Light Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Light source intensity and EM charge strength"
-      },
-      {
-        "id": "em_distortion",
-        "name": "EM Distortion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Electric field ray bending and dust density"
-      },
-      {
-        "id": "chromatic_split",
-        "name": "Chromatic Split",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Magnetic field RGB separation and scattering"
-      },
-      {
-        "id": "ripple_charge",
-        "name": "Ripple Charge",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Secondary charge strength from clicks and noise speed"
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "physics",
-      "volumetric",
-      "god-rays",
-      "electromagnetic"
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "noise",
-      "Radial blur",
-      "electricField (mouse-electromagnetic-aurora.wgsl)",
-      "magneticField (mouse-electromagnetic-aurora.wgsl)"
-    ],
-    "performance_target": "45-60 FPS (GTX 1060)",
-    "created_by": "Agent CB-4 - Mouse Physics Injector",
-    "created_date": "2026-04-18"
-  },
-  {
-    "id": "aurora-rift-2-pass2",
-    "name": "Aurora Rift 2 (Pass 2: Enhanced Scattering)",
-    "url": "shaders/aurora-rift-2-pass2.wgsl",
-    "category": "lighting-effects",
-    "description": "Enhanced atmospheric scattering with richer color grading. Second pass of 2-pass system.",
+    "description": "Atmospheric scattering, color grading, and tone mapping. Second pass of 2-pass system.",
     "features": [
       "multi-pass-2",
       "compute-shader",
@@ -313,13 +414,13 @@
     "multipass": {
       "pass": 2,
       "totalPasses": 2,
-      "prevShader": "aurora-rift-2-pass1"
+      "prevShader": "aurora-rift-pass1"
     },
     "tags": [
       "aurora",
       "scattering",
       "grading",
-      "enhanced"
+      "post-processing"
     ],
     "params": [
       {
@@ -355,6 +456,131 @@
         "step": 0.01
       }
     ]
+  },
+  {
+    "id": "divine-light-gpt52",
+    "name": "Divine Light Cathedral gpt52",
+    "url": "shaders/divine-light-gpt52.wgsl",
+    "category": "lighting-effects",
+    "description": "Expanded volumetric rays with dust motes and warm cinematic bloom.",
+    "params": [
+      {
+        "id": "intensity",
+        "name": "Ray Intensity",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Ray Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Ray Density",
+        "default": 0.6,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Brightness Filter",
+        "default": 0.45,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "volumetric",
+      "atmospheric",
+      "audio-reactive"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "audio-reactive",
+      "god-rays",
+      "cinematic"
+    ]
+  },
+  {
+    "id": "sim-volumetric-fake-em",
+    "name": "Volumetric Fake + EM Field",
+    "url": "shaders/sim-volumetric-fake-em.wgsl",
+    "category": "lighting-effects",
+    "description": "God rays with mouse electromagnetic field distortion. Electric field bends light rays; magnetic field causes chromatic RGB separation. Click ripples spawn secondary light charges.",
+    "features": [
+      "simulation",
+      "fake-volumetrics",
+      "mouse-driven",
+      "electromagnetic",
+      "interactive",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "light_intensity",
+        "name": "Light Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Light source intensity and EM charge strength"
+      },
+      {
+        "id": "em_distortion",
+        "name": "EM Distortion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Electric field ray bending and dust density"
+      },
+      {
+        "id": "chromatic_split",
+        "name": "Chromatic Split",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Magnetic field RGB separation and scattering"
+      },
+      {
+        "id": "ripple_charge",
+        "name": "Ripple Charge",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Secondary charge strength from clicks and noise speed"
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "physics",
+      "volumetric",
+      "god-rays",
+      "electromagnetic"
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "noise",
+      "Radial blur",
+      "electricField (mouse-electromagnetic-aurora.wgsl)",
+      "magneticField (mouse-electromagnetic-aurora.wgsl)"
+    ],
+    "performance_target": "45-60 FPS (GTX 1060)",
+    "created_by": "Agent CB-4 - Mouse Physics Injector",
+    "created_date": "2026-04-18"
   },
   {
     "id": "underwater_caustics",
@@ -413,65 +639,6 @@
     "target_rating": 4.7
   },
   {
-    "id": "alpha-aurora-bands",
-    "name": "Alpha Aurora Bands",
-    "url": "shaders/alpha-aurora-bands.wgsl",
-    "category": "lighting-effects",
-    "description": "Physically-motivated aurora borealis simulation with emission-line spectral decomposition. RGB stores oxygen green, oxygen red, and nitrogen blue emission intensities. Alpha tracks altitude layer index. Mouse controls solar wind direction; ripples trigger magnetic reconnection substorms.",
-    "tags": [
-      "aurora",
-      "borealis",
-      "lighting",
-      "spectral",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "atmospheric"
-    ],
-    "features": [
-      "mouse-driven",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "intensity",
-        "name": "Aurora Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "curtainFreq",
-        "name": "Curtain Frequency",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "speed",
-        "name": "Wind Speed",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
     "id": "sim-volumetric-fake",
     "name": "Volumetric Fake (God Rays)",
     "url": "shaders/sim-volumetric-fake.wgsl",
@@ -489,8 +656,8 @@
         "id": "light_intensity",
         "name": "Light Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Light source intensity"
@@ -499,8 +666,8 @@
         "id": "dust",
         "name": "Dust Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Dust particle density"
@@ -509,8 +676,8 @@
         "id": "scattering",
         "name": "Scattering",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "Scattering amount"
@@ -519,8 +686,8 @@
         "id": "noise_speed",
         "name": "Noise Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Dust movement speed"
@@ -535,172 +702,5 @@
     "performance_target": "60 FPS (GTX 1060)",
     "created_by": "Agent 3B - Advanced Hybrid Creator",
     "created_date": "2026-03-22"
-  },
-  {
-    "id": "gen-velocity-bloom",
-    "name": "Velocity Bloom",
-    "url": "shaders/gen-velocity-bloom.wgsl",
-    "category": "lighting-effects",
-    "description": "Velocity-sensitive bloom effect that intensifies on motion, creating multi-octave glow with white core and colored aura based on velocity",
-    "tags": [
-      "temporal",
-      "bloom",
-      "velocity",
-      "motion",
-      "glow",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "temporal",
-      "motion-aware",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "threshold",
-        "name": "Velocity Threshold",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "intensity",
-        "name": "Bloom Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "radius",
-        "name": "Bloom Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "decay",
-        "name": "Decay Rate",
-        "default": 0.85,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "atmos_volumetric_fog",
-    "name": "Volumetric Fog",
-    "url": "shaders/atmos_volumetric_fog.wgsl",
-    "category": "lighting-effects",
-    "description": "Volumetric fog with ray marching, Mie/Rayleigh scattering, height-based density, god rays, and mouse-controlled light source",
-    "tags": [
-      "volumetric",
-      "fog",
-      "god-rays",
-      "scattering",
-      "atmosphere"
-    ],
-    "features": [
-      "ray-marching",
-      "mouse-control",
-      "audio-reactive",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Fog Density",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Light Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Scattering",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "God Rays",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.7
-  },
-  {
-    "id": "holographic_interference",
-    "name": "Holographic Interference",
-    "url": "shaders/holographic_interference.wgsl",
-    "category": "lighting-effects",
-    "description": "Holographic rainbow patterns with interference fringes, multi-layer ghosting with staggered alpha, and wavelength-dependent diffraction",
-    "tags": [
-      "holographic",
-      "interference",
-      "rainbow",
-      "ghosting",
-      "diffraction"
-    ],
-    "features": [
-      "rgba",
-      "interference",
-      "diffraction",
-      "hologram",
-      "rainbow"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Layers",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Rainbow Spread",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Coherence",
-        "default": 0.7,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Ghost Offset",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.6
   }
 ]

--- a/public/shader-lists/liquid-effects.json
+++ b/public/shader-lists/liquid-effects.json
@@ -1,5 +1,63 @@
 [
   {
+    "id": "ink_dispersion_alpha",
+    "name": "Ink Dispersion RGBA",
+    "url": "shaders/ink_dispersion_alpha.wgsl",
+    "category": "liquid-effects",
+    "description": "Ink in water simulation with Navier-Stokes velocity field. Alpha = ink density/concentration. Multiple colors, chemical reactions.",
+    "tags": [
+      "ink",
+      "fluid",
+      "dispersion",
+      "chemical",
+      "curl",
+      "water"
+    ],
+    "features": [
+      "rgba",
+      "fluid-sim",
+      "curl-noise",
+      "advection",
+      "alpha-density",
+      "mouse-spawn"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Diffusion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Reaction",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.7
+  },
+  {
     "id": "liquid_magnetic_ferro",
     "name": "Magnetic Ferrofluid",
     "url": "shaders/liquid_magnetic_ferro.wgsl",
@@ -53,154 +111,6 @@
       }
     ],
     "target_rating": 4.7
-  },
-  {
-    "id": "liquid-optimized",
-    "name": "Liquid Surface Tension (Optimized)",
-    "url": "shaders/liquid-optimized.wgsl",
-    "category": "liquid-effects",
-    "description": "Surface tension liquid simulation with shared memory optimization. Uses workgroup-local caching to reduce texture fetches by 80% for 8-10x performance improvement. Audio reactivity drives ambient wave amplitude and virtual ripple sources.",
-    "tags": [
-      "liquid",
-      "surface-tension",
-      "capillary-waves",
-      "optimized",
-      "shared-memory",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "surfaceTension",
-        "name": "Surface Tension",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "gravityScale",
-        "name": "Gravity Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbidity",
-        "name": "Turbidity",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "viscous-drag",
-    "name": "Viscous Drag",
-    "url": "shaders/viscous-drag.wgsl",
-    "category": "liquid-effects",
-    "description": "The screen becomes a thick, viscous fluid that ripples and deforms under your touch.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.6
-      },
-      {
-        "id": "drag-strength",
-        "name": "Push Strength",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "id": "recovery-speed",
-        "name": "Flow Memory",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.95
-      },
-      {
-        "id": "distortion-scale",
-        "name": "Warp Amount",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      }
-    ],
-    "tags": [
-      "fluid",
-      "liquid",
-      "water"
-    ]
-  },
-  {
-    "id": "luma-melt-interactive",
-    "url": "shaders/luma-melt-interactive.wgsl",
-    "category": "liquid-effects",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "speed",
-        "name": "Melt Speed",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "persistence",
-        "name": "Trails",
-        "type": "float",
-        "default": 0.9,
-        "min": 0.5,
-        "max": 0.99
-      },
-      {
-        "id": "radius",
-        "name": "Heat Radius",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "heat",
-        "name": "Heat Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "description": "Video melts downwards, accelerated by brightness and mouse heat.",
-    "tags": [
-      "fluid",
-      "liquid",
-      "water"
-    ],
-    "name": "Luma Melt"
   },
   {
     "id": "kimi-liquid-glass",
@@ -270,32 +180,32 @@
         "id": "viscosity",
         "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "pressure_iterations",
         "name": "Pressure Iterations",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "flow_speed",
         "name": "Flow Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "turbulence",
         "name": "Turbulence",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ],
@@ -314,62 +224,6 @@
       "eddy",
       "interactive",
       "physics"
-    ]
-  },
-  {
-    "id": "liquid-optimized-pass2",
-    "name": "Liquid Optimized (Pass 2)",
-    "url": "shaders/liquid-optimized-pass2.wgsl",
-    "category": "liquid-effects",
-    "description": "Fluid rendering pass: Fresnel reflection, Beer-Lambert absorption, specular highlights, and alpha blending. Reads physics state from dataTextureC.",
-    "tags": [
-      "liquid",
-      "fresnel",
-      "beer-lambert",
-      "multi-pass",
-      "rendering"
-    ],
-    "features": [
-      "multi-pass-2",
-      "mouse-driven"
-    ],
-    "multipass": {
-      "pass": 2,
-      "totalPasses": 2
-    },
-    "params": [
-      {
-        "id": "surfaceTension",
-        "name": "Surface Tension",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "gravityScale",
-        "name": "Gravity Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "damping",
-        "name": "Damping",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "turbidity",
-        "name": "Turbidity",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
     ]
   },
   {
@@ -399,92 +253,238 @@
         "id": "surfaceTension",
         "name": "Surface Tension",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "gravityScale",
         "name": "Gravity Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "damping",
         "name": "Damping",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
         "id": "turbidity",
         "name": "Turbidity",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "ink_dispersion_alpha",
-    "name": "Ink Dispersion RGBA",
-    "url": "shaders/ink_dispersion_alpha.wgsl",
+    "id": "liquid-optimized-pass2",
+    "name": "Liquid Optimized (Pass 2)",
+    "url": "shaders/liquid-optimized-pass2.wgsl",
     "category": "liquid-effects",
-    "description": "Ink in water simulation with Navier-Stokes velocity field. Alpha = ink density/concentration. Multiple colors, chemical reactions.",
+    "description": "Fluid rendering pass: Fresnel reflection, Beer-Lambert absorption, specular highlights, and alpha blending. Reads physics state from dataTextureC.",
     "tags": [
-      "ink",
-      "fluid",
-      "dispersion",
-      "chemical",
-      "curl",
-      "water"
+      "liquid",
+      "fresnel",
+      "beer-lambert",
+      "multi-pass",
+      "rendering"
     ],
     "features": [
-      "rgba",
-      "fluid-sim",
-      "curl-noise",
-      "advection",
-      "alpha-density",
-      "mouse-spawn"
+      "multi-pass-2",
+      "mouse-driven"
     ],
+    "multipass": {
+      "pass": 2,
+      "totalPasses": 2
+    },
     "params": [
       {
-        "id": "param1",
-        "name": "Diffusion",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Viscosity",
+        "id": "surfaceTension",
+        "name": "Surface Tension",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01
       },
       {
-        "id": "param3",
-        "name": "Intensity",
-        "default": 0.7,
+        "id": "gravityScale",
+        "name": "Gravity Scale",
+        "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.1
+        "step": 0.01
       },
       {
-        "id": "param4",
-        "name": "Reaction",
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbidity",
+        "name": "Turbidity",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "liquid-optimized",
+    "name": "Liquid Surface Tension (Optimized)",
+    "url": "shaders/liquid-optimized.wgsl",
+    "category": "liquid-effects",
+    "description": "Surface tension liquid simulation with shared memory optimization. Uses workgroup-local caching to reduce texture fetches by 80% for 8-10x performance improvement. Audio reactivity drives ambient wave amplitude and virtual ripple sources.",
+    "tags": [
+      "liquid",
+      "surface-tension",
+      "capillary-waves",
+      "optimized",
+      "shared-memory",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "surfaceTension",
+        "name": "Surface Tension",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "gravityScale",
+        "name": "Gravity Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbidity",
+        "name": "Turbidity",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "luma-melt-interactive",
+    "url": "shaders/luma-melt-interactive.wgsl",
+    "category": "liquid-effects",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "speed",
+        "name": "Melt Speed",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "persistence",
+        "name": "Trails",
+        "type": "float",
+        "default": 0.9,
+        "min": 0.5,
+        "max": 0.99
+      },
+      {
+        "id": "radius",
+        "name": "Heat Radius",
+        "type": "float",
         "default": 0.2,
         "min": 0,
-        "max": 1,
-        "step": 0.1
+        "max": 1
+      },
+      {
+        "id": "heat",
+        "name": "Heat Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
     ],
-    "target_rating": 4.7
+    "description": "Video melts downwards, accelerated by brightness and mouse heat.",
+    "tags": [
+      "fluid",
+      "liquid",
+      "water"
+    ],
+    "name": "Luma Melt"
+  },
+  {
+    "id": "viscous-drag",
+    "name": "Viscous Drag",
+    "url": "shaders/viscous-drag.wgsl",
+    "category": "liquid-effects",
+    "description": "The screen becomes a thick, viscous fluid that ripples and deforms under your touch.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "min": 0,
+        "max": 1,
+        "default": 0.6
+      },
+      {
+        "id": "drag-strength",
+        "name": "Push Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "id": "recovery-speed",
+        "name": "Flow Memory",
+        "min": 0,
+        "max": 1,
+        "default": 0.95
+      },
+      {
+        "id": "distortion-scale",
+        "name": "Warp Amount",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      }
+    ],
+    "tags": [
+      "fluid",
+      "liquid",
+      "water"
+    ]
   }
 ]

--- a/public/shader-lists/post-processing.json
+++ b/public/shader-lists/post-processing.json
@@ -1,5 +1,113 @@
 [
   {
+    "id": "luma-pixel-sort",
+    "name": "Luma Pixel Sort",
+    "url": "shaders/luma-pixel-sort.wgsl",
+    "category": "post-processing",
+    "description": "Fibonacci disk neighborhood pixel sorting with depth-aware blending, audio-reactive threshold modulation, and luminance-keyed alpha.",
+    "features": [
+      "upgraded-rgba",
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware"
+    ],
+    "tags": [
+      "stylized",
+      "artistic",
+      "glitch",
+      "pixel-sort",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Luma Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Sort Length",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Depth Blend",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Noise Mix",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "pixel-depth-sort",
+    "name": "Pixel Depth Sort",
+    "url": "shaders/pixel-depth-sort.wgsl",
+    "category": "post-processing",
+    "description": "Directional pixel sorting by depth with mouse-following sort angle, chromatic aberration at boundaries, bass-driven sort length, and depth-layered alpha.",
+    "features": [
+      "upgraded-rgba",
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware"
+    ],
+    "tags": [
+      "filter",
+      "depth-aware",
+      "pixel-sort",
+      "chromatic-aberration",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Depth Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Sort Length",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Sort Angle",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Aberration",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
     "id": "pp-bloom",
     "name": "PP Bloom",
     "url": "shaders/pp-bloom.wgsl",
@@ -86,258 +194,6 @@
     ]
   },
   {
-    "id": "pp-vignette",
-    "name": "PP Vignette",
-    "url": "shaders/pp-vignette.wgsl",
-    "category": "post-processing",
-    "description": "Film vignette with grain, sepia/warm/cool color grading, and retro scanline effects",
-    "tags": [
-      "post-process",
-      "vignette",
-      "grain",
-      "film",
-      "vintage"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Vignette",
-        "default": 0.4,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param2",
-        "name": "Grain",
-        "default": 0.2,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param3",
-        "name": "Color Style",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param4",
-        "name": "Effect",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      }
-    ]
-  },
-  {
-    "id": "pixel-depth-sort",
-    "name": "Pixel Depth Sort",
-    "url": "shaders/pixel-depth-sort.wgsl",
-    "category": "post-processing",
-    "description": "Directional pixel sorting by depth with mouse-following sort angle, chromatic aberration at boundaries, bass-driven sort length, and depth-layered alpha.",
-    "features": [
-      "upgraded-rgba",
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware"
-    ],
-    "tags": [
-      "filter",
-      "depth-aware",
-      "pixel-sort",
-      "chromatic-aberration",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Depth Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Sort Length",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Sort Angle",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Aberration",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "pp-tone-map",
-    "name": "PP Tone Map",
-    "url": "shaders/pp-tone-map.wgsl",
-    "category": "post-processing",
-    "description": "HDR to LDR tone mapping with ACES, Uncharted 2, Reinhard, and AgX algorithms. Includes exposure, contrast, and saturation controls.",
-    "tags": [
-      "post-process",
-      "tone-map",
-      "hdr",
-      "color-grading"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Algorithm",
-        "default": 0,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param2",
-        "name": "Exposure",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param3",
-        "name": "Contrast",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param4",
-        "name": "Saturation",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ]
-  },
-  {
-    "id": "luma-pixel-sort",
-    "name": "Luma Pixel Sort",
-    "url": "shaders/luma-pixel-sort.wgsl",
-    "category": "post-processing",
-    "description": "Fibonacci disk neighborhood pixel sorting with depth-aware blending, audio-reactive threshold modulation, and luminance-keyed alpha.",
-    "features": [
-      "upgraded-rgba",
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware"
-    ],
-    "tags": [
-      "stylized",
-      "artistic",
-      "glitch",
-      "pixel-sort",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Luma Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Sort Length",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Depth Blend",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Noise Mix",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "radial-blur",
-    "name": "Radial Blur",
-    "url": "shaders/radial-blur.wgsl",
-    "category": "post-processing",
-    "description": "Depth-aware radial blur with bokeh shape selection, chromatic aberration, Gaussian kernel weighting, and vignette.",
-    "params": [
-      {
-        "id": "sigma",
-        "name": "Blur Sigma",
-        "default": 0.3,
-        "min": 0.01,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "shape",
-        "name": "Bokeh Shape",
-        "default": 0,
-        "min": 0,
-        "max": 2,
-        "step": 1,
-        "labels": [
-          "Circle",
-          "Hexagon",
-          "Star"
-        ]
-      },
-      {
-        "id": "focalDepth",
-        "name": "Focal Depth",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "maxBlur",
-        "name": "Max Blur",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "depth-aware"
-    ],
-    "tags": [
-      "blur",
-      "bokeh",
-      "depth-of-field",
-      "post-processing",
-      "chromatic"
-    ]
-  },
-  {
     "id": "pp-sharpen",
     "name": "PP Sharpen",
     "url": "shaders/pp-sharpen.wgsl",
@@ -421,6 +277,150 @@
         "min": 0,
         "max": 1
       }
+    ]
+  },
+  {
+    "id": "pp-tone-map",
+    "name": "PP Tone Map",
+    "url": "shaders/pp-tone-map.wgsl",
+    "category": "post-processing",
+    "description": "HDR to LDR tone mapping with ACES, Uncharted 2, Reinhard, and AgX algorithms. Includes exposure, contrast, and saturation controls.",
+    "tags": [
+      "post-process",
+      "tone-map",
+      "hdr",
+      "color-grading"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Algorithm",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Exposure",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Saturation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "pp-vignette",
+    "name": "PP Vignette",
+    "url": "shaders/pp-vignette.wgsl",
+    "category": "post-processing",
+    "description": "Film vignette with grain, sepia/warm/cool color grading, and retro scanline effects",
+    "tags": [
+      "post-process",
+      "vignette",
+      "grain",
+      "film",
+      "vintage"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Vignette",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Grain",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Color Style",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param4",
+        "name": "Effect",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ]
+  },
+  {
+    "id": "radial-blur",
+    "name": "Radial Blur",
+    "url": "shaders/radial-blur.wgsl",
+    "category": "post-processing",
+    "description": "Depth-aware radial blur with bokeh shape selection, chromatic aberration, Gaussian kernel weighting, and vignette.",
+    "params": [
+      {
+        "id": "sigma",
+        "name": "Blur Sigma",
+        "default": 0.3,
+        "min": 0.01,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "shape",
+        "name": "Bokeh Shape",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "step": 1,
+        "labels": [
+          "Circle",
+          "Hexagon",
+          "Star"
+        ]
+      },
+      {
+        "id": "focalDepth",
+        "name": "Focal Depth",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "maxBlur",
+        "name": "Max Blur",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "depth-aware"
+    ],
+    "tags": [
+      "blur",
+      "bokeh",
+      "depth-of-field",
+      "post-processing",
+      "chromatic"
     ]
   }
 ]

--- a/public/shader-lists/retro-glitch.json
+++ b/public/shader-lists/retro-glitch.json
@@ -1,5 +1,176 @@
 [
   {
+    "id": "retro_phosphor_dream",
+    "name": "Phosphor Dream",
+    "url": "shaders/retro_phosphor_dream.wgsl",
+    "category": "retro-glitch",
+    "description": "Authentic CRT simulation with RGB phosphor triads, persistence afterglow, interlaced flicker, barrel distortion, and chromatic aberration",
+    "tags": [
+      "crt",
+      "retro",
+      "phosphor",
+      "analog",
+      "vintage"
+    ],
+    "features": [
+      "temporal-persistence",
+      "audio-reactive",
+      "phosphor-glow"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Curvature",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Phosphor Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Scanlines",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Flicker",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "scanline-tear",
+    "name": "Scanline Tear",
+    "url": "shaders/scanline-tear.wgsl",
+    "category": "retro-glitch",
+    "description": "Authentic analog video interlacing simulation with field-based temporal offset, HSync/VSync modeling, and VHS-style tracking errors.",
+    "params": [
+      {
+        "id": "interlaceStrength",
+        "name": "Interlace Strength",
+        "description": "Controls interlacing artifact intensity, field persistence, and combing on motion",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "hsyncError",
+        "name": "HSync Error",
+        "description": "Horizontal sync instability - creates rolling bars and horizontal displacement",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "vsyncError",
+        "name": "VSync Error",
+        "description": "Vertical sync roll - creates image rolling and retrace bars",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorBurstError",
+        "name": "Color Burst Error",
+        "description": "Chroma phase errors causing hue shifts and chroma noise",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "multi-pass",
+      "glitch",
+      "temporal"
+    ],
+    "tags": [
+      "interlacing",
+      "vhs",
+      "analog",
+      "retro",
+      "scanlines",
+      "sync-loss",
+      "tracking",
+      "video",
+      "ntsc"
+    ]
+  },
+  {
+    "id": "synthwave-grid-warp",
+    "name": "Synthwave Grid Warp",
+    "url": "shaders/synthwave-grid-warp.wgsl",
+    "category": "retro-glitch",
+    "description": "3D perspective-projected synthwave floor with atmospheric fog, sun, and mountain silhouettes.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "params": [
+      {
+        "id": "camY",
+        "name": "Camera Height",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x"
+      },
+      {
+        "id": "fogDensity",
+        "name": "Fog Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y"
+      },
+      {
+        "id": "fogFalloff",
+        "name": "Fog Falloff",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z"
+      },
+      {
+        "id": "mountainScale",
+        "name": "Mountain Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w"
+      }
+    ],
+    "tags": [
+      "retro",
+      "synthwave",
+      "3d",
+      "fog",
+      "atmospheric"
+    ]
+  },
+  {
     "id": "matrix_digital_rain",
     "name": "Matrix Digital Rain",
     "url": "shaders/matrix_digital_rain.wgsl",
@@ -55,6 +226,702 @@
       }
     ],
     "target_rating": 4.6
+  },
+  {
+    "id": "ascii-flow",
+    "category": "retro-glitch",
+    "url": "shaders/ascii-flow.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ],
+    "name": "ASCII Flow"
+  },
+  {
+    "id": "bayer-dither-interactive",
+    "name": "Bayer Dither Interactive",
+    "category": "retro-glitch",
+    "url": "shaders/bayer-dither-interactive.wgsl",
+    "description": "Applies an ordered 8x8 Bayer dithering effect with adjustable bit depth and pixelation scale.",
+    "features": [
+      "mouse-driven",
+      "retro-style"
+    ],
+    "params": [
+      {
+        "id": "bit_depth",
+        "name": "Bit Depth",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Effective bit depth of the dithered output"
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Contrast applied before dithering"
+      },
+      {
+        "id": "dither_spread",
+        "name": "Dither Spread",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Spread of the Bayer dither threshold"
+      },
+      {
+        "id": "pixel_scale",
+        "name": "Pixel Scale Max",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Maximum scale of the pixelation effect"
+      }
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ]
+  },
+  {
+    "id": "crt-magnet",
+    "name": "CRT Magnet",
+    "url": "shaders/crt-magnet.wgsl",
+    "category": "retro-glitch",
+    "description": "Simulates a CRT monitor with degaussing magnetic distortion near the mouse. Features color bloom, Gaussian blur, curl-noise field lines, barrel distortion, and bass-driven magnet pulse.",
+    "params": [
+      {
+        "id": "magnet_strength",
+        "name": "Magnet Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bloom_intensity",
+        "name": "Bloom Intensity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "distortion_radius",
+        "name": "Distortion Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "filter",
+      "image-processing",
+      "noise",
+      "curl",
+      "fractal",
+      "crt",
+      "magnet",
+      "bloom"
+    ]
+  },
+  {
+    "id": "crt-phosphor-decay",
+    "name": "CRT Phosphor Decay",
+    "url": "shaders/crt-phosphor-decay.wgsl",
+    "category": "retro-glitch",
+    "description": "Simulates the ghosting trails and scanlines of an old monitor. Touch adds static.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "decay-rate",
+        "name": "Trail Length",
+        "min": 0,
+        "max": 1,
+        "default": 0.8
+      },
+      {
+        "id": "brightness-boost",
+        "name": "Glow Boost",
+        "min": 0,
+        "max": 1,
+        "default": 0.2
+      },
+      {
+        "id": "scanline-opacity",
+        "name": "Scanlines",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      },
+      {
+        "id": "noise-level",
+        "name": "Touch Static",
+        "min": 0,
+        "max": 1,
+        "default": 0.5
+      }
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ]
+  },
+  {
+    "id": "crt-tv",
+    "name": "CRT TV - Phosphor Physics",
+    "url": "shaders/crt-tv.wgsl",
+    "category": "retro-glitch",
+    "description": "Authentic CRT phosphor physics simulation with aperture grille shadow mask, per-channel phosphor decay (R>G>B persistence rates), halation glow from glass scattering, barrel distortion, and realistic scanlines",
+    "tags": [
+      "crt",
+      "retro",
+      "phosphor",
+      "scanlines",
+      "vintage",
+      "monitor",
+      "arcade",
+      "gaming"
+    ],
+    "params": [
+      {
+        "id": "scanline_intensity",
+        "name": "Scanline Intensity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "phosphor_glow",
+        "name": "Phosphor Glow",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "halation",
+        "name": "Halation Strength",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "barrel_distortion",
+        "name": "Barrel Distortion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ]
+  },
+  {
+    "id": "cyber-rain-interactive",
+    "name": "Cyber Rain",
+    "category": "retro-glitch",
+    "url": "shaders/cyber-rain-interactive.wgsl",
+    "description": "Matrix-style digital rain that reacts to image luminance and mouse.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "speed",
+        "name": "Rain Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glitch",
+        "name": "Glitch",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "trail",
+        "name": "Trail Len",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ]
+  },
+  {
+    "id": "halftone",
+    "name": "Retro Halftone",
+    "url": "shaders/halftone.wgsl",
+    "category": "retro-glitch",
+    "description": "Classic newspaper halftone dot pattern with adjustable scale, contrast, and color mode. Audio-reactive bass pulse modulates dot intensity.",
+    "params": [
+      {
+        "id": "dotScale",
+        "name": "Dot Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "contrast",
+        "name": "Contrast",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "colorMode",
+        "name": "Color Mode",
+        "default": 1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "grid_rotation",
+        "name": "Grid Rotation",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Rotation angle of halftone grid"
+      }
+    ],
+    "tags": [
+      "retro",
+      "halftone",
+      "print",
+      "monochrome",
+      "colorful",
+      "image-processing",
+      "filter"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ]
+  },
+  {
+    "id": "holographic-projection-failure",
+    "name": "Holo-Projection Failure",
+    "url": "shaders/holographic-projection-failure.wgsl",
+    "category": "retro-glitch",
+    "description": "A failing holographic transmission. Glitches stabilize when the mouse 'tunes' the signal locally.",
+    "params": [
+      {
+        "id": "instability",
+        "name": "Instability",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chromatic_split",
+        "name": "RGB Split",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scanline_drift",
+        "name": "V-Hold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "signal_noise",
+        "name": "Static",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage",
+      "audio",
+      "music"
+    ]
+  },
+  {
+    "id": "phosphor-decay",
+    "name": "Phosphor Decay",
+    "url": "shaders/phosphor-decay.wgsl",
+    "category": "retro-glitch",
+    "description": "CRT phosphor persistence with per-channel decay rates, color bloom, shadow mask, scan-line blanking, depth haze, and bass-reactive bloom burst.",
+    "params": [
+      {
+        "id": "decay_rate",
+        "name": "Decay Rate",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "bloom_spread",
+        "name": "Bloom Spread",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "shadow_mask",
+        "name": "Shadow Mask Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scan_blanking",
+        "name": "Scan Blanking",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "depth-aware",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "vfx",
+      "particles",
+      "glow",
+      "hdr",
+      "crt",
+      "tone-mapped",
+      "phosphor",
+      "bloom"
+    ]
+  },
+  {
+    "id": "pixelate-blast",
+    "url": "shaders/pixelate-blast.wgsl",
+    "icon": "blur_on",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Max Pixel Size",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param2",
+        "name": "Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "param3",
+        "name": "Invert Area",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 1
+      },
+      {
+        "id": "param4",
+        "name": "Color Crunch",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "category": "retro-glitch",
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ],
+    "name": "Pixelate Blast"
+  },
+  {
+    "id": "rgb-glitch-displacement",
+    "name": "RGB Glitch Displacement",
+    "url": "shaders/rgb-glitch-displacement.wgsl",
+    "category": "retro-glitch",
+    "description": "Digital glitch effect with RGB channel displacement, block glitches, scanlines, pixel sorting, and datamosh effects. Mouse-reactive wave displacement and chromatic aberration. Audio reactivity pulses glitch intensity and adds beat-synchronized flashes.",
+    "tags": [
+      "glitch",
+      "rgb",
+      "digital",
+      "scanlines",
+      "chromatic",
+      "datamosh",
+      "retro",
+      "vintage",
+      "audio",
+      "music"
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "author": "Kimi",
+    "params": [
+      {
+        "id": "glitchIntensity",
+        "name": "Glitch Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "scanlineDensity",
+        "name": "Scanline Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "scanline-drift",
+    "name": "Scanline Drift",
+    "category": "retro-glitch",
+    "url": "shaders/scanline-drift.wgsl",
+    "description": "Horizontal segments of the image drift left and right, simulating a bad video signal or tracking error.",
+    "params": [
+      {
+        "name": "Drift Speed",
+        "id": "zoomParam1",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Line Height",
+        "id": "zoomParam2",
+        "default": 0.1,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Jitter Amount",
+        "id": "zoomParam3",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Color Shift",
+        "id": "zoomParam4",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ]
+  },
+  {
+    "id": "signal-noise",
+    "name": "Signal Noise",
+    "url": "shaders/signal-noise.wgsl",
+    "category": "retro-glitch",
+    "description": "Multi-octave analog noise with VHS head-switching bands, DCT block artifacts, datamoshing smear, and directional chromatic aberration with YUV chroma noise.",
+    "features": [
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "vhsIntensity",
+        "name": "VHS Intensity",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "artifactStrength",
+        "name": "Artifact Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "smearAmount",
+        "name": "Smear Amount",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chromaStrength",
+        "name": "Chroma Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vhs",
+      "noise",
+      "analog"
+    ]
+  },
+  {
+    "id": "spectral-glitch-sort",
+    "name": "Spectral Glitch Sort",
+    "url": "shaders/spectral-glitch-sort.wgsl",
+    "category": "retro-glitch",
+    "features": [
+      "mouse-driven",
+      "chromatic-aberration"
+    ],
+    "description": "Displaces pixels based on their brightness, creating a glitchy sorting effect controlled by the mouse.",
+    "params": [
+      {
+        "id": "strength",
+        "name": "Sort Length",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "threshold",
+        "name": "Luma Threshold",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "angle",
+        "name": "Direction",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "noise",
+        "name": "Digital Noise",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "glitch",
+      "retro",
+      "vintage"
+    ]
   },
   {
     "id": "waveform-glitch",
@@ -121,301 +988,6 @@
     ]
   },
   {
-    "id": "rgb-glitch-displacement",
-    "name": "RGB Glitch Displacement",
-    "url": "shaders/rgb-glitch-displacement.wgsl",
-    "category": "retro-glitch",
-    "description": "Digital glitch effect with RGB channel displacement, block glitches, scanlines, pixel sorting, and datamosh effects. Mouse-reactive wave displacement and chromatic aberration. Audio reactivity pulses glitch intensity and adds beat-synchronized flashes.",
-    "tags": [
-      "glitch",
-      "rgb",
-      "digital",
-      "scanlines",
-      "chromatic",
-      "datamosh",
-      "retro",
-      "vintage",
-      "audio",
-      "music"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "author": "Kimi",
-    "params": [
-      {
-        "id": "glitchIntensity",
-        "name": "Glitch Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "scanlineDensity",
-        "name": "Scanline Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "scanline-drift",
-    "name": "Scanline Drift",
-    "category": "retro-glitch",
-    "url": "shaders/scanline-drift.wgsl",
-    "description": "Horizontal segments of the image drift left and right, simulating a bad video signal or tracking error.",
-    "params": [
-      {
-        "name": "Drift Speed",
-        "id": "zoomParam1",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Line Height",
-        "id": "zoomParam2",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Jitter Amount",
-        "id": "zoomParam3",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Color Shift",
-        "id": "zoomParam4",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ]
-  },
-  {
-    "id": "crt-magnet",
-    "name": "CRT Magnet",
-    "url": "shaders/crt-magnet.wgsl",
-    "category": "retro-glitch",
-    "description": "Simulates a CRT monitor with degaussing magnetic distortion near the mouse. Features color bloom, Gaussian blur, curl-noise field lines, barrel distortion, and bass-driven magnet pulse.",
-    "params": [
-      {
-        "id": "magnet_strength",
-        "name": "Magnet Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "bloom_intensity",
-        "name": "Bloom Intensity",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "distortion_radius",
-        "name": "Distortion Radius",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware",
-      "upgraded-rgba"
-    ],
-    "tags": [
-      "filter",
-      "image-processing",
-      "noise",
-      "curl",
-      "fractal",
-      "crt",
-      "magnet",
-      "bloom"
-    ]
-  },
-  {
-    "id": "phosphor-decay",
-    "name": "Phosphor Decay",
-    "url": "shaders/phosphor-decay.wgsl",
-    "category": "retro-glitch",
-    "description": "CRT phosphor persistence with per-channel decay rates, color bloom, shadow mask, scan-line blanking, depth haze, and bass-reactive bloom burst.",
-    "params": [
-      {
-        "id": "decay_rate",
-        "name": "Decay Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "bloom_spread",
-        "name": "Bloom Spread",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "shadow_mask",
-        "name": "Shadow Mask Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scan_blanking",
-        "name": "Scan Blanking",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware",
-      "upgraded-rgba"
-    ],
-    "tags": [
-      "vfx",
-      "particles",
-      "glow",
-      "hdr",
-      "crt",
-      "tone-mapped",
-      "phosphor",
-      "bloom"
-    ]
-  },
-  {
-    "id": "ascii-flow",
-    "category": "retro-glitch",
-    "url": "shaders/ascii-flow.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ],
-    "name": "ASCII Flow"
-  },
-  {
-    "id": "spectral-glitch-sort",
-    "name": "Spectral Glitch Sort",
-    "url": "shaders/spectral-glitch-sort.wgsl",
-    "category": "retro-glitch",
-    "features": [
-      "mouse-driven",
-      "chromatic-aberration"
-    ],
-    "description": "Displaces pixels based on their brightness, creating a glitchy sorting effect controlled by the mouse.",
-    "params": [
-      {
-        "id": "strength",
-        "name": "Sort Length",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "threshold",
-        "name": "Luma Threshold",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "angle",
-        "name": "Direction",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "noise",
-        "name": "Digital Noise",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ]
-  },
-  {
     "id": "xerox-degrade",
     "name": "Xerox Degrade",
     "url": "shaders/xerox-degrade.wgsl",
@@ -426,29 +998,29 @@
         "id": "contrast",
         "name": "Contrast",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "grain",
         "name": "Grain",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "smear",
         "name": "Smear",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "threshold",
         "name": "Threshold",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -460,577 +1032,5 @@
       "filter",
       "image-processing"
     ]
-  },
-  {
-    "id": "signal-noise",
-    "name": "Signal Noise",
-    "url": "shaders/signal-noise.wgsl",
-    "category": "retro-glitch",
-    "description": "Multi-octave analog noise with VHS head-switching bands, DCT block artifacts, datamoshing smear, and directional chromatic aberration with YUV chroma noise.",
-    "features": [
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "vhsIntensity",
-        "name": "VHS Intensity",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "artifactStrength",
-        "name": "Artifact Strength",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "smearAmount",
-        "name": "Smear Amount",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "chromaStrength",
-        "name": "Chroma Strength",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vhs",
-      "noise",
-      "analog"
-    ]
-  },
-  {
-    "id": "cyber-rain-interactive",
-    "name": "Cyber Rain",
-    "category": "retro-glitch",
-    "url": "shaders/cyber-rain-interactive.wgsl",
-    "description": "Matrix-style digital rain that reacts to image luminance and mouse.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "speed",
-        "name": "Rain Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "trail",
-        "name": "Trail Len",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ]
-  },
-  {
-    "id": "bayer-dither-interactive",
-    "name": "Bayer Dither Interactive",
-    "category": "retro-glitch",
-    "url": "shaders/bayer-dither-interactive.wgsl",
-    "description": "Applies an ordered 8x8 Bayer dithering effect with adjustable bit depth and pixelation scale.",
-    "features": [
-      "mouse-driven",
-      "retro-style"
-    ],
-    "params": [
-      {
-        "id": "bit_depth",
-        "name": "Bit Depth",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Effective bit depth of the dithered output"
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Contrast applied before dithering"
-      },
-      {
-        "id": "dither_spread",
-        "name": "Dither Spread",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Spread of the Bayer dither threshold"
-      },
-      {
-        "id": "pixel_scale",
-        "name": "Pixel Scale Max",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Maximum scale of the pixelation effect"
-      }
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ]
-  },
-  {
-    "id": "crt-phosphor-decay",
-    "name": "CRT Phosphor Decay",
-    "url": "shaders/crt-phosphor-decay.wgsl",
-    "category": "retro-glitch",
-    "description": "Simulates the ghosting trails and scanlines of an old monitor. Touch adds static.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "decay-rate",
-        "name": "Trail Length",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.8
-      },
-      {
-        "id": "brightness-boost",
-        "name": "Glow Boost",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.2
-      },
-      {
-        "id": "scanline-opacity",
-        "name": "Scanlines",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      },
-      {
-        "id": "noise-level",
-        "name": "Touch Static",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.5
-      }
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ]
-  },
-  {
-    "id": "halftone",
-    "name": "Retro Halftone",
-    "url": "shaders/halftone.wgsl",
-    "category": "retro-glitch",
-    "description": "Classic newspaper halftone dot pattern with adjustable scale, contrast, and color mode. Audio-reactive bass pulse modulates dot intensity.",
-    "params": [
-      {
-        "id": "dotScale",
-        "name": "Dot Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "contrast",
-        "name": "Contrast",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "colorMode",
-        "name": "Color Mode",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "grid_rotation",
-        "name": "Grid Rotation",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Rotation angle of halftone grid"
-      }
-    ],
-    "tags": [
-      "retro",
-      "halftone",
-      "print",
-      "monochrome",
-      "colorful",
-      "image-processing",
-      "filter"
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ]
-  },
-  {
-    "id": "crt-tv",
-    "name": "CRT TV - Phosphor Physics",
-    "url": "shaders/crt-tv.wgsl",
-    "category": "retro-glitch",
-    "description": "Authentic CRT phosphor physics simulation with aperture grille shadow mask, per-channel phosphor decay (R>G>B persistence rates), halation glow from glass scattering, barrel distortion, and realistic scanlines",
-    "tags": [
-      "crt",
-      "retro",
-      "phosphor",
-      "scanlines",
-      "vintage",
-      "monitor",
-      "arcade",
-      "gaming"
-    ],
-    "params": [
-      {
-        "id": "scanline_intensity",
-        "name": "Scanline Intensity",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "phosphor_glow",
-        "name": "Phosphor Glow",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "halation",
-        "name": "Halation Strength",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "barrel_distortion",
-        "name": "Barrel Distortion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ]
-  },
-  {
-    "id": "holographic-projection-failure",
-    "name": "Holo-Projection Failure",
-    "url": "shaders/holographic-projection-failure.wgsl",
-    "category": "retro-glitch",
-    "description": "A failing holographic transmission. Glitches stabilize when the mouse 'tunes' the signal locally.",
-    "params": [
-      {
-        "id": "instability",
-        "name": "Instability",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chromatic_split",
-        "name": "RGB Split",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scanline_drift",
-        "name": "V-Hold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "signal_noise",
-        "name": "Static",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage",
-      "audio",
-      "music"
-    ]
-  },
-  {
-    "id": "pixelate-blast",
-    "url": "shaders/pixelate-blast.wgsl",
-    "icon": "blur_on",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Max Pixel Size",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param2",
-        "name": "Radius",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "param3",
-        "name": "Invert Area",
-        "default": 0.0,
-        "min": 0,
-        "max": 1,
-        "step": 1.0
-      },
-      {
-        "id": "param4",
-        "name": "Color Crunch",
-        "default": 0.0,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "category": "retro-glitch",
-    "tags": [
-      "glitch",
-      "retro",
-      "vintage"
-    ],
-    "name": "Pixelate Blast"
-  },
-  {
-    "id": "scanline-tear",
-    "name": "Scanline Tear",
-    "url": "shaders/scanline-tear.wgsl",
-    "category": "retro-glitch",
-    "description": "Authentic analog video interlacing simulation with field-based temporal offset, HSync/VSync modeling, and VHS-style tracking errors.",
-    "params": [
-      {
-        "id": "interlaceStrength",
-        "name": "Interlace Strength",
-        "description": "Controls interlacing artifact intensity, field persistence, and combing on motion",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "hsyncError",
-        "name": "HSync Error",
-        "description": "Horizontal sync instability - creates rolling bars and horizontal displacement",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "vsyncError",
-        "name": "VSync Error",
-        "description": "Vertical sync roll - creates image rolling and retrace bars",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorBurstError",
-        "name": "Color Burst Error",
-        "description": "Chroma phase errors causing hue shifts and chroma noise",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "features": [
-      "multi-pass",
-      "glitch",
-      "temporal"
-    ],
-    "tags": [
-      "interlacing",
-      "vhs",
-      "analog",
-      "retro",
-      "scanlines",
-      "sync-loss",
-      "tracking",
-      "video",
-      "ntsc"
-    ]
-  },
-  {
-    "id": "synthwave-grid-warp",
-    "name": "Synthwave Grid Warp",
-    "url": "shaders/synthwave-grid-warp.wgsl",
-    "category": "retro-glitch",
-    "description": "3D perspective-projected synthwave floor with atmospheric fog, sun, and mountain silhouettes.",
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "params": [
-      {
-        "id": "camY",
-        "name": "Camera Height",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x"
-      },
-      {
-        "id": "fogDensity",
-        "name": "Fog Density",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y"
-      },
-      {
-        "id": "fogFalloff",
-        "name": "Fog Falloff",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z"
-      },
-      {
-        "id": "mountainScale",
-        "name": "Mountain Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w"
-      }
-    ],
-    "tags": [
-      "retro",
-      "synthwave",
-      "3d",
-      "fog",
-      "atmospheric"
-    ]
-  },
-  {
-    "id": "retro_phosphor_dream",
-    "name": "Phosphor Dream",
-    "url": "shaders/retro_phosphor_dream.wgsl",
-    "category": "retro-glitch",
-    "description": "Authentic CRT simulation with RGB phosphor triads, persistence afterglow, interlaced flicker, barrel distortion, and chromatic aberration",
-    "tags": [
-      "crt",
-      "retro",
-      "phosphor",
-      "analog",
-      "vintage"
-    ],
-    "features": [
-      "temporal-persistence",
-      "audio-reactive",
-      "phosphor-glow"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Curvature",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Phosphor Size",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Scanlines",
-        "default": 0.4,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Flicker",
-        "default": 0.2,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.6
   }
 ]

--- a/public/shader-lists/simulation.json
+++ b/public/shader-lists/simulation.json
@@ -1,287 +1,5 @@
 [
   {
-    "id": "hybrid-reaction-diffusion-glass",
-    "name": "Hybrid Reaction-Diffusion Glass",
-    "url": "shaders/hybrid-reaction-diffusion-glass.wgsl",
-    "category": "simulation",
-    "description": "Turing patterns (reaction-diffusion) refracted through depth-aware glass distortion",
-    "features": [
-      "hybrid",
-      "reaction-diffusion",
-      "glass-distortion",
-      "depth-aware",
-      "fresnel",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "feed_rate",
-        "name": "Feed Rate",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Chemical feed rate (pattern density)"
-      },
-      {
-        "id": "kill_rate",
-        "name": "Kill Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Chemical kill rate (pattern stability)"
-      },
-      {
-        "id": "refraction",
-        "name": "Glass Refraction",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Strength of glass refraction"
-      },
-      {
-        "id": "depth_effect",
-        "name": "Depth Effect",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "How much depth affects distortion"
-      }
-    ],
-    "chunks_used": [
-      "Gray-Scott reaction-diffusion (reaction-diffusion.wgsl)",
-      "fresnelSchlick (crystal-facets.wgsl)",
-      "laplacian operator",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hybrid-particle-fluid",
-    "name": "Hybrid Particle Fluid",
-    "url": "shaders/hybrid-particle-fluid.wgsl",
-    "category": "simulation",
-    "description": "Particles that move like fluid with glowing trails, combining particle advection with curl noise velocity field",
-    "features": [
-      "hybrid",
-      "particle-system",
-      "fluid-advection",
-      "glow",
-      "curl-noise",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "particle_count",
-        "name": "Particle Density",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Number of particles in simulation"
-      },
-      {
-        "id": "flow_speed",
-        "name": "Flow Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Fluid velocity magnitude"
-      },
-      {
-        "id": "trails",
-        "name": "Trail Decay",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "How long trails persist (higher = longer)"
-      },
-      {
-        "id": "glow_size",
-        "name": "Glow Size",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Size of particle glow effect"
-      }
-    ],
-    "chunks_used": [
-      "curl noise velocity field",
-      "fbm2 (gen_grid.wgsl)",
-      "palette (gen-xeno-botanical-synth-flora.wgsl)"
-    ],
-    "created_by": "Agent 2A - Shader Surgeon",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "hyper-tensor-fluid",
-    "name": "Hyper Tensor Fluid",
-    "url": "shaders/hyper-tensor-fluid.wgsl",
-    "category": "simulation",
-    "description": "Fluid flows according to image structure via tensor eigendecomposition. Combines tensor fields with Navier-Stokes dynamics.",
-    "features": [
-      "advanced-hybrid",
-      "tensor-field",
-      "navier-stokes",
-      "depth-aware",
-      "fbm",
-      "randomization-safe",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "tensor_strength",
-        "name": "Tensor Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Strength of tensor field influence on flow"
-      },
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Fluid viscosity (flow resistance)"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Amount of FBM turbulence"
-      },
-      {
-        "id": "advection_speed",
-        "name": "Advection Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Speed of fluid advection"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "fbm2 (gen_grid.wgsl)",
-      "Structure tensor eigendecomposition",
-      "Velocity advection"
-    ],
-    "performance_target": "45-60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22",
-    "tags": [
-      "audio",
-      "music",
-      "reactive"
-    ]
-  },
-  {
-    "id": "hyper-tensor-fluid-coupled",
-    "name": "Hyper Tensor Fluid + Mouse Coupling",
-    "url": "shaders/hyper-tensor-fluid-coupled.wgsl",
-    "category": "simulation",
-    "description": "Tensor-field fluid dynamics with viscous mouse stirring. Mouse injects velocity and vorticity; click ripples spawn radial fluid bursts.",
-    "features": [
-      "advanced-hybrid",
-      "tensor-field",
-      "navier-stokes",
-      "mouse-driven",
-      "fluid-coupling",
-      "interactive",
-      "randomization-safe",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "tensor_strength",
-        "name": "Tensor Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Strength of tensor field influence on flow"
-      },
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Fluid viscosity and mouse radius"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "FBM turbulence and fluid influence"
-      },
-      {
-        "id": "advection_speed",
-        "name": "Advection Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Fluid advection speed and vortex strength"
-      }
-    ],
-    "tags": [
-      "interactive",
-      "mouse-driven",
-      "physics",
-      "fluid",
-      "tensor",
-      "audio",
-      "music",
-      "reactive"
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "fbm2 (gen_grid.wgsl)",
-      "Structure tensor eigendecomposition",
-      "Velocity advection",
-      "Mouse fluid coupling (mouse-fluid-coupling.wgsl)"
-    ],
-    "performance_target": "40-55 FPS (GTX 1060)",
-    "created_by": "Agent CB-4 - Mouse Physics Injector",
-    "created_date": "2026-04-18"
-  },
-  {
     "id": "fractal-boids-field-coupled",
     "name": "Fractal Boids Field + Fluid Coupling",
     "url": "shaders/fractal-boids-field-coupled.wgsl",
@@ -303,8 +21,8 @@
         "id": "boid_count",
         "name": "Boid Count",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Number of simulated boids and ripple force"
@@ -313,8 +31,8 @@
         "id": "flow_strength",
         "name": "Flow Field Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Fractal flow field strength and mouse radius"
@@ -323,8 +41,8 @@
         "id": "fluid_influence",
         "name": "Fluid Influence",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "How much mouse fluid pushes boids"
@@ -333,8 +51,8 @@
         "id": "separation",
         "name": "Separation Distance",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Boid separation distance and vortex strength"
@@ -382,8 +100,8 @@
         "id": "boid_count",
         "name": "Boid Count",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Number of simulated boids"
@@ -392,8 +110,8 @@
         "id": "flow_strength",
         "name": "Flow Field Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Influence of fractal flow field"
@@ -402,8 +120,8 @@
         "id": "trail_persistence",
         "name": "Trail Persistence",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "How long trails persist"
@@ -412,8 +130,8 @@
         "id": "separation",
         "name": "Separation Distance",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Boid separation distance"
@@ -435,1373 +153,248 @@
     ]
   },
   {
-    "id": "sim-smoke-trails",
-    "name": "Smoke Trails",
-    "url": "shaders/sim-smoke-trails.wgsl",
+    "id": "hyper-tensor-fluid-coupled",
+    "name": "Hyper Tensor Fluid + Mouse Coupling",
+    "url": "shaders/hyper-tensor-fluid-coupled.wgsl",
     "category": "simulation",
-    "description": "Volumetric smoke with vorticity and buoyancy. Billowing smoke rising with natural turbulence.",
+    "description": "Tensor-field fluid dynamics with viscous mouse stirring. Mouse injects velocity and vorticity; click ripples spawn radial fluid bursts.",
     "features": [
-      "simulation",
-      "volumetric-smoke",
-      "vorticity",
-      "buoyancy",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "density",
-        "name": "Smoke Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Smoke density"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Turbulence strength"
-      },
-      {
-        "id": "rise_speed",
-        "name": "Rise Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Smoke rise speed"
-      },
-      {
-        "id": "dissipation",
-        "name": "Dissipation",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Smoke dissipation rate"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "noise",
-      "Curl noise",
-      "Buoyancy simulation"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "quantum-foam-pass2",
-    "name": "Quantum Foam (Pass 2: Particle Advection)",
-    "url": "shaders/quantum-foam-pass2.wgsl",
-    "category": "simulation",
-    "description": "Advects particles through the quantum field. Second pass of 3-pass system.",
-    "features": [
-      "multi-pass-2",
-      "compute-shader",
-      "temporal"
-    ],
-    "multipass": {
-      "pass": 2,
-      "totalPasses": 3,
-      "prevShader": "quantum-foam-pass1",
-      "nextShader": "quantum-foam-pass3"
-    },
-    "tags": [
-      "quantum",
-      "particles",
-      "advection",
-      "simulation"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "alpha-fluid-simulation-paint",
-    "name": "Alpha Fluid Simulation Paint",
-    "url": "shaders/alpha-fluid-simulation-paint.wgsl",
-    "category": "simulation",
-    "description": "Full 2D incompressible fluid simulation packed into a single RGBA32FLOAT texture. R=velocity.x, G=velocity.y, B=pressure, A=dye density. Mouse creates vortices and injects dye. Requires f32 for signed velocity and pressure fields.",
-    "tags": [
-      "fluid",
-      "simulation",
-      "interactive",
-      "mouse-driven",
+      "advanced-hybrid",
+      "tensor-field",
       "navier-stokes",
-      "psychedelic",
-      "colorful",
-      "rgba-state-machine"
-    ],
-    "features": [
       "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "dyeBrightness",
-        "name": "Dye Brightness",
-        "type": "float",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "vorticity",
-        "name": "Vorticity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "decayRate",
-        "name": "Decay Rate",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "alpha-em-field-simulation",
-    "name": "Alpha EM Field Simulation",
-    "url": "shaders/alpha-em-field-simulation.wgsl",
-    "category": "simulation",
-    "description": "Electromagnetic field simulation using RGBA32FLOAT as four data channels: R=E-field X, G=E-field Y, B=magnetic potential, A=charge density. Mouse and ripples inject alternating positive/negative charges. Wave equation propagation with damping.",
-    "tags": [
-      "electromagnetic",
-      "simulation",
-      "interactive",
-      "mouse-driven",
-      "field",
-      "wave",
-      "rgba-state-machine"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "damping",
-        "name": "Field Damping",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chargeIntensity",
-        "name": "Charge Intensity",
-        "type": "float",
-        "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "bFieldVis",
-        "name": "B-Field Visibility",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "waveSpeed",
-        "name": "Wave Speed",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "nano-assembler",
-    "name": "Nano Assembler",
-    "url": "shaders/nano-assembler.wgsl",
-    "category": "simulation",
-    "description": "Simulates nanobots constructing the image. Mouse movement disrupts the assembly, scattering the particles.",
-    "params": [
-      {
-        "id": "assembly_progress",
-        "name": "Assembly",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "particle_density",
-        "name": "Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "scatter_force",
-        "name": "Disruption",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "rebuild_speed",
-        "name": "Rebuild Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics"
-    ]
-  },
-  {
-    "id": "sim-fluid-feedback-field",
-    "name": "Fluid Feedback Field",
-    "url": "shaders/sim-fluid-feedback-field-pass1.wgsl",
-    "category": "simulation",
-    "description": "Multi-pass Navier-Stokes fluid simulation with feedback trails. Glowing fluid that swirls and mixes.",
-    "features": [
-      "simulation",
-      "multi-pass",
-      "navier-stokes",
-      "velocity-advection",
-      "density-advection",
-      "randomization-safe"
-    ],
-    "multipass": {
-      "pass": 1,
-      "totalPasses": 3,
-      "passes": [
-        {
-          "pass": 1,
-          "name": "Velocity Advection",
-          "file": "sim-fluid-feedback-field-pass1.wgsl"
-        },
-        {
-          "pass": 2,
-          "name": "Density Advection",
-          "file": "sim-fluid-feedback-field-pass2.wgsl"
-        },
-        {
-          "pass": 3,
-          "name": "Composite",
-          "file": "sim-fluid-feedback-field-pass3.wgsl"
-        }
-      ]
-    },
-    "params": [
-      {
-        "id": "viscosity",
-        "name": "Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Flow resistance (viscosity)"
-      },
-      {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Turbulence amount"
-      },
-      {
-        "id": "fade_rate",
-        "name": "Fade Rate",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Density fade rate"
-      },
-      {
-        "id": "glow",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Glow intensity"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "noise",
-      "Curl noise",
-      "Velocity advection",
-      "Density advection"
-    ],
-    "performance_target": "45-60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "luma-flow-field",
-    "category": "simulation",
-    "url": "shaders/luma-flow-field.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Flow Speed",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 5.0
-      },
-      {
-        "id": "param2",
-        "name": "Decay",
-        "default": 0.96,
-        "min": 0.9,
-        "max": 0.999
-      },
-      {
-        "id": "param3",
-        "name": "Mouse Force",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 2.0
-      },
-      {
-        "id": "param4",
-        "name": "Color Shift",
-        "default": 0.01,
-        "min": 0.0,
-        "max": 0.1
-      }
-    ],
-    "tags": [
-      "simulation",
-      "physics"
-    ],
-    "name": "Luma Flow Field"
-  },
-  {
-    "id": "bitonic-sort",
-    "name": "Bitonic Pixel Sort",
-    "url": "shaders/bitonic-sort.wgsl",
-    "category": "simulation",
-    "description": "Workgroup bitonic pixel sort with FBM-enhanced sort keys, bass-reactive mixing, and semantic luminance-key alpha.",
-    "features": [
-      "upgraded-rgba",
-      "depth-aware",
-      "audio-reactive",
-      "mouse-driven",
-      "multi-ripple"
-    ],
-    "tags": [
-      "simulation",
-      "filter",
-      "glitch",
-      "algorithmic",
-      "sort",
-      "noise"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Sort Mix",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Noise Mix",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Sort Direction",
-        "default": 0.0,
-        "min": 0,
-        "max": 1,
-        "step": 0.01,
-        "labels": [
-          "Ascending",
-          "Descending"
-        ]
-      },
-      {
-        "id": "param4",
-        "name": "Noise Octaves",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "quantum-foam-pass3",
-    "name": "Quantum Foam (Pass 3: Compositing)",
-    "url": "shaders/quantum-foam-pass3.wgsl",
-    "category": "simulation",
-    "description": "Volumetric rendering and final compositing with glow and tone mapping. Third pass of 3-pass system.",
-    "features": [
-      "multi-pass-3",
-      "compute-shader",
-      "post-processing"
-    ],
-    "multipass": {
-      "pass": 3,
-      "totalPasses": 3,
-      "prevShader": "quantum-foam-pass2"
-    },
-    "tags": [
-      "quantum",
-      "compositing",
-      "glow",
-      "tone-mapping"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "sim-sand-dunes",
-    "name": "Sand Dunes",
-    "url": "shaders/sim-sand-dunes.wgsl",
-    "category": "simulation",
-    "description": "Falling sand physics with wind erosion. Sand falls, piles at angle of repose, wind moves loose sand.",
-    "features": [
-      "simulation",
-      "cellular-automata",
-      "falling-sand",
-      "wind-erosion",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "gravity",
-        "name": "Gravity Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Gravity strength"
-      },
-      {
-        "id": "wind",
-        "name": "Wind Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Wind direction and speed"
-      },
-      {
-        "id": "viscosity",
-        "name": "Sand Viscosity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Sand viscosity"
-      },
-      {
-        "id": "erosion",
-        "name": "Erosion Rate",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Wind erosion rate"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "Sand physics rules",
-      "Wind simulation"
-    ],
-    "performance_target": "60 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
-  },
-  {
-    "id": "aero-chromatics",
-    "name": "Aero Chromatics",
-    "category": "simulation",
-    "url": "shaders/aero-chromatics.wgsl",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "Wind tunnel simulation where image brightness determines aerodynamic drag, creating chromatic smoke trails.",
-    "params": [
-      {
-        "id": "wind-strength",
-        "name": "Wind Force",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "decay",
-        "name": "Smoke Decay",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "chroma",
-        "name": "Chromatic Split",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "source-mix",
-        "name": "Source Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "simulation",
-      "physics"
-    ]
-  },
-  {
-    "id": "sim-decay-system-rgba",
-    "name": "Sim: Decay System RGBA",
-    "url": "shaders/sim-decay-system-rgba.wgsl",
-    "category": "simulation",
-    "description": "Four-layer material decay simulation with cross-coupling. Paint integrity, metal corrosion, organic rot, and structural integrity each decay at different rates. When one layer fails, others decay faster. Mouse interaction can restore/repair.",
-    "tags": [
-      "simulation",
-      "decay",
-      "corrosion",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "rust",
-      "aging"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "baseDecay",
-        "name": "Base Decay",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "edgeVuln",
-        "name": "Edge Vulnerability",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "moisture",
-        "name": "Moisture",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "recovery",
-        "name": "Recovery Rate",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "pixel-sand",
-    "name": "Pixel Sand",
-    "url": "shaders/pixel-sand.wgsl",
-    "category": "simulation",
-    "description": "Falling granular automata with curl noise force fields, height-field weight physics, mouse gravity wells, audio-reactive spawn, depth shading, and bounce.",
-    "features": [
-      "upgraded-rgba",
-      "mouse-driven",
-      "audio-reactive",
-      "depth-aware",
-      "temporal"
-    ],
-    "tags": [
-      "sand",
-      "granular",
-      "falling",
-      "interactive",
-      "audio-reactive",
-      "particles",
-      "simulation",
-      "curl-noise"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Gravity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Particle Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Curl Force",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Bounce",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "alpha-crystal-growth-phase",
-    "name": "Alpha Crystal Growth Phase",
-    "url": "shaders/alpha-crystal-growth-phase.wgsl",
-    "category": "simulation",
-    "description": "Phase-field model of crystal growth with RGBA-packed state. Phase (solid/liquid), temperature, crystal orientation, and impurity concentration evolve together. Creates dendritic crystal patterns with orientation-dependent color. Mouse seeds new crystals; ripples trigger nucleation.",
-    "tags": [
-      "crystal",
-      "growth",
-      "simulation",
-      "interactive",
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "dendritic"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "supercooling",
-        "name": "Supercooling",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "anisotropy",
-        "name": "Anisotropy",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "growthRate",
-        "name": "Growth Rate",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "impurity",
-        "name": "Impurity Level",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "alpha-erosion-terrain",
-    "name": "Alpha Erosion Terrain",
-    "url": "shaders/alpha-erosion-terrain.wgsl",
-    "category": "simulation",
-    "description": "Hydraulic erosion simulation with RGBA-packed terrain state. Height from image luminance is eroded by flowing water that picks up sediment and deposits it in flat areas. Mouse creates rainstorms; ripples trigger flash floods. Alpha tracks cumulative erosion history.",
-    "tags": [
-      "erosion",
-      "terrain",
-      "simulation",
-      "interactive",
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "hydraulic"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "rainRate",
-        "name": "Rain Rate",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "erosionRate",
-        "name": "Erosion Rate",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "depositionRate",
-        "name": "Deposition Rate",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "sedimentCapacity",
-        "name": "Sediment Capacity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "alpha-multi-state-ecosystem",
-    "name": "Alpha Multi-State Ecosystem",
-    "url": "shaders/alpha-multi-state-ecosystem.wgsl",
-    "category": "simulation",
-    "description": "Continuous multi-species ecosystem simulation packed into RGBA32FLOAT. Two species compete for shared resources while producing toxins. Species diffuse, grow, compete, and die. Mouse nurtures by adding resources.",
-    "tags": [
-      "ecosystem",
-      "simulation",
-      "interactive",
-      "mouse-driven",
-      "cellular-automata",
-      "pattern",
-      "rgba-state-machine"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "growthRate1",
-        "name": "Species 1 Growth",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "growthRate2",
-        "name": "Species 2 Growth",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "diffusion",
-        "name": "Diffusion Rate",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "toxinStrength",
-        "name": "Toxin Strength",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "spec-runge-kutta-advection",
-    "name": "Runge-Kutta Advection",
-    "url": "shaders/spec-runge-kutta-advection.wgsl",
-    "category": "simulation",
-    "description": "4th-order Runge-Kutta fluid advection. Dramatically more accurate than Euler method, preserving fine dye structures 10x longer. Mouse creates counter-rotating vortex pairs.",
-    "tags": [
-      "runge-kutta",
-      "RK4",
-      "fluid",
-      "advection",
-      "simulation",
-      "vortex",
-      "temporal"
-    ],
-    "features": [
-      "runge-kutta",
-      "RK4",
-      "fluid-advection",
-      "mouse-driven",
-      "temporal"
-    ],
-    "params": [
-      {
-        "id": "dt",
-        "name": "Time Step",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "diffusion",
-        "name": "Diffusion",
-        "default": 0.1,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "vortex",
-        "name": "Vortex Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "feedback",
-        "name": "Temporal Feedback",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ],
-    "target_rating": 4.8
-  },
-  {
-    "id": "alpha-reaction-diffusion-rgba",
-    "name": "Alpha Reaction Diffusion RGBA",
-    "url": "shaders/alpha-reaction-diffusion-rgba.wgsl",
-    "category": "simulation",
-    "description": "Four-species reaction-diffusion simulation packed into RGBA32FLOAT. A feeds B, C feeds D, with cross-inhibition between pairs. Creates complex multi-color patterns impossible in 2-species systems.",
-    "tags": [
-      "reaction-diffusion",
-      "simulation",
-      "interactive",
-      "mouse-driven",
-      "pattern",
-      "rgba-state-machine",
-      "colorful"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "feed",
-        "name": "Feed Rate",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "kill",
-        "name": "Kill Rate",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "crossInhibit",
-        "name": "Cross Inhibition",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "sourceMix",
-        "name": "Source Mix",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "sim-fluid-feedback-coupled",
-    "name": "Fluid Feedback Coupled",
-    "url": "shaders/sim-fluid-feedback-coupled.wgsl",
-    "category": "simulation",
-    "description": "Mouse-steerable coupled fluid simulation combining Navier-Stokes feedback fields with viscous fluid stirring. Mouse drags fluid creating vortex streets; click ripples inject bursts. Fluid thickness drives color absorption, blur, and glow.",
-    "features": [
-      "simulation",
-      "mouse-driven",
-      "temporal",
-      "navier-stokes",
       "fluid-coupling",
-      "randomization-safe"
+      "interactive",
+      "randomization-safe",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
+      {
+        "id": "tensor_strength",
+        "name": "Tensor Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Strength of tensor field influence on flow"
+      },
       {
         "id": "viscosity",
         "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Fluid viscosity / damping"
+        "mapping": "zoom_params.y",
+        "description": "Fluid viscosity and mouse radius"
       },
       {
         "id": "turbulence",
         "name": "Turbulence",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Curl noise turbulence amount"
-      },
-      {
-        "id": "fade_rate",
-        "name": "Fade Rate",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
-        "description": "Density fade rate over time"
+        "description": "FBM turbulence and fluid influence"
       },
       {
-        "id": "glow",
-        "name": "Glow Intensity",
+        "id": "advection_speed",
+        "name": "Advection Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Glow intensity from fluid density"
-      }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "curlNoise (sim-fluid-feedback-field)",
-      "velocity advection (sim-fluid-feedback-field)",
-      "mouse stirring (mouse-fluid-coupling)",
-      "vortex force (mouse-fluid-coupling)"
-    ],
-    "tags": [
-      "fluid",
-      "simulation",
-      "mouse-driven",
-      "interactive",
-      "temporal"
-    ],
-    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
-    "created_date": "2026-04-18"
-  },
-  {
-    "id": "sim-slime-mold-growth-em",
-    "name": "Slime Mold Growth + EM Field",
-    "url": "shaders/sim-slime-mold-growth-em.wgsl",
-    "category": "simulation",
-    "description": "Physarum slime mold simulation with mouse electromagnetic field interaction. Agents steer along electric field lines; click ripples spawn secondary charges.",
-    "features": [
-      "simulation",
-      "agent-based",
-      "mouse-driven",
-      "electromagnetic",
-      "interactive",
-      "randomization-safe"
-    ],
-    "params": [
-      {
-        "id": "sensor_angle",
-        "name": "Sensor Angle",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Steering sensitivity and EM charge strength"
-      },
-      {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Trail decay rate and field visualization"
-      },
-      {
-        "id": "em_influence",
-        "name": "EM Influence",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "How much EM field steers agents"
-      },
-      {
-        "id": "ripple_charge",
-        "name": "Ripple Charge",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Secondary charge strength from clicks"
+        "description": "Fluid advection speed and vortex strength"
       }
     ],
     "tags": [
       "interactive",
       "mouse-driven",
       "physics",
-      "slime",
-      "electromagnetic",
-      "agents"
+      "fluid",
+      "tensor",
+      "audio",
+      "music",
+      "reactive"
     ],
     "chunks_used": [
       "hash12 (gen_grid.wgsl)",
-      "hash22 (gen_grid.wgsl)",
-      "hueShift (stellar-plasma.wgsl)",
-      "electricField (mouse-electromagnetic-aurora.wgsl)",
-      "magneticField (mouse-electromagnetic-aurora.wgsl)",
-      "Physarum agent simulation"
+      "fbm2 (gen_grid.wgsl)",
+      "Structure tensor eigendecomposition",
+      "Velocity advection",
+      "Mouse fluid coupling (mouse-fluid-coupling.wgsl)"
     ],
-    "performance_target": "25-40 FPS (GTX 1060)",
+    "performance_target": "40-55 FPS (GTX 1060)",
     "created_by": "Agent CB-4 - Mouse Physics Injector",
     "created_date": "2026-04-18"
   },
   {
-    "id": "alpha-fire-temperature",
-    "name": "Alpha Fire Temperature",
-    "url": "shaders/alpha-fire-temperature.wgsl",
+    "id": "hyper-tensor-fluid",
+    "name": "Hyper Tensor Fluid",
+    "url": "shaders/hyper-tensor-fluid.wgsl",
     "category": "simulation",
-    "description": "Fire simulation with RGBA-packed state: fuel, temperature, smoke density, and combustion age. Temperature drives blackbody radiation color. Fuel burns, generates smoke, and heat rises via convection. Mouse injects fuel; ripples create sparks.",
-    "tags": [
-      "fire",
-      "simulation",
-      "interactive",
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine",
-      "blackbody",
-      "smoke"
-    ],
+    "description": "Fluid flows according to image structure via tensor eigendecomposition. Combines tensor fields with Navier-Stokes dynamics.",
     "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
+      "advanced-hybrid",
+      "tensor-field",
+      "navier-stokes",
+      "depth-aware",
+      "fbm",
+      "randomization-safe",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
       {
-        "id": "burnRate",
-        "name": "Burn Rate",
-        "type": "float",
+        "id": "tensor_strength",
+        "name": "Tensor Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Strength of tensor field influence on flow"
       },
       {
-        "id": "convection",
-        "name": "Convection",
-        "type": "float",
-        "default": 0.6,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "smokeDensity",
-        "name": "Smoke Density",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "emberGlow",
-        "name": "Ember Glow",
-        "type": "float",
+        "id": "viscosity",
+        "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Fluid viscosity (flow resistance)"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Amount of FBM turbulence"
+      },
+      {
+        "id": "advection_speed",
+        "name": "Advection Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Speed of fluid advection"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "fbm2 (gen_grid.wgsl)",
+      "Structure tensor eigendecomposition",
+      "Velocity advection"
+    ],
+    "performance_target": "45-60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22",
+    "tags": [
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "boids",
+    "name": "Boids Reveal",
+    "url": "shaders/boids.wgsl",
+    "category": "simulation",
+    "description": "Flocking boids with reveal masking and simple attraction mechanics.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "chromatic-reaction-diffusion-rgba",
-    "name": "Chromatic Reaction Diffusion RGBA",
-    "url": "shaders/chromatic-reaction-diffusion-rgba.wgsl",
+    "id": "chromatographic-separation",
+    "name": "Chromatographic Separation",
+    "url": "shaders/chromatographic-separation.wgsl",
     "category": "simulation",
-    "description": "Four-species reaction-diffusion with chromatic cross-coupling. Activators A/C and inhibitors B/D form warm/cool tone pairs that suppress each other at boundaries, creating iridescent fringe patterns. RGBA packs full simulation state.",
-    "tags": [
-      "reaction-diffusion",
-      "simulation",
+    "description": "RGB channel fluid simulation with separate viscosities, wind forces, and inter-layer drag.",
+    "params": [
+      {
+        "id": "viscosityR",
+        "name": "Red Viscosity",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "viscosityG",
+        "name": "Green Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "viscosityB",
+        "name": "Blue Viscosity",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "temperature",
+        "name": "Temperature",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
       "interactive",
-      "mouse-driven",
-      "pattern",
-      "rgba-state-machine",
-      "chromatic",
-      "colorful"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "feed",
-        "name": "Feed Rate",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "kill",
-        "name": "Kill Rate",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chromaticSep",
-        "name": "Chromatic Separation",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "crossCouple",
-        "name": "Cross Coupling",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "steamy-glass",
-    "name": "Steamy Glass",
-    "category": "simulation",
-    "url": "shaders/steamy-glass.wgsl",
-    "description": "Simulates a foggy window that can be wiped clean with the mouse. The steam slowly returns over time.",
-    "params": [
-      {
-        "name": "Fog Density",
-        "id": "zoomParam1",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Fade Speed",
-        "id": "zoomParam2",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Wipe Radius",
-        "id": "zoomParam3",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Blur Amount",
-        "id": "zoomParam4",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "feedback"
+      "fluid-dynamics",
+      "mouse-driven"
     ],
     "tags": [
       "simulation",
@@ -1809,272 +402,522 @@
     ]
   },
   {
-    "id": "sim-sand-dunes-rgba",
-    "name": "Sim: Sand Dunes RGBA",
-    "url": "shaders/sim-sand-dunes-rgba.wgsl",
+    "id": "dla-crystals",
+    "name": "DLA Crystal Growth",
+    "url": "shaders/dla-crystals.wgsl",
     "category": "simulation",
-    "description": "Four-grain-type sand physics with distinct behaviors. Fine sand blows easily in wind, coarse sand is stable with high angle of repose, moist sand clumps together, and dust rises on updrafts. RGBA packs all grain fractions per cell.",
-    "tags": [
-      "simulation",
-      "sand",
-      "physics",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "wind",
-      "erosion"
+    "description": "Diffusion-limited aggregation creating fractal crystal structures that grow from click points.",
+    "params": [
+      {
+        "id": "walkerSpeed",
+        "name": "Walker Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "attractStrength",
+        "name": "Attraction Strength",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "stickiness",
+        "name": "Stickiness",
+        "default": 0.7,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "branchAngle",
+        "name": "Branch Angle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
     ],
     "features": [
+      "temporal-persistence",
+      "interactive",
+      "fractal",
       "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
+      "audio-reactive",
+      "audio-driven"
     ],
+    "tags": [
+      "simulation",
+      "physics",
+      "audio",
+      "music",
+      "reactive"
+    ]
+  },
+  {
+    "id": "fabric-step",
+    "name": "Fabric of Reality",
+    "url": "shaders/fabric-step.wgsl",
+    "category": "simulation",
+    "description": "Mass-spring cloth simulation with Verlet integration, constraint solving, and interactive tearing mechanics.",
     "params": [
+      {
+        "id": "stiffness",
+        "name": "Stiffness",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "tearThreshold",
+        "name": "Tear Threshold",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
       {
         "id": "gravity",
         "name": "Gravity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "wind",
-        "name": "Wind",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "moisture",
-        "name": "Moisture",
-        "type": "float",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "dustiness",
-        "name": "Dustiness",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "damping",
+        "name": "Damping",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
-    ]
-  },
-  {
-    "id": "sim-ink-diffusion-rgba",
-    "name": "Sim: Ink Diffusion RGBA",
-    "url": "shaders/sim-ink-diffusion-rgba.wgsl",
-    "category": "simulation",
-    "description": "Four-ink wet diffusion simulation on paper texture. RGB channels hold cyan, magenta, and yellow pigment concentrations; alpha holds water saturation that drives all diffusion. Pigments mix subtractively on wet paper.",
+    ],
+    "features": [
+      "depth-aware",
+      "temporal-persistence",
+      "interactive",
+      "physics",
+      "mouse-driven"
+    ],
     "tags": [
       "simulation",
-      "ink",
-      "diffusion",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "artistic",
-      "paper"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "wetness",
-        "name": "Wetness",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "diffusion",
-        "name": "Pigment Diffusion",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorMixing",
-        "name": "Color Mixing",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "evaporation",
-        "name": "Evaporation Rate",
-        "type": "float",
-        "default": 0.8,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
+      "physics"
     ]
   },
   {
-    "id": "cellular-automata-rgba",
-    "name": "Cellular Automata RGBA",
-    "url": "shaders/cellular-automata-rgba.wgsl",
+    "id": "lenia",
+    "name": "Lenia Cellular Automata",
+    "url": "shaders/lenia.wgsl",
     "category": "simulation",
-    "description": "2D ecosystem cellular automaton with four interacting species packed into RGBA. Plants grow from nutrients, herbivores eat plants, predators eat herbivores, and all dead matter cycles back to soil nutrients. Continuous densities enable stable predator-prey oscillations.",
+    "description": "Continuous cellular automata (Lenia) with ring kernel growth functions.",
+    "features": [
+      "mouse-driven"
+    ],
     "tags": [
       "simulation",
-      "cellular-automata",
-      "ecosystem",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "organic",
-      "predator-prey"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
+      "physics"
     ],
     "params": [
       {
-        "id": "growthRate",
-        "name": "Plant Growth",
-        "type": "float",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "herbivoreEff",
-        "name": "Herbivore Efficiency",
-        "type": "float",
+        "id": "param2",
+        "name": "Speed",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "predatorEff",
-        "name": "Predator Efficiency",
-        "type": "float",
+        "id": "param3",
+        "name": "Scale",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "decayRate",
-        "name": "Decay Rate",
-        "type": "float",
+        "id": "param4",
+        "name": "Detail",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]
   },
   {
-    "id": "sim-slime-mold-growth",
-    "name": "Slime Mold Growth",
-    "url": "shaders/sim-slime-mold-growth.wgsl",
+    "id": "magnetic-dipole",
+    "name": "Magnetic Dipole Field",
+    "url": "shaders/magnetic-dipole.wgsl",
     "category": "simulation",
-    "description": "Physarum-style slime mold with trail following. Branching network of glowing trails exploring space.",
+    "description": "Magnetic field visualization with iron filing alignment and dipole physics.",
+    "params": [
+      {
+        "id": "chargeStrength",
+        "name": "Charge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "alignmentInertia",
+        "name": "Alignment Inertia",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "spriteSize",
+        "name": "Filing Size",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "fieldDensity",
+        "name": "Field Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
     "features": [
+      "temporal-persistence",
+      "interactive",
+      "physics",
+      "mouse-driven"
+    ],
+    "tags": [
       "simulation",
-      "agent-based",
-      "chemoattractant",
-      "sensor-steering",
-      "randomization-safe"
+      "physics"
+    ]
+  },
+  {
+    "id": "melting-oil",
+    "name": "Melting Oil",
+    "url": "shaders/melting-oil.wgsl",
+    "category": "simulation",
+    "description": "Sobel gradient-driven oil-paint flow with viscosity and hue shifts.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
     ],
     "params": [
       {
-        "id": "sensor_angle",
-        "name": "Sensor Angle",
+        "id": "viscosity",
+        "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Steering sensitivity (sensor angle)"
+        "description": "Liquid thickness/resistance"
       },
       {
-        "id": "decay",
-        "name": "Trail Decay",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Trail decay rate"
+        "description": "Chaotic flow intensity"
       },
       {
-        "id": "particle_count",
-        "name": "Particle Count",
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
-        "description": "Number of simulated particles"
+        "description": "Wave distortion amount"
       },
       {
-        "id": "randomness",
-        "name": "Randomness",
+        "id": "color_shift",
+        "name": "Color Shift",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Randomness/jitter in movement"
+        "description": "Color manipulation amount"
       }
-    ],
-    "chunks_used": [
-      "hash12 (gen_grid.wgsl)",
-      "hash22 (gen_grid.wgsl)",
-      "Physarum agent simulation",
-      "Trail deposition",
-      "Sensor-based steering"
-    ],
-    "performance_target": "30-45 FPS (GTX 1060)",
-    "created_by": "Agent 3B - Advanced Hybrid Creator",
-    "created_date": "2026-03-22"
+    ]
   },
   {
-    "id": "quantum-foam-pass1",
-    "name": "Quantum Foam (Pass 1: Field Generation)",
-    "url": "shaders/quantum-foam-pass1.wgsl",
+    "id": "multi-turing",
+    "name": "Multiscale Turing Patterns",
+    "url": "shaders/multi-turing.wgsl",
     "category": "simulation",
-    "description": "Generates quantum probability field with curl noise and FBM. First pass of 3-pass system.",
-    "features": [
-      "multi-pass-1",
-      "compute-shader",
-      "temporal"
+    "description": "Multiple reaction-diffusion systems at different scales combined for organic pattern generation.",
+    "params": [
+      {
+        "id": "feed1",
+        "name": "Feed Rate 1",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "kill1",
+        "name": "Kill Rate 1",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "feed2",
+        "name": "Feed Rate 2",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "kill2",
+        "name": "Kill Rate 2",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
     ],
-    "multipass": {
-      "pass": 1,
-      "totalPasses": 3,
-      "nextShader": "quantum-foam-pass2"
-    },
+    "features": [
+      "temporal-persistence",
+      "interactive",
+      "organic-growth",
+      "mouse-driven"
+    ],
     "tags": [
-      "quantum",
-      "field-generation",
-      "noise",
-      "simulation"
+      "simulation",
+      "physics"
+    ]
+  },
+  {
+    "id": "navier-stokes-dye",
+    "name": "Navier-Stokes Dye",
+    "url": "shaders/navier-stokes-dye.wgsl",
+    "category": "simulation",
+    "description": "Velocity advection and dye injection with a pressure-like solve placeholder.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Liquid thickness/resistance"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chaotic flow intensity"
+      },
+      {
+        "id": "ripple_strength",
+        "name": "Ripple Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Wave distortion amount"
+      },
+      {
+        "id": "color_shift",
+        "name": "Color Shift",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Color manipulation amount"
+      }
+    ]
+  },
+  {
+    "id": "physarum-gemini",
+    "name": "Physarum Gemini",
+    "url": "shaders/physarum-gemini.wgsl",
+    "category": "simulation",
+    "description": "An advanced, agent-based slime mold simulation with emergent, time-driven growth patterns, complex nutrient interaction, and mouse-driven agent spawning.",
+    "features": [
+      "mouse-driven",
+      "time-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "physarum-grokcf1",
+    "name": "Physarum grokcf1",
+    "url": "shaders/physarum-grokcf1.wgsl",
+    "category": "simulation",
+    "description": "An advanced, agent-based slime mold simulation with emergent, time-driven growth patterns, complex nutrient interaction, and mouse-driven agent spawning.",
+    "features": [
+      "mouse-driven",
+      "time-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "physarum",
+    "name": "Physarum Slime Mold",
+    "url": "shaders/physarum.wgsl",
+    "category": "simulation",
+    "description": "Agent-based slime mold texture feeder that creates trails and networks.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics",
+      "audio",
+      "music",
+      "reactive"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "reaction-diffusion",
+    "name": "Reaction-Diffusion",
+    "url": "shaders/reaction-diffusion.wgsl",
+    "category": "simulation",
+    "description": "Grey-Scott style color bleed with cross-channel inhibition.",
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
     ],
     "params": [
       {
@@ -2225,144 +1068,236 @@
     "target_rating": 4.7
   },
   {
-    "id": "chromatographic-separation",
-    "name": "Chromatographic Separation",
-    "url": "shaders/chromatographic-separation.wgsl",
+    "id": "hybrid-particle-fluid",
+    "name": "Hybrid Particle Fluid",
+    "url": "shaders/hybrid-particle-fluid.wgsl",
     "category": "simulation",
-    "description": "RGB channel fluid simulation with separate viscosities, wind forces, and inter-layer drag.",
+    "description": "Particles that move like fluid with glowing trails, combining particle advection with curl noise velocity field",
+    "features": [
+      "hybrid",
+      "particle-system",
+      "fluid-advection",
+      "glow",
+      "curl-noise",
+      "randomization-safe"
+    ],
     "params": [
       {
-        "id": "viscosityR",
-        "name": "Red Viscosity",
-        "default": 0.3,
+        "id": "particle_count",
+        "name": "Particle Density",
+        "default": 0.4,
         "min": 0,
-        "max": 1
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Number of particles in simulation"
       },
       {
-        "id": "viscosityG",
-        "name": "Green Viscosity",
+        "id": "flow_speed",
+        "name": "Flow Speed",
         "default": 0.5,
         "min": 0,
-        "max": 1
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Fluid velocity magnitude"
       },
       {
-        "id": "viscosityB",
-        "name": "Blue Viscosity",
-        "default": 0.7,
+        "id": "trails",
+        "name": "Trail Decay",
+        "default": 0.8,
         "min": 0,
-        "max": 1
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "How long trails persist (higher = longer)"
       },
       {
-        "id": "temperature",
-        "name": "Temperature",
-        "default": 0.3,
+        "id": "glow_size",
+        "name": "Glow Size",
+        "default": 0.4,
         "min": 0,
-        "max": 1
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Size of particle glow effect"
       }
     ],
+    "chunks_used": [
+      "curl noise velocity field",
+      "fbm2 (gen_grid.wgsl)",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "hybrid-reaction-diffusion-glass",
+    "name": "Hybrid Reaction-Diffusion Glass",
+    "url": "shaders/hybrid-reaction-diffusion-glass.wgsl",
+    "category": "simulation",
+    "description": "Turing patterns (reaction-diffusion) refracted through depth-aware glass distortion",
     "features": [
+      "hybrid",
+      "reaction-diffusion",
+      "glass-distortion",
       "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "fluid-dynamics",
-      "mouse-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics"
-    ]
-  },
-  {
-    "id": "boids",
-    "name": "Boids Reveal",
-    "url": "shaders/boids.wgsl",
-    "category": "simulation",
-    "description": "Flocking boids with reveal masking and simple attraction mechanics.",
-    "features": [
-      "mouse-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics"
+      "fresnel",
+      "randomization-safe"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
+        "id": "feed_rate",
+        "name": "Feed Rate",
+        "default": 0.4,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Chemical feed rate (pattern density)"
       },
       {
-        "id": "param2",
-        "name": "Speed",
+        "id": "kill_rate",
+        "name": "Kill Rate",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Chemical kill rate (pattern stability)"
       },
       {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
+        "id": "refraction",
+        "name": "Glass Refraction",
+        "default": 0.4,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Strength of glass refraction"
       },
       {
-        "id": "param4",
-        "name": "Detail",
+        "id": "depth_effect",
+        "name": "Depth Effect",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "How much depth affects distortion"
       }
+    ],
+    "chunks_used": [
+      "Gray-Scott reaction-diffusion (reaction-diffusion.wgsl)",
+      "fresnelSchlick (crystal-facets.wgsl)",
+      "laplacian operator",
+      "palette (gen-xeno-botanical-synth-flora.wgsl)"
+    ],
+    "created_by": "Agent 2A - Shader Surgeon",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "aero-chromatics",
+    "name": "Aero Chromatics",
+    "category": "simulation",
+    "url": "shaders/aero-chromatics.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Wind tunnel simulation where image brightness determines aerodynamic drag, creating chromatic smoke trails.",
+    "params": [
+      {
+        "id": "wind-strength",
+        "name": "Wind Force",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "decay",
+        "name": "Smoke Decay",
+        "type": "float",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "chroma",
+        "name": "Chromatic Split",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "source-mix",
+        "name": "Source Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "simulation",
+      "physics"
     ]
   },
   {
-    "id": "physarum-gemini",
-    "name": "Physarum Gemini",
-    "url": "shaders/physarum-gemini.wgsl",
+    "id": "alpha-crystal-growth-phase",
+    "name": "Alpha Crystal Growth Phase",
+    "url": "shaders/alpha-crystal-growth-phase.wgsl",
     "category": "simulation",
-    "description": "An advanced, agent-based slime mold simulation with emergent, time-driven growth patterns, complex nutrient interaction, and mouse-driven agent spawning.",
+    "description": "Phase-field model of crystal growth with RGBA-packed state. Phase (solid/liquid), temperature, crystal orientation, and impurity concentration evolve together. Creates dendritic crystal patterns with orientation-dependent color. Mouse seeds new crystals; ripples trigger nucleation.",
+    "tags": [
+      "crystal",
+      "growth",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine",
+      "dendritic"
+    ],
     "features": [
       "mouse-driven",
-      "time-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics"
+      "temporal",
+      "rgba-state-machine"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
+        "id": "supercooling",
+        "name": "Supercooling",
+        "type": "float",
         "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
+        "id": "anisotropy",
+        "name": "Anisotropy",
+        "type": "float",
+        "default": 0.3,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
+        "id": "growthRate",
+        "name": "Growth Rate",
+        "type": "float",
+        "default": 0.4,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
+        "id": "impurity",
+        "name": "Impurity Level",
+        "type": "float",
+        "default": 0.2,
         "min": 0,
         "max": 1,
         "step": 0.01
@@ -2370,69 +1305,708 @@
     ]
   },
   {
-    "id": "dla-crystals",
-    "name": "DLA Crystal Growth",
-    "url": "shaders/dla-crystals.wgsl",
+    "id": "alpha-em-field-simulation",
+    "name": "Alpha EM Field Simulation",
+    "url": "shaders/alpha-em-field-simulation.wgsl",
     "category": "simulation",
-    "description": "Diffusion-limited aggregation creating fractal crystal structures that grow from click points.",
+    "description": "Electromagnetic field simulation using RGBA32FLOAT as four data channels: R=E-field X, G=E-field Y, B=magnetic potential, A=charge density. Mouse and ripples inject alternating positive/negative charges. Wave equation propagation with damping.",
+    "tags": [
+      "electromagnetic",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "field",
+      "wave",
+      "rgba-state-machine"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
     "params": [
       {
-        "id": "walkerSpeed",
-        "name": "Walker Speed",
+        "id": "damping",
+        "name": "Field Damping",
+        "type": "float",
         "default": 0.5,
         "min": 0,
-        "max": 1
+        "max": 1,
+        "step": 0.01
       },
       {
-        "id": "attractStrength",
-        "name": "Attraction Strength",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "stickiness",
-        "name": "Stickiness",
+        "id": "chargeIntensity",
+        "name": "Charge Intensity",
+        "type": "float",
         "default": 0.7,
         "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "bFieldVis",
+        "name": "B-Field Visibility",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "waveSpeed",
+        "name": "Wave Speed",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-erosion-terrain",
+    "name": "Alpha Erosion Terrain",
+    "url": "shaders/alpha-erosion-terrain.wgsl",
+    "category": "simulation",
+    "description": "Hydraulic erosion simulation with RGBA-packed terrain state. Height from image luminance is eroded by flowing water that picks up sediment and deposits it in flat areas. Mouse creates rainstorms; ripples trigger flash floods. Alpha tracks cumulative erosion history.",
+    "tags": [
+      "erosion",
+      "terrain",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine",
+      "hydraulic"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "rainRate",
+        "name": "Rain Rate",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "erosionRate",
+        "name": "Erosion Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "depositionRate",
+        "name": "Deposition Rate",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "sedimentCapacity",
+        "name": "Sediment Capacity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-fire-temperature",
+    "name": "Alpha Fire Temperature",
+    "url": "shaders/alpha-fire-temperature.wgsl",
+    "category": "simulation",
+    "description": "Fire simulation with RGBA-packed state: fuel, temperature, smoke density, and combustion age. Temperature drives blackbody radiation color. Fuel burns, generates smoke, and heat rises via convection. Mouse injects fuel; ripples create sparks.",
+    "tags": [
+      "fire",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine",
+      "blackbody",
+      "smoke"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "burnRate",
+        "name": "Burn Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "convection",
+        "name": "Convection",
+        "type": "float",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "smokeDensity",
+        "name": "Smoke Density",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "emberGlow",
+        "name": "Ember Glow",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-fluid-simulation-paint",
+    "name": "Alpha Fluid Simulation Paint",
+    "url": "shaders/alpha-fluid-simulation-paint.wgsl",
+    "category": "simulation",
+    "description": "Full 2D incompressible fluid simulation packed into a single RGBA32FLOAT texture. R=velocity.x, G=velocity.y, B=pressure, A=dye density. Mouse creates vortices and injects dye. Requires f32 for signed velocity and pressure fields.",
+    "tags": [
+      "fluid",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "navier-stokes",
+      "psychedelic",
+      "colorful",
+      "rgba-state-machine"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "viscosity",
+        "name": "Viscosity",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dyeBrightness",
+        "name": "Dye Brightness",
+        "type": "float",
+        "default": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "vorticity",
+        "name": "Vorticity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "decayRate",
+        "name": "Decay Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-multi-state-ecosystem",
+    "name": "Alpha Multi-State Ecosystem",
+    "url": "shaders/alpha-multi-state-ecosystem.wgsl",
+    "category": "simulation",
+    "description": "Continuous multi-species ecosystem simulation packed into RGBA32FLOAT. Two species compete for shared resources while producing toxins. Species diffuse, grow, compete, and die. Mouse nurtures by adding resources.",
+    "tags": [
+      "ecosystem",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "cellular-automata",
+      "pattern",
+      "rgba-state-machine"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "growthRate1",
+        "name": "Species 1 Growth",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "growthRate2",
+        "name": "Species 2 Growth",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "diffusion",
+        "name": "Diffusion Rate",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "toxinStrength",
+        "name": "Toxin Strength",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-reaction-diffusion-rgba",
+    "name": "Alpha Reaction Diffusion RGBA",
+    "url": "shaders/alpha-reaction-diffusion-rgba.wgsl",
+    "category": "simulation",
+    "description": "Four-species reaction-diffusion simulation packed into RGBA32FLOAT. A feeds B, C feeds D, with cross-inhibition between pairs. Creates complex multi-color patterns impossible in 2-species systems.",
+    "tags": [
+      "reaction-diffusion",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "pattern",
+      "rgba-state-machine",
+      "colorful"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "feed",
+        "name": "Feed Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "kill",
+        "name": "Kill Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "crossInhibit",
+        "name": "Cross Inhibition",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "sourceMix",
+        "name": "Source Mix",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "bitonic-sort",
+    "name": "Bitonic Pixel Sort",
+    "url": "shaders/bitonic-sort.wgsl",
+    "category": "simulation",
+    "description": "Workgroup bitonic pixel sort with FBM-enhanced sort keys, bass-reactive mixing, and semantic luminance-key alpha.",
+    "features": [
+      "upgraded-rgba",
+      "depth-aware",
+      "audio-reactive",
+      "mouse-driven",
+      "multi-ripple"
+    ],
+    "tags": [
+      "simulation",
+      "filter",
+      "glitch",
+      "algorithmic",
+      "sort",
+      "noise"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Sort Mix",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Noise Mix",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Sort Direction",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "labels": [
+          "Ascending",
+          "Descending"
+        ]
+      },
+      {
+        "id": "param4",
+        "name": "Noise Octaves",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "cellular-automata-rgba",
+    "name": "Cellular Automata RGBA",
+    "url": "shaders/cellular-automata-rgba.wgsl",
+    "category": "simulation",
+    "description": "2D ecosystem cellular automaton with four interacting species packed into RGBA. Plants grow from nutrients, herbivores eat plants, predators eat herbivores, and all dead matter cycles back to soil nutrients. Continuous densities enable stable predator-prey oscillations.",
+    "tags": [
+      "simulation",
+      "cellular-automata",
+      "ecosystem",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "organic",
+      "predator-prey"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "growthRate",
+        "name": "Plant Growth",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "herbivoreEff",
+        "name": "Herbivore Efficiency",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "predatorEff",
+        "name": "Predator Efficiency",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "decayRate",
+        "name": "Decay Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "chromatic-reaction-diffusion-rgba",
+    "name": "Chromatic Reaction Diffusion RGBA",
+    "url": "shaders/chromatic-reaction-diffusion-rgba.wgsl",
+    "category": "simulation",
+    "description": "Four-species reaction-diffusion with chromatic cross-coupling. Activators A/C and inhibitors B/D form warm/cool tone pairs that suppress each other at boundaries, creating iridescent fringe patterns. RGBA packs full simulation state.",
+    "tags": [
+      "reaction-diffusion",
+      "simulation",
+      "interactive",
+      "mouse-driven",
+      "pattern",
+      "rgba-state-machine",
+      "chromatic",
+      "colorful"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "feed",
+        "name": "Feed Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "kill",
+        "name": "Kill Rate",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chromaticSep",
+        "name": "Chromatic Separation",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "crossCouple",
+        "name": "Cross Coupling",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "luma-flow-field",
+    "category": "simulation",
+    "url": "shaders/luma-flow-field.wgsl",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Flow Speed",
+        "default": 1,
+        "min": 0,
+        "max": 5
+      },
+      {
+        "id": "param2",
+        "name": "Decay",
+        "default": 0.96,
+        "min": 0.9,
+        "max": 0.999
+      },
+      {
+        "id": "param3",
+        "name": "Mouse Force",
+        "default": 0.5,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "param4",
+        "name": "Color Shift",
+        "default": 0.01,
+        "min": 0,
+        "max": 0.1
+      }
+    ],
+    "tags": [
+      "simulation",
+      "physics"
+    ],
+    "name": "Luma Flow Field"
+  },
+  {
+    "id": "nano-assembler",
+    "name": "Nano Assembler",
+    "url": "shaders/nano-assembler.wgsl",
+    "category": "simulation",
+    "description": "Simulates nanobots constructing the image. Mouse movement disrupts the assembly, scattering the particles.",
+    "params": [
+      {
+        "id": "assembly_progress",
+        "name": "Assembly",
+        "default": 1,
+        "min": 0,
         "max": 1
       },
       {
-        "id": "branchAngle",
-        "name": "Branch Angle",
+        "id": "particle_density",
+        "name": "Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "scatter_force",
+        "name": "Disruption",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "rebuild_speed",
+        "name": "Rebuild Speed",
         "default": 0.5,
         "min": 0,
         "max": 1
       }
     ],
     "features": [
-      "temporal-persistence",
-      "interactive",
-      "fractal",
+      "mouse-driven"
+    ],
+    "tags": [
+      "simulation",
+      "physics"
+    ]
+  },
+  {
+    "id": "pixel-sand",
+    "name": "Pixel Sand",
+    "url": "shaders/pixel-sand.wgsl",
+    "category": "simulation",
+    "description": "Falling granular automata with curl noise force fields, height-field weight physics, mouse gravity wells, audio-reactive spawn, depth shading, and bounce.",
+    "features": [
+      "upgraded-rgba",
       "mouse-driven",
       "audio-reactive",
-      "audio-driven"
+      "depth-aware",
+      "temporal"
     ],
     "tags": [
+      "sand",
+      "granular",
+      "falling",
+      "interactive",
+      "audio-reactive",
+      "particles",
       "simulation",
-      "physics",
-      "audio",
-      "music",
-      "reactive"
+      "curl-noise"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Gravity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Particle Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Curl Force",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Bounce",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
     ]
   },
   {
-    "id": "reaction-diffusion",
-    "name": "Reaction-Diffusion",
-    "url": "shaders/reaction-diffusion.wgsl",
+    "id": "quantum-foam-pass1",
+    "name": "Quantum Foam (Pass 1: Field Generation)",
+    "url": "shaders/quantum-foam-pass1.wgsl",
     "category": "simulation",
-    "description": "Grey-Scott style color bleed with cross-channel inhibition.",
+    "description": "Generates quantum probability field with curl noise and FBM. First pass of 3-pass system.",
     "features": [
-      "mouse-driven"
+      "multi-pass-1",
+      "compute-shader",
+      "temporal"
     ],
+    "multipass": {
+      "pass": 1,
+      "totalPasses": 3,
+      "nextShader": "quantum-foam-pass2"
+    },
     "tags": [
-      "simulation",
-      "physics"
+      "quantum",
+      "field-generation",
+      "noise",
+      "simulation"
     ],
     "params": [
       {
@@ -2470,17 +2044,27 @@
     ]
   },
   {
-    "id": "lenia",
-    "name": "Lenia Cellular Automata",
-    "url": "shaders/lenia.wgsl",
+    "id": "quantum-foam-pass2",
+    "name": "Quantum Foam (Pass 2: Particle Advection)",
+    "url": "shaders/quantum-foam-pass2.wgsl",
     "category": "simulation",
-    "description": "Continuous cellular automata (Lenia) with ring kernel growth functions.",
+    "description": "Advects particles through the quantum field. Second pass of 3-pass system.",
     "features": [
-      "mouse-driven"
+      "multi-pass-2",
+      "compute-shader",
+      "temporal"
     ],
+    "multipass": {
+      "pass": 2,
+      "totalPasses": 3,
+      "prevShader": "quantum-foam-pass1",
+      "nextShader": "quantum-foam-pass3"
+    },
     "tags": [
-      "simulation",
-      "physics"
+      "quantum",
+      "particles",
+      "advection",
+      "simulation"
     ],
     "params": [
       {
@@ -2518,160 +2102,337 @@
     ]
   },
   {
-    "id": "navier-stokes-dye",
-    "name": "Navier-Stokes Dye",
-    "url": "shaders/navier-stokes-dye.wgsl",
+    "id": "quantum-foam-pass3",
+    "name": "Quantum Foam (Pass 3: Compositing)",
+    "url": "shaders/quantum-foam-pass3.wgsl",
     "category": "simulation",
-    "description": "Velocity advection and dye injection with a pressure-like solve placeholder.",
+    "description": "Volumetric rendering and final compositing with glow and tone mapping. Third pass of 3-pass system.",
     "features": [
-      "mouse-driven"
+      "multi-pass-3",
+      "compute-shader",
+      "post-processing"
     ],
+    "multipass": {
+      "pass": 3,
+      "totalPasses": 3,
+      "prevShader": "quantum-foam-pass2"
+    },
+    "tags": [
+      "quantum",
+      "compositing",
+      "glow",
+      "tone-mapping"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param2",
+        "name": "Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "sim-decay-system-rgba",
+    "name": "Sim: Decay System RGBA",
+    "url": "shaders/sim-decay-system-rgba.wgsl",
+    "category": "simulation",
+    "description": "Four-layer material decay simulation with cross-coupling. Paint integrity, metal corrosion, organic rot, and structural integrity each decay at different rates. When one layer fails, others decay faster. Mouse interaction can restore/repair.",
     "tags": [
       "simulation",
-      "physics"
+      "decay",
+      "corrosion",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "rust",
+      "aging"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "baseDecay",
+        "name": "Base Decay",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "edgeVuln",
+        "name": "Edge Vulnerability",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "moisture",
+        "name": "Moisture",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "recovery",
+        "name": "Recovery Rate",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "sim-fluid-feedback-coupled",
+    "name": "Fluid Feedback Coupled",
+    "url": "shaders/sim-fluid-feedback-coupled.wgsl",
+    "category": "simulation",
+    "description": "Mouse-steerable coupled fluid simulation combining Navier-Stokes feedback fields with viscous fluid stirring. Mouse drags fluid creating vortex streets; click ripples inject bursts. Fluid thickness drives color absorption, blur, and glow.",
+    "features": [
+      "simulation",
+      "mouse-driven",
+      "temporal",
+      "navier-stokes",
+      "fluid-coupling",
+      "randomization-safe"
     ],
     "params": [
       {
         "id": "viscosity",
         "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
+        "description": "Fluid viscosity / damping"
       },
       {
         "id": "turbulence",
         "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
+        "description": "Curl noise turbulence amount"
       },
       {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "fade_rate",
+        "name": "Fade Rate",
+        "default": 0.6,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
+        "description": "Density fade rate over time"
       },
       {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
+        "description": "Glow intensity from fluid density"
       }
-    ]
-  },
-  {
-    "id": "melting-oil",
-    "name": "Melting Oil",
-    "url": "shaders/melting-oil.wgsl",
-    "category": "simulation",
-    "description": "Sobel gradient-driven oil-paint flow with viscosity and hue shifts.",
-    "features": [
-      "mouse-driven"
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "curlNoise (sim-fluid-feedback-field)",
+      "velocity advection (sim-fluid-feedback-field)",
+      "mouse stirring (mouse-fluid-coupling)",
+      "vortex force (mouse-fluid-coupling)"
     ],
     "tags": [
+      "fluid",
       "simulation",
-      "physics"
+      "mouse-driven",
+      "interactive",
+      "temporal"
     ],
+    "created_by": "Agent CB-7 - Flow & Multi-Pass Enhancer",
+    "created_date": "2026-04-18"
+  },
+  {
+    "id": "sim-fluid-feedback-field",
+    "name": "Fluid Feedback Field",
+    "url": "shaders/sim-fluid-feedback-field-pass1.wgsl",
+    "category": "simulation",
+    "description": "Multi-pass Navier-Stokes fluid simulation with feedback trails. Glowing fluid that swirls and mixes.",
+    "features": [
+      "simulation",
+      "multi-pass",
+      "navier-stokes",
+      "velocity-advection",
+      "density-advection",
+      "randomization-safe"
+    ],
+    "multipass": {
+      "pass": 1,
+      "totalPasses": 3,
+      "passes": [
+        {
+          "pass": 1,
+          "name": "Velocity Advection",
+          "file": "sim-fluid-feedback-field-pass1.wgsl"
+        },
+        {
+          "pass": 2,
+          "name": "Density Advection",
+          "file": "sim-fluid-feedback-field-pass2.wgsl"
+        },
+        {
+          "pass": 3,
+          "name": "Composite",
+          "file": "sim-fluid-feedback-field-pass3.wgsl"
+        }
+      ]
+    },
     "params": [
       {
         "id": "viscosity",
         "name": "Viscosity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
-        "description": "Liquid thickness/resistance"
+        "description": "Flow resistance (viscosity)"
       },
       {
         "id": "turbulence",
         "name": "Turbulence",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
-        "description": "Chaotic flow intensity"
+        "description": "Turbulence amount"
       },
       {
-        "id": "ripple_strength",
-        "name": "Ripple Strength",
+        "id": "fade_rate",
+        "name": "Fade Rate",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
-        "description": "Wave distortion amount"
+        "description": "Density fade rate"
       },
       {
-        "id": "color_shift",
-        "name": "Color Shift",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "id": "glow",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
-        "description": "Color manipulation amount"
+        "description": "Glow intensity"
       }
-    ]
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "noise",
+      "Curl noise",
+      "Velocity advection",
+      "Density advection"
+    ],
+    "performance_target": "45-60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
   },
   {
-    "id": "physarum-grokcf1",
-    "name": "Physarum grokcf1",
-    "url": "shaders/physarum-grokcf1.wgsl",
+    "id": "sim-ink-diffusion-rgba",
+    "name": "Sim: Ink Diffusion RGBA",
+    "url": "shaders/sim-ink-diffusion-rgba.wgsl",
     "category": "simulation",
-    "description": "An advanced, agent-based slime mold simulation with emergent, time-driven growth patterns, complex nutrient interaction, and mouse-driven agent spawning.",
+    "description": "Four-ink wet diffusion simulation on paper texture. RGB channels hold cyan, magenta, and yellow pigment concentrations; alpha holds water saturation that drives all diffusion. Pigments mix subtractively on wet paper.",
+    "tags": [
+      "simulation",
+      "ink",
+      "diffusion",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "artistic",
+      "paper"
+    ],
     "features": [
       "mouse-driven",
-      "time-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics"
+      "temporal",
+      "rgba-state-machine"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
+        "id": "wetness",
+        "name": "Wetness",
+        "type": "float",
         "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param2",
-        "name": "Speed",
+        "id": "diffusion",
+        "name": "Pigment Diffusion",
+        "type": "float",
         "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param3",
-        "name": "Scale",
+        "id": "colorMixing",
+        "name": "Color Mixing",
+        "type": "float",
         "default": 0.5,
         "min": 0,
         "max": 1,
         "step": 0.01
       },
       {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
+        "id": "evaporation",
+        "name": "Evaporation Rate",
+        "type": "float",
+        "default": 0.8,
         "min": 0,
         "max": 1,
         "step": 0.01
@@ -2679,194 +2440,433 @@
     ]
   },
   {
-    "id": "multi-turing",
-    "name": "Multiscale Turing Patterns",
-    "url": "shaders/multi-turing.wgsl",
+    "id": "sim-sand-dunes-rgba",
+    "name": "Sim: Sand Dunes RGBA",
+    "url": "shaders/sim-sand-dunes-rgba.wgsl",
     "category": "simulation",
-    "description": "Multiple reaction-diffusion systems at different scales combined for organic pattern generation.",
-    "params": [
-      {
-        "id": "feed1",
-        "name": "Feed Rate 1",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "kill1",
-        "name": "Kill Rate 1",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "feed2",
-        "name": "Feed Rate 2",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "kill2",
-        "name": "Kill Rate 2",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "temporal-persistence",
+    "description": "Four-grain-type sand physics with distinct behaviors. Fine sand blows easily in wind, coarse sand is stable with high angle of repose, moist sand clumps together, and dust rises on updrafts. RGBA packs all grain fractions per cell.",
+    "tags": [
+      "simulation",
+      "sand",
+      "physics",
       "interactive",
-      "organic-growth",
-      "mouse-driven"
+      "mouse-driven",
+      "rgba-state-machine",
+      "wind",
+      "erosion"
     ],
-    "tags": [
-      "simulation",
-      "physics"
-    ]
-  },
-  {
-    "id": "physarum",
-    "name": "Physarum Slime Mold",
-    "url": "shaders/physarum.wgsl",
-    "category": "simulation",
-    "description": "Agent-based slime mold texture feeder that creates trails and networks.",
     "features": [
       "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics",
-      "audio",
-      "music",
-      "reactive"
+      "temporal",
+      "rgba-state-machine"
     ],
     "params": [
-      {
-        "id": "param1",
-        "name": "Intensity",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param2",
-        "name": "Speed",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param3",
-        "name": "Scale",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      },
-      {
-        "id": "param4",
-        "name": "Detail",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "magnetic-dipole",
-    "name": "Magnetic Dipole Field",
-    "url": "shaders/magnetic-dipole.wgsl",
-    "category": "simulation",
-    "description": "Magnetic field visualization with iron filing alignment and dipole physics.",
-    "params": [
-      {
-        "id": "chargeStrength",
-        "name": "Charge Strength",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "alignmentInertia",
-        "name": "Alignment Inertia",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "spriteSize",
-        "name": "Filing Size",
-        "default": 0.3,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "fieldDensity",
-        "name": "Field Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      }
-    ],
-    "features": [
-      "temporal-persistence",
-      "interactive",
-      "physics",
-      "mouse-driven"
-    ],
-    "tags": [
-      "simulation",
-      "physics"
-    ]
-  },
-  {
-    "id": "fabric-step",
-    "name": "Fabric of Reality",
-    "url": "shaders/fabric-step.wgsl",
-    "category": "simulation",
-    "description": "Mass-spring cloth simulation with Verlet integration, constraint solving, and interactive tearing mechanics.",
-    "params": [
-      {
-        "id": "stiffness",
-        "name": "Stiffness",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
-      {
-        "id": "tearThreshold",
-        "name": "Tear Threshold",
-        "default": 0.5,
-        "min": 0,
-        "max": 1
-      },
       {
         "id": "gravity",
         "name": "Gravity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "wind",
+        "name": "Wind",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "moisture",
+        "name": "Moisture",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dustiness",
+        "name": "Dustiness",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "sim-sand-dunes",
+    "name": "Sand Dunes",
+    "url": "shaders/sim-sand-dunes.wgsl",
+    "category": "simulation",
+    "description": "Falling sand physics with wind erosion. Sand falls, piles at angle of repose, wind moves loose sand.",
+    "features": [
+      "simulation",
+      "cellular-automata",
+      "falling-sand",
+      "wind-erosion",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "gravity",
+        "name": "Gravity Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Gravity strength"
+      },
+      {
+        "id": "wind",
+        "name": "Wind Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Wind direction and speed"
+      },
+      {
+        "id": "viscosity",
+        "name": "Sand Viscosity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Sand viscosity"
+      },
+      {
+        "id": "erosion",
+        "name": "Erosion Rate",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Wind erosion rate"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "Sand physics rules",
+      "Wind simulation"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "sim-slime-mold-growth-em",
+    "name": "Slime Mold Growth + EM Field",
+    "url": "shaders/sim-slime-mold-growth-em.wgsl",
+    "category": "simulation",
+    "description": "Physarum slime mold simulation with mouse electromagnetic field interaction. Agents steer along electric field lines; click ripples spawn secondary charges.",
+    "features": [
+      "simulation",
+      "agent-based",
+      "mouse-driven",
+      "electromagnetic",
+      "interactive",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "sensor_angle",
+        "name": "Sensor Angle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Steering sensitivity and EM charge strength"
+      },
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Trail decay rate and field visualization"
+      },
+      {
+        "id": "em_influence",
+        "name": "EM Influence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "How much EM field steers agents"
+      },
+      {
+        "id": "ripple_charge",
+        "name": "Ripple Charge",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Secondary charge strength from clicks"
+      }
+    ],
+    "tags": [
+      "interactive",
+      "mouse-driven",
+      "physics",
+      "slime",
+      "electromagnetic",
+      "agents"
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "hash22 (gen_grid.wgsl)",
+      "hueShift (stellar-plasma.wgsl)",
+      "electricField (mouse-electromagnetic-aurora.wgsl)",
+      "magneticField (mouse-electromagnetic-aurora.wgsl)",
+      "Physarum agent simulation"
+    ],
+    "performance_target": "25-40 FPS (GTX 1060)",
+    "created_by": "Agent CB-4 - Mouse Physics Injector",
+    "created_date": "2026-04-18"
+  },
+  {
+    "id": "sim-slime-mold-growth",
+    "name": "Slime Mold Growth",
+    "url": "shaders/sim-slime-mold-growth.wgsl",
+    "category": "simulation",
+    "description": "Physarum-style slime mold with trail following. Branching network of glowing trails exploring space.",
+    "features": [
+      "simulation",
+      "agent-based",
+      "chemoattractant",
+      "sensor-steering",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "sensor_angle",
+        "name": "Sensor Angle",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Steering sensitivity (sensor angle)"
+      },
+      {
+        "id": "decay",
+        "name": "Trail Decay",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Trail decay rate"
+      },
+      {
+        "id": "particle_count",
+        "name": "Particle Count",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Number of simulated particles"
+      },
+      {
+        "id": "randomness",
+        "name": "Randomness",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Randomness/jitter in movement"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "hash22 (gen_grid.wgsl)",
+      "Physarum agent simulation",
+      "Trail deposition",
+      "Sensor-based steering"
+    ],
+    "performance_target": "30-45 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "sim-smoke-trails",
+    "name": "Smoke Trails",
+    "url": "shaders/sim-smoke-trails.wgsl",
+    "category": "simulation",
+    "description": "Volumetric smoke with vorticity and buoyancy. Billowing smoke rising with natural turbulence.",
+    "features": [
+      "simulation",
+      "volumetric-smoke",
+      "vorticity",
+      "buoyancy",
+      "randomization-safe"
+    ],
+    "params": [
+      {
+        "id": "density",
+        "name": "Smoke Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Smoke density"
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Turbulence strength"
+      },
+      {
+        "id": "rise_speed",
+        "name": "Rise Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Smoke rise speed"
+      },
+      {
+        "id": "dissipation",
+        "name": "Dissipation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Smoke dissipation rate"
+      }
+    ],
+    "chunks_used": [
+      "hash12 (gen_grid.wgsl)",
+      "noise",
+      "Curl noise",
+      "Buoyancy simulation"
+    ],
+    "performance_target": "60 FPS (GTX 1060)",
+    "created_by": "Agent 3B - Advanced Hybrid Creator",
+    "created_date": "2026-03-22"
+  },
+  {
+    "id": "spec-runge-kutta-advection",
+    "name": "Runge-Kutta Advection",
+    "url": "shaders/spec-runge-kutta-advection.wgsl",
+    "category": "simulation",
+    "description": "4th-order Runge-Kutta fluid advection. Dramatically more accurate than Euler method, preserving fine dye structures 10x longer. Mouse creates counter-rotating vortex pairs.",
+    "tags": [
+      "runge-kutta",
+      "RK4",
+      "fluid",
+      "advection",
+      "simulation",
+      "vortex",
+      "temporal"
+    ],
+    "features": [
+      "runge-kutta",
+      "RK4",
+      "fluid-advection",
+      "mouse-driven",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "dt",
+        "name": "Time Step",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "diffusion",
+        "name": "Diffusion",
+        "default": 0.1,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "vortex",
+        "name": "Vortex Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "feedback",
+        "name": "Temporal Feedback",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "target_rating": 4.8
+  },
+  {
+    "id": "steamy-glass",
+    "name": "Steamy Glass",
+    "category": "simulation",
+    "url": "shaders/steamy-glass.wgsl",
+    "description": "Simulates a foggy window that can be wiped clean with the mouse. The steam slowly returns over time.",
+    "params": [
+      {
+        "name": "Fog Density",
+        "id": "zoomParam1",
+        "default": 0.8,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Fade Speed",
+        "id": "zoomParam2",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Wipe Radius",
+        "id": "zoomParam3",
         "default": 0.3,
         "min": 0,
         "max": 1
       },
       {
-        "id": "damping",
-        "name": "Damping",
+        "name": "Blur Amount",
+        "id": "zoomParam4",
         "default": 0.5,
         "min": 0,
         "max": 1
       }
     ],
     "features": [
-      "depth-aware",
-      "temporal-persistence",
-      "interactive",
-      "physics",
-      "mouse-driven"
+      "mouse-driven",
+      "feedback"
     ],
     "tags": [
       "simulation",

--- a/public/shader-lists/visual-effects.json
+++ b/public/shader-lists/visual-effects.json
@@ -1,5 +1,122 @@
 [
   {
+    "id": "parallax_depth_layers",
+    "name": "Parallax Layers RGBA",
+    "url": "shaders/parallax_depth_layers.wgsl",
+    "category": "visual-effects",
+    "description": "5 depth layers with parallax displacement. Each layer has independent alpha for occlusion. Atmospheric perspective and depth of field.",
+    "tags": [
+      "parallax",
+      "depth",
+      "layers",
+      "alpha",
+      "perspective",
+      "scrolling"
+    ],
+    "features": [
+      "rgba",
+      "parallax",
+      "depth-layers",
+      "alpha-occlusion",
+      "dof",
+      "atmospheric"
+    ],
+    "params": [
+      {
+        "id": "param1",
+        "name": "Parallax",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param2",
+        "name": "Layer Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param3",
+        "name": "Depth of Field",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      },
+      {
+        "id": "param4",
+        "name": "Fog",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.1
+      }
+    ],
+    "target_rating": 4.6
+  },
+  {
+    "id": "alpha-depth-fog-volumetric",
+    "name": "Alpha Depth Fog Volumetric",
+    "url": "shaders/alpha-depth-fog-volumetric.wgsl",
+    "category": "visual-effects",
+    "description": "Physically-motivated volumetric fog using depth texture. Alpha stores optical depth / transmittance via Beer-Lambert law. Fog density varies with 3D noise, depth, and height. Mouse clears local fog; ripples create swirling disturbances.",
+    "tags": [
+      "volumetric",
+      "fog",
+      "depth-aware",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "atmospheric"
+    ],
+    "features": [
+      "mouse-driven",
+      "depth-aware",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "fogDensity",
+        "name": "Fog Density",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "fogHeight",
+        "name": "Fog Height",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "turbulence",
+        "name": "Turbulence",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorTemp",
+        "name": "Color Temperature",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
     "id": "alpha-hdr-bloom-chain",
     "name": "Alpha HDR Bloom Chain",
     "url": "shaders/alpha-hdr-bloom-chain.wgsl",
@@ -24,8 +141,8 @@
         "name": "Bloom Radius",
         "type": "float",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
@@ -33,8 +150,8 @@
         "name": "Bloom Intensity",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
@@ -42,8 +159,8 @@
         "name": "Exposure",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
@@ -51,10 +168,390 @@
         "name": "Saturation",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
+    ]
+  },
+  {
+    "id": "alpha-luminance-history",
+    "name": "Alpha Luminance History",
+    "url": "shaders/alpha-luminance-history.wgsl",
+    "category": "visual-effects",
+    "description": "Temporal luminance history with rolling average stored in alpha. Areas that were recently bright retain a warm glow. Creates light-painting and after-image effects. Mouse leaves persistent bright trails.",
+    "tags": [
+      "temporal",
+      "history",
+      "luminance",
+      "glow",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "light-painting"
+    ],
+    "features": [
+      "mouse-driven",
+      "temporal",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "decay",
+        "name": "Memory Decay",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "glowIntensity",
+        "name": "Glow Intensity",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "colorShift",
+        "name": "History Tint",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "diffusion",
+        "name": "Trail Diffusion",
+        "type": "float",
+        "default": 0.2,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-multi-layer-glass",
+    "name": "Alpha Multi-Layer Glass",
+    "url": "shaders/alpha-multi-layer-glass.wgsl",
+    "category": "visual-effects",
+    "description": "Multi-layer glass refraction with RGBA data channels. Simulates looking through 3 layers of procedurally-distorted glass with Fresnel reflection, chromatic aberration, and per-layer tinting. Alpha stores accumulated transmittance.",
+    "tags": [
+      "glass",
+      "refraction",
+      "chromatic",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "fresnel"
+    ],
+    "features": [
+      "mouse-driven",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "ior",
+        "name": "Index of Refraction",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "thickness",
+        "name": "Glass Thickness",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chromatic",
+        "name": "Chromatic Aberration",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "roughness",
+        "name": "Surface Roughness",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "alpha-spectral-decompose",
+    "name": "Alpha Spectral Decompose",
+    "url": "shaders/alpha-spectral-decompose.wgsl",
+    "category": "visual-effects",
+    "description": "Decomposes the image into 4 spectral frequency bands stored in RGBA. Low freq (R), mid-low (G), mid-high (B), high freq/detail (A). Recomposes with user-controlled per-band gain for frequency-equalizer style image manipulation.",
+    "tags": [
+      "spectral",
+      "frequency",
+      "decomposition",
+      "interactive",
+      "mouse-driven",
+      "rgba-state-machine",
+      "filter"
+    ],
+    "features": [
+      "mouse-driven",
+      "rgba-state-machine"
+    ],
+    "params": [
+      {
+        "id": "gainLow",
+        "name": "Low Freq Gain",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "gainMidLow",
+        "name": "Mid-Low Gain",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "gainMidHigh",
+        "name": "Mid-High Gain",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "gainHigh",
+        "name": "High Freq Gain",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "chroma-vortex",
+    "url": "shaders/chroma-vortex.wgsl",
+    "category": "visual-effects",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
+    ],
+    "params": [
+      {
+        "id": "twist",
+        "name": "Vortex Twist",
+        "type": "float",
+        "default": 0.2,
+        "min": -1,
+        "max": 1
+      },
+      {
+        "id": "spread",
+        "name": "RGB Split",
+        "type": "float",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Vortex Radius",
+        "type": "float",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "centerBias",
+        "name": "Center Stability",
+        "type": "float",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "description": "Rotational RGB splitting effect centered on the mouse.",
+    "tags": [
+      "vfx",
+      "particles",
+      "glow",
+      "audio",
+      "music"
+    ],
+    "name": "Chroma Vortex"
+  },
+  {
+    "id": "chromatic-focus-interactive",
+    "name": "Chromatic Focus",
+    "category": "visual-effects",
+    "url": "shaders/chromatic-focus-interactive.wgsl",
+    "description": "Strong chromatic aberration that increases with distance from mouse focus.",
+    "features": [
+      "mouse-driven"
+    ],
+    "params": [
+      {
+        "id": "strength",
+        "name": "Abberation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "blur",
+        "name": "Blur",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "radius",
+        "name": "Focus Rad",
+        "default": 0.2,
+        "min": 0,
+        "max": 0.8
+      },
+      {
+        "id": "hard",
+        "name": "Falloff",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "vfx",
+      "particles",
+      "glow"
+    ]
+  },
+  {
+    "id": "cross-spec-alpha-spectral-bloom",
+    "name": "Spectral Bloom HDR",
+    "url": "shaders/cross-spec-alpha-spectral-bloom.wgsl",
+    "category": "visual-effects",
+    "description": "Crossover shader combining spectral dispersion with HDR bloom using RGBA as independent spectral bands. Decomposes the image into wavelength channels and applies per-band bloom with exposure control in alpha.",
+    "tags": [
+      "crossover",
+      "spectral",
+      "bloom",
+      "hdr",
+      "rgba-as-data",
+      "chromatic"
+    ],
+    "features": [
+      "crossover",
+      "spectral-rendering",
+      "rgba32float-exploiting"
+    ],
+    "params": [
+      {
+        "id": "bloomRadius",
+        "name": "Bloom Radius",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "dispersion",
+        "name": "Dispersion",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "exposure",
+        "name": "Exposure",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "chromaticShift",
+        "name": "Chromatic Shift",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "crt-clear-zone",
+    "name": "CRT Clear Zone",
+    "category": "visual-effects",
+    "url": "shaders/crt-clear-zone.wgsl",
+    "description": "Heavy CRT distortion with chromatic aberration, scanlines, and vignette. A clean, high-resolution zone follows the mouse cursor with an audio-reactive scanline intensity.",
+    "params": [
+      {
+        "name": "Distortion",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "distortion"
+      },
+      {
+        "name": "Aberration",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "id": "aberration"
+      },
+      {
+        "name": "Zone Size",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.3,
+        "id": "zone_size"
+      },
+      {
+        "name": "Scanlines",
+        "type": "f32",
+        "min": 0,
+        "max": 1,
+        "default": 0.5,
+        "id": "scanlines"
+      }
+    ],
+    "features": [
+      "mouse-driven",
+      "audio-reactive"
+    ],
+    "tags": [
+      "crt",
+      "retro",
+      "glitch",
+      "filter",
+      "image-processing"
     ]
   },
   {
@@ -103,158 +600,193 @@
     "name": "Cyber Grid Pulse"
   },
   {
-    "id": "voxel-grid",
-    "name": "Voxel Grid",
-    "url": "shaders/voxel-grid.wgsl",
+    "id": "cyber-scan",
+    "name": "Cyber Scan",
+    "url": "shaders/cyber-scan.wgsl",
+    "category": "visual-effects",
     "features": [
-      "mouse-driven",
-      "audio-reactive"
+      "mouse-driven"
     ],
+    "description": "A digital scanning line that follows the mouse, highlighting edges and overlaying a cybernetic grid.",
     "params": [
       {
-        "id": "grid",
-        "name": "Grid Density",
-        "default": 40.0,
-        "min": 10.0,
-        "max": 100.0
+        "id": "scanWidth",
+        "name": "Scan Width",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "radius",
-        "name": "Touch Radius",
-        "default": 0.4,
-        "min": 0.1,
-        "max": 0.8
+        "id": "gridIntensity",
+        "name": "Grid Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "strength",
-        "name": "Rotation Force",
-        "default": 1.0,
-        "min": 0.0,
-        "max": 2.0
+        "id": "colorSpeed",
+        "name": "Color Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "gap",
-        "name": "Cell Gap",
-        "default": 0.05,
-        "min": 0.0,
-        "max": 0.4
+        "id": "edgeStrength",
+        "name": "Edge Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
     ],
-    "description": "Transforms the image into a grid of rotating 3D voxels that react to mouse proximity and audio bass.",
-    "category": "visual-effects",
     "tags": [
       "vfx",
       "particles",
-      "glow",
-      "audio-reactive"
+      "glow"
     ]
   },
   {
-    "id": "alpha-depth-fog-volumetric",
-    "name": "Alpha Depth Fog Volumetric",
-    "url": "shaders/alpha-depth-fog-volumetric.wgsl",
+    "id": "data-scanner",
     "category": "visual-effects",
-    "description": "Physically-motivated volumetric fog using depth texture. Alpha stores optical depth / transmittance via Beer-Lambert law. Fog density varies with 3D noise, depth, and height. Mouse clears local fog; ripples create swirling disturbances.",
-    "tags": [
-      "volumetric",
-      "fog",
-      "depth-aware",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "atmospheric"
-    ],
+    "url": "shaders/data-scanner.wgsl",
     "features": [
       "mouse-driven",
-      "depth-aware",
-      "rgba-state-machine"
+      "audio-reactive"
     ],
     "params": [
       {
-        "id": "fogDensity",
-        "name": "Fog Density",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "fogHeight",
-        "name": "Fog Height",
-        "type": "float",
+        "id": "param1",
+        "name": "Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       },
       {
-        "id": "turbulence",
-        "name": "Turbulence",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorTemp",
-        "name": "Color Temperature",
-        "type": "float",
+        "id": "param2",
+        "name": "Audio Reactivity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param3",
+        "name": "Scale",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "param4",
+        "name": "Detail",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
+    ],
+    "tags": [
+      "vfx",
+      "particles",
+      "glow"
+    ],
+    "name": "Data Scanner"
+  },
+  {
+    "id": "hex-circuit",
+    "name": "Hex Circuit",
+    "url": "shaders/hex-circuit.wgsl",
+    "category": "visual-effects",
+    "features": [
+      "mouse-driven"
+    ],
+    "description": "Overlays a cybernetic hexagonal grid that highlights image edges and reacts to mouse pulses.",
+    "params": [
+      {
+        "id": "grid_size",
+        "name": "Grid Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glow_strength",
+        "name": "Glow Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "pulse_speed",
+        "name": "Pulse Speed",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "edge_sensitivity",
+        "name": "Edge Sensitivity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "vfx",
+      "particles",
+      "glow"
     ]
   },
   {
-    "id": "interactive-fresnel",
-    "name": "Interactive Fresnel",
-    "url": "shaders/interactive-fresnel.wgsl",
+    "id": "holographic-projection-gpt52",
+    "name": "Holo Projection Prism gpt52",
+    "url": "shaders/holographic-projection-gpt52.wgsl",
     "category": "visual-effects",
-    "description": "Simulates a Fresnel lens with stepped concentric rings. Features chromatic aberration with alpha-aware blending, depth influence, and audio reactivity.",
+    "description": "Prismatic hologram with stabilized focus, scan interference, and spectral tinting.",
     "features": [
       "mouse-driven",
+      "glitch",
+      "animated",
       "audio-reactive",
       "audio-driven"
     ],
     "params": [
       {
-        "id": "ringDensity",
-        "name": "Ring Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "scanSpeed",
+        "name": "Scan Speed",
+        "min": 0,
+        "max": 5,
+        "default": 1.2
       },
       {
-        "id": "magnification",
-        "name": "Magnification",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "glitch",
+        "name": "Glitch Amount",
+        "min": 0,
+        "max": 1,
+        "default": 0.35
       },
       {
-        "id": "aberration",
-        "name": "Aberration",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "hue",
+        "name": "Holo Tint",
+        "min": 0,
+        "max": 1,
+        "default": 0.15
       },
       {
-        "id": "depthInfluence",
-        "name": "Depth Influence",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "id": "focus",
+        "name": "Focus Strength",
+        "min": 0,
+        "max": 1,
+        "default": 0.85
       }
     ],
     "tags": [
-      "filter",
-      "image-processing",
+      "vfx",
+      "particles",
+      "glow",
       "audio",
-      "music",
-      "reactive"
+      "music"
     ]
   },
   {
@@ -272,29 +804,29 @@
       {
         "id": "scanSpeed",
         "name": "Scan Speed",
-        "min": 0.0,
-        "max": 5.0,
-        "default": 1.0
+        "min": 0,
+        "max": 5,
+        "default": 1
       },
       {
         "id": "glitch",
         "name": "Glitch Amount",
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "default": 0.3
       },
       {
         "id": "hue",
         "name": "Holo Tint",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.0
+        "min": 0,
+        "max": 1,
+        "default": 0
       },
       {
         "id": "focus",
         "name": "Focus Strength",
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "default": 0.8
       }
     ],
@@ -360,147 +892,105 @@
     "name": "Holographic Sticker"
   },
   {
-    "id": "cross-spec-alpha-spectral-bloom",
-    "name": "Spectral Bloom HDR",
-    "url": "shaders/cross-spec-alpha-spectral-bloom.wgsl",
+    "id": "interactive-fresnel",
+    "name": "Interactive Fresnel",
+    "url": "shaders/interactive-fresnel.wgsl",
     "category": "visual-effects",
-    "description": "Crossover shader combining spectral dispersion with HDR bloom using RGBA as independent spectral bands. Decomposes the image into wavelength channels and applies per-band bloom with exposure control in alpha.",
-    "tags": [
-      "crossover",
-      "spectral",
-      "bloom",
-      "hdr",
-      "rgba-as-data",
-      "chromatic"
-    ],
+    "description": "Simulates a Fresnel lens with stepped concentric rings. Features chromatic aberration with alpha-aware blending, depth influence, and audio reactivity.",
     "features": [
-      "crossover",
-      "spectral-rendering",
-      "rgba32float-exploiting"
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven"
     ],
     "params": [
       {
-        "id": "bloomRadius",
-        "name": "Bloom Radius",
+        "id": "ringDensity",
+        "name": "Ring Density",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "dispersion",
-        "name": "Dispersion",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "exposure",
-        "name": "Exposure",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "chromaticShift",
-        "name": "Chromatic Shift",
+        "id": "magnification",
+        "name": "Magnification",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "chromatic-focus-interactive",
-    "name": "Chromatic Focus",
-    "category": "visual-effects",
-    "url": "shaders/chromatic-focus-interactive.wgsl",
-    "description": "Strong chromatic aberration that increases with distance from mouse focus.",
-    "features": [
-      "mouse-driven"
-    ],
-    "params": [
+        "min": 0,
+        "max": 1
+      },
       {
-        "id": "strength",
-        "name": "Abberation",
+        "id": "aberration",
+        "name": "Aberration",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "blur",
-        "name": "Blur",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "radius",
-        "name": "Focus Rad",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 0.8
-      },
-      {
-        "id": "hard",
-        "name": "Falloff",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "depthInfluence",
+        "name": "Depth Influence",
+        "default": 0,
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
-      "vfx",
-      "particles",
-      "glow"
+      "filter",
+      "image-processing",
+      "audio",
+      "music",
+      "reactive"
     ]
   },
   {
-    "id": "hex-circuit",
-    "name": "Hex Circuit",
-    "url": "shaders/hex-circuit.wgsl",
+    "id": "neon-edge-pulse",
+    "name": "Neon Edge Pulse",
+    "url": "shaders/neon-edge-pulse.wgsl",
     "category": "visual-effects",
     "features": [
-      "mouse-driven"
+      "mouse-driven",
+      "audio-reactive",
+      "audio-driven",
+      "advanced-alpha"
     ],
-    "description": "Overlays a cybernetic hexagonal grid that highlights image edges and reacts to mouse pulses.",
+    "description": "Detects edges and highlights them with pulsing neon colors. Mouse proximity increases intensity.",
     "params": [
       {
-        "id": "grid_size",
-        "name": "Grid Density",
+        "id": "edgeThreshold",
+        "name": "Edge Threshold",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "glow_strength",
+        "id": "pulseSpeed",
+        "name": "Pulse Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "glowIntensity",
         "name": "Glow Intensity",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "pulse_speed",
-        "name": "Pulse Speed",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edge_sensitivity",
-        "name": "Edge Sensitivity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "colorShift",
+        "name": "Color Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
       "vfx",
       "particles",
-      "glow"
+      "glow",
+      "audio",
+      "music",
+      "reactive",
+      "alpha",
+      "edge-preserve"
     ]
   },
   {
@@ -514,32 +1004,32 @@
         "name": "Line Density",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "height",
         "name": "Height Scale",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "mouse",
         "name": "Mouse Force",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "glow",
         "name": "Glow Strength",
         "type": "float",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "features": [
@@ -558,215 +1048,49 @@
     "name": "Neon Topology"
   },
   {
-    "id": "alpha-multi-layer-glass",
-    "name": "Alpha Multi-Layer Glass",
-    "url": "shaders/alpha-multi-layer-glass.wgsl",
+    "id": "quantum-field-visualizer",
+    "name": "Quantum Field Visualizer",
+    "url": "shaders/quantum-field-visualizer.wgsl",
     "category": "visual-effects",
-    "description": "Multi-layer glass refraction with RGBA data channels. Simulates looking through 3 layers of procedurally-distorted glass with Fresnel reflection, chromatic aberration, and per-layer tinting. Alpha stores accumulated transmittance.",
-    "tags": [
-      "glass",
-      "refraction",
-      "chromatic",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "fresnel"
-    ],
-    "features": [
-      "mouse-driven",
-      "rgba-state-machine"
-    ],
+    "description": "Visualizes quantum fluctuations as colorful noise. The act of observation (mouse proximity) collapses the wave function, clearing the image.",
     "params": [
       {
-        "id": "ior",
-        "name": "Index of Refraction",
-        "type": "float",
+        "id": "observation_strength",
+        "name": "Observation Field",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "thickness",
-        "name": "Glass Thickness",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "fluctuation_speed",
+        "name": "Fluctuation Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "chromatic",
-        "name": "Chromatic Aberration",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "energy_level",
+        "name": "Energy Level",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       },
       {
-        "id": "roughness",
-        "name": "Surface Roughness",
-        "type": "float",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
+        "id": "uncertainty",
+        "name": "Uncertainty",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
       }
-    ]
-  },
-  {
-    "id": "holographic-projection-gpt52",
-    "name": "Holo Projection Prism gpt52",
-    "url": "shaders/holographic-projection-gpt52.wgsl",
-    "category": "visual-effects",
-    "description": "Prismatic hologram with stabilized focus, scan interference, and spectral tinting.",
+    ],
     "features": [
       "mouse-driven",
-      "glitch",
-      "animated",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "scanSpeed",
-        "name": "Scan Speed",
-        "min": 0.0,
-        "max": 5.0,
-        "default": 1.2
-      },
-      {
-        "id": "glitch",
-        "name": "Glitch Amount",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.35
-      },
-      {
-        "id": "hue",
-        "name": "Holo Tint",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.15
-      },
-      {
-        "id": "focus",
-        "name": "Focus Strength",
-        "min": 0.0,
-        "max": 1.0,
-        "default": 0.85
-      }
-    ],
-    "tags": [
-      "vfx",
-      "particles",
-      "glow",
-      "audio",
-      "music"
-    ]
-  },
-  {
-    "id": "rgb-topology",
-    "name": "RGB Topology",
-    "category": "visual-effects",
-    "url": "shaders/rgb-topology.wgsl",
-    "description": "Visualizes the image as 3D topographic maps, one for each color channel (Red, Green, Blue). The layers are offset based on mouse tilt.",
-    "params": [
-      {
-        "name": "Contour Density",
-        "id": "zoomParam1",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Parallax Height",
-        "id": "zoomParam2",
-        "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Line Thickness",
-        "id": "zoomParam3",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "name": "Glow",
-        "id": "zoomParam4",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven"
+      "audio-reactive"
     ],
     "tags": [
       "vfx",
       "particles",
       "glow"
-    ]
-  },
-  {
-    "id": "alpha-spectral-decompose",
-    "name": "Alpha Spectral Decompose",
-    "url": "shaders/alpha-spectral-decompose.wgsl",
-    "category": "visual-effects",
-    "description": "Decomposes the image into 4 spectral frequency bands stored in RGBA. Low freq (R), mid-low (G), mid-high (B), high freq/detail (A). Recomposes with user-controlled per-band gain for frequency-equalizer style image manipulation.",
-    "tags": [
-      "spectral",
-      "frequency",
-      "decomposition",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "filter"
-    ],
-    "features": [
-      "mouse-driven",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "gainLow",
-        "name": "Low Freq Gain",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "gainMidLow",
-        "name": "Mid-Low Gain",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "gainMidHigh",
-        "name": "Mid-High Gain",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "gainHigh",
-        "name": "High Freq Gain",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
     ]
   },
   {
@@ -782,29 +1106,29 @@
         "id": "split",
         "name": "Split Strength",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "angle",
         "name": "Angle Offset",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
+        "default": 0,
+        "min": 0,
+        "max": 1
       },
       {
         "id": "blur",
         "name": "Blur Amount",
         "default": 0.2,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       },
       {
         "id": "deadzone",
         "name": "Deadzone",
         "default": 0.1,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0,
+        "max": 1
       }
     ],
     "tags": [
@@ -815,158 +1139,110 @@
     "name": "RGB Distance Split"
   },
   {
-    "id": "data-scanner",
+    "id": "rgb-topology",
+    "name": "RGB Topology",
     "category": "visual-effects",
-    "url": "shaders/data-scanner.wgsl",
+    "url": "shaders/rgb-topology.wgsl",
+    "description": "Visualizes the image as 3D topographic maps, one for each color channel (Red, Green, Blue). The layers are offset based on mouse tilt.",
+    "params": [
+      {
+        "name": "Contour Density",
+        "id": "zoomParam1",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Parallax Height",
+        "id": "zoomParam2",
+        "default": 0.4,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Line Thickness",
+        "id": "zoomParam3",
+        "default": 0.2,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "Glow",
+        "id": "zoomParam4",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "features": [
+      "mouse-driven"
+    ],
+    "tags": [
+      "vfx",
+      "particles",
+      "glow"
+    ]
+  },
+  {
+    "id": "spectral-rain",
+    "category": "visual-effects",
+    "url": "shaders/spectral-rain.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive"
     ],
     "params": [
       {
-        "id": "param1",
-        "name": "Intensity",
+        "id": "density",
+        "name": "Rain Density",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.x",
+        "description": "Density of rain streaks"
       },
       {
-        "id": "param2",
-        "name": "Audio Reactivity",
+        "id": "chromatic_strength",
+        "name": "Chromatic Strength",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.y",
+        "description": "Strength of chromatic displacement"
       },
       {
-        "id": "param3",
-        "name": "Scale",
+        "id": "trail_length",
+        "name": "Trail Length",
         "default": 0.5,
         "min": 0,
         "max": 1,
-        "step": 0.01
+        "step": 0.01,
+        "mapping": "zoom_params.z",
+        "description": "Length of raindrop trails"
       },
       {
-        "id": "param4",
-        "name": "Detail",
+        "id": "rain_angle_scale",
+        "name": "Rain Angle Scale",
         "default": 0.5,
         "min": 0,
-        "max": 1,
-        "step": 0.01
+        "max": 1.5,
+        "step": 0.01,
+        "mapping": "zoom_params.w",
+        "description": "Scale of the rain angle variation"
       }
     ],
     "tags": [
-      "vfx",
-      "particles",
-      "glow"
+      "rain",
+      "chromatic",
+      "distortion",
+      "filter",
+      "image-processing",
+      "audio-reactive"
     ],
-    "name": "Data Scanner"
-  },
-  {
-    "id": "alpha-luminance-history",
-    "name": "Alpha Luminance History",
-    "url": "shaders/alpha-luminance-history.wgsl",
-    "category": "visual-effects",
-    "description": "Temporal luminance history with rolling average stored in alpha. Areas that were recently bright retain a warm glow. Creates light-painting and after-image effects. Mouse leaves persistent bright trails.",
-    "tags": [
-      "temporal",
-      "history",
-      "luminance",
-      "glow",
-      "interactive",
-      "mouse-driven",
-      "rgba-state-machine",
-      "light-painting"
-    ],
-    "features": [
-      "mouse-driven",
-      "temporal",
-      "rgba-state-machine"
-    ],
-    "params": [
-      {
-        "id": "decay",
-        "name": "Memory Decay",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "colorShift",
-        "name": "History Tint",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      },
-      {
-        "id": "diffusion",
-        "name": "Trail Diffusion",
-        "type": "float",
-        "default": 0.2,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01
-      }
-    ]
-  },
-  {
-    "id": "cyber-scan",
-    "name": "Cyber Scan",
-    "url": "shaders/cyber-scan.wgsl",
-    "category": "visual-effects",
-    "features": [
-      "mouse-driven"
-    ],
-    "description": "A digital scanning line that follows the mouse, highlighting edges and overlaying a cybernetic grid.",
-    "params": [
-      {
-        "id": "scanWidth",
-        "name": "Scan Width",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "gridIntensity",
-        "name": "Grid Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorSpeed",
-        "name": "Color Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "edgeStrength",
-        "name": "Edge Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "vfx",
-      "particles",
-      "glow"
-    ]
+    "name": "Spectral Rain",
+    "description": "Falling streaks of chromatic distortion with audio-reactive intensity and mouse-driven angle and speed controls."
   },
   {
     "id": "temporal-rgb-smear",
@@ -979,8 +1255,8 @@
         "id": "smear_length",
         "name": "Smear Length",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.x",
         "description": "Length of the directional smear"
@@ -989,8 +1265,8 @@
         "id": "smear_decay",
         "name": "Smear Decay",
         "default": 0.7,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.y",
         "description": "Temporal feedback decay amount"
@@ -999,8 +1275,8 @@
         "id": "chromatic_split",
         "name": "Chromatic Split",
         "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.z",
         "description": "RGB channel separation along smear direction"
@@ -1009,8 +1285,8 @@
         "id": "turbulence",
         "name": "Turbulence",
         "default": 0.3,
-        "min": 0.0,
-        "max": 1.0,
+        "min": 0,
+        "max": 1,
         "step": 0.01,
         "mapping": "zoom_params.w",
         "description": "Time-based directional turbulence"
@@ -1033,326 +1309,50 @@
     ]
   },
   {
-    "id": "spectral-rain",
-    "category": "visual-effects",
-    "url": "shaders/spectral-rain.wgsl",
+    "id": "voxel-grid",
+    "name": "Voxel Grid",
+    "url": "shaders/voxel-grid.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive"
     ],
     "params": [
       {
-        "id": "density",
-        "name": "Rain Density",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.x",
-        "description": "Density of rain streaks"
-      },
-      {
-        "id": "chromatic_strength",
-        "name": "Chromatic Strength",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.y",
-        "description": "Strength of chromatic displacement"
-      },
-      {
-        "id": "trail_length",
-        "name": "Trail Length",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0,
-        "step": 0.01,
-        "mapping": "zoom_params.z",
-        "description": "Length of raindrop trails"
-      },
-      {
-        "id": "rain_angle_scale",
-        "name": "Rain Angle Scale",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.5,
-        "step": 0.01,
-        "mapping": "zoom_params.w",
-        "description": "Scale of the rain angle variation"
-      }
-    ],
-    "tags": [
-      "rain",
-      "chromatic",
-      "distortion",
-      "filter",
-      "image-processing",
-      "audio-reactive"
-    ],
-    "name": "Spectral Rain",
-    "description": "Falling streaks of chromatic distortion with audio-reactive intensity and mouse-driven angle and speed controls."
-  },
-  {
-    "id": "chroma-vortex",
-    "url": "shaders/chroma-vortex.wgsl",
-    "category": "visual-effects",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven"
-    ],
-    "params": [
-      {
-        "id": "twist",
-        "name": "Vortex Twist",
-        "type": "float",
-        "default": 0.2,
-        "min": -1.0,
-        "max": 1.0
-      },
-      {
-        "id": "spread",
-        "name": "RGB Split",
-        "type": "float",
-        "default": 0.3,
-        "min": 0.0,
-        "max": 1.0
+        "id": "grid",
+        "name": "Grid Density",
+        "default": 40,
+        "min": 10,
+        "max": 100
       },
       {
         "id": "radius",
-        "name": "Vortex Radius",
-        "type": "float",
+        "name": "Touch Radius",
         "default": 0.4,
-        "min": 0.0,
-        "max": 1.0
+        "min": 0.1,
+        "max": 0.8
       },
       {
-        "id": "centerBias",
-        "name": "Center Stability",
-        "type": "float",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
+        "id": "strength",
+        "name": "Rotation Force",
+        "default": 1,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "id": "gap",
+        "name": "Cell Gap",
+        "default": 0.05,
+        "min": 0,
+        "max": 0.4
       }
     ],
-    "description": "Rotational RGB splitting effect centered on the mouse.",
+    "description": "Transforms the image into a grid of rotating 3D voxels that react to mouse proximity and audio bass.",
+    "category": "visual-effects",
     "tags": [
       "vfx",
       "particles",
       "glow",
-      "audio",
-      "music"
-    ],
-    "name": "Chroma Vortex"
-  },
-  {
-    "id": "crt-clear-zone",
-    "name": "CRT Clear Zone",
-    "category": "visual-effects",
-    "url": "shaders/crt-clear-zone.wgsl",
-    "description": "Heavy CRT distortion with chromatic aberration, scanlines, and vignette. A clean, high-resolution zone follows the mouse cursor with an audio-reactive scanline intensity.",
-    "params": [
-      {
-        "name": "Distortion",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "distortion"
-      },
-      {
-        "name": "Aberration",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "id": "aberration"
-      },
-      {
-        "name": "Zone Size",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.3,
-        "id": "zone_size"
-      },
-      {
-        "name": "Scanlines",
-        "type": "f32",
-        "min": 0,
-        "max": 1,
-        "default": 0.5,
-        "id": "scanlines"
-      }
-    ],
-    "features": [
-      "mouse-driven",
       "audio-reactive"
-    ],
-    "tags": [
-      "crt",
-      "retro",
-      "glitch",
-      "filter",
-      "image-processing"
     ]
-  },
-  {
-    "id": "quantum-field-visualizer",
-    "name": "Quantum Field Visualizer",
-    "url": "shaders/quantum-field-visualizer.wgsl",
-    "category": "visual-effects",
-    "description": "Visualizes quantum fluctuations as colorful noise. The act of observation (mouse proximity) collapses the wave function, clearing the image.",
-    "params": [
-      {
-        "id": "observation_strength",
-        "name": "Observation Field",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "fluctuation_speed",
-        "name": "Fluctuation Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "energy_level",
-        "name": "Energy Level",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "uncertainty",
-        "name": "Uncertainty",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "features": [
-      "mouse-driven",
-      "audio-reactive"
-    ],
-    "tags": [
-      "vfx",
-      "particles",
-      "glow"
-    ]
-  },
-  {
-    "id": "neon-edge-pulse",
-    "name": "Neon Edge Pulse",
-    "url": "shaders/neon-edge-pulse.wgsl",
-    "category": "visual-effects",
-    "features": [
-      "mouse-driven",
-      "audio-reactive",
-      "audio-driven",
-      "advanced-alpha"
-    ],
-    "description": "Detects edges and highlights them with pulsing neon colors. Mouse proximity increases intensity.",
-    "params": [
-      {
-        "id": "edgeThreshold",
-        "name": "Edge Threshold",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "pulseSpeed",
-        "name": "Pulse Speed",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "glowIntensity",
-        "name": "Glow Intensity",
-        "default": 0.5,
-        "min": 0.0,
-        "max": 1.0
-      },
-      {
-        "id": "colorShift",
-        "name": "Color Shift",
-        "default": 0.0,
-        "min": 0.0,
-        "max": 1.0
-      }
-    ],
-    "tags": [
-      "vfx",
-      "particles",
-      "glow",
-      "audio",
-      "music",
-      "reactive",
-      "alpha",
-      "edge-preserve"
-    ]
-  },
-  {
-    "id": "parallax_depth_layers",
-    "name": "Parallax Layers RGBA",
-    "url": "shaders/parallax_depth_layers.wgsl",
-    "category": "visual-effects",
-    "description": "5 depth layers with parallax displacement. Each layer has independent alpha for occlusion. Atmospheric perspective and depth of field.",
-    "tags": [
-      "parallax",
-      "depth",
-      "layers",
-      "alpha",
-      "perspective",
-      "scrolling"
-    ],
-    "features": [
-      "rgba",
-      "parallax",
-      "depth-layers",
-      "alpha-occlusion",
-      "dof",
-      "atmospheric"
-    ],
-    "params": [
-      {
-        "id": "param1",
-        "name": "Parallax",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param2",
-        "name": "Layer Density",
-        "default": 0.5,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param3",
-        "name": "Depth of Field",
-        "default": 0.3,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      },
-      {
-        "id": "param4",
-        "name": "Fog",
-        "default": 0.2,
-        "min": 0,
-        "max": 1,
-        "step": 0.1
-      }
-    ],
-    "target_rating": 4.6
   }
 ]

--- a/public/shaders/gen-eldritch-tesseract-hive-mind.wgsl
+++ b/public/shaders/gen-eldritch-tesseract-hive-mind.wgsl
@@ -1,0 +1,165 @@
+// ----------------------------------------------------------------
+// Eldritch Tesseract-Hive Mind
+// Category: generative
+// ----------------------------------------------------------------
+// --- COPY PASTE THIS HEADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>
+};
+
+// --- CONSTANTS & HELPERS ---
+const MAX_STEPS: i32 = 100;
+const MAX_DIST: f32 = 100.0;
+const SURF_DIST: f32 = 0.001;
+
+// 4D Rotation matrix helper
+fn rot4D(theta: f32) -> mat2x2<f32> {
+    let c = cos(theta);
+    let s = sin(theta);
+    return mat2x2<f32>(c, -s, s, c);
+}
+
+// 3D rotation helper
+fn rot3D(axis: vec3<f32>, angle: f32) -> mat3x3<f32> {
+    let a = normalize(axis);
+    let s = sin(angle);
+    let c = cos(angle);
+    let r = 1.0 - c;
+    return mat3x3<f32>(
+        a.x * a.x * r + c,       a.x * a.y * r - a.z * s, a.x * a.z * r + a.y * s,
+        a.y * a.x * r + a.z * s, a.y * a.y * r + c,       a.y * a.z * r - a.x * s,
+        a.z * a.x * r - a.y * s, a.z * a.y * r + a.x * s, a.z * a.z * r + c
+    );
+}
+
+// Map function evaluating the 4D Tesseract SDF
+fn map(p_in: vec3<f32>, time: f32, audio_intensity: f32, mouse: vec2<f32>, rot_speed: f32, voxel_tear: f32) -> vec2<f32> {
+    // Gravitational Anomaly from mouse
+    let mouse_world = vec3<f32>((mouse.x - 0.5) * 4.0, (mouse.y - 0.5) * 4.0, 0.0);
+    let dist_to_mouse = length(p_in.xy - mouse_world.xy);
+    let gravity_pull = 0.5 / (1.0 + dist_to_mouse * dist_to_mouse * 5.0);
+    var p = p_in - vec3<f32>(mouse_world.xy * gravity_pull, 0.0);
+
+    // 4D coordinate initialization (using gravity pull on 4th dim)
+    var p4 = vec4<f32>(p, gravity_pull * 2.0);
+
+    // Rotate in 4D space
+    let t = time * rot_speed;
+    let r1 = rot4D(t * 0.5);
+    let x_new = r1[0][0]*p4.x + r1[0][1]*p4.z;
+    let z_new = r1[1][0]*p4.x + r1[1][1]*p4.z;
+    p4.x = x_new;
+    p4.z = z_new;
+
+    let r2 = rot4D(t * 0.7);
+    let y_new = r2[0][0]*p4.y + r2[0][1]*p4.w;
+    let w_new = r2[1][0]*p4.y + r2[1][1]*p4.w;
+    p4.y = y_new;
+    p4.w = w_new;
+
+    // Core tesseract SDF evaluation
+    let d1 = length(max(abs(p4) - vec4<f32>(1.0), vec4<f32>(0.0))) - 0.1;
+
+    // Add voxel tearing based on audio
+    let tear = audio_intensity * voxel_tear;
+    let voxel_scale = vec3<f32>(10.0 + tear * 20.0);
+    let voxel_p = floor(p * voxel_scale) / voxel_scale;
+    let d2 = length(p - voxel_p) - 0.05;
+
+    // Boolean Carving using pseudo-Voronoi
+    let q = p * 2.0;
+    let noise = sin(q.x)*cos(q.y)*sin(q.z) + sin(q.x*2.0)*cos(q.y*2.0)*sin(q.z*2.0)*0.5;
+    let d3 = d1 + noise * 0.2;
+
+    // Material ID mix
+    var mat_id = 1.0;
+    var d = max(d3, -d2); // Subtract voxels from structure
+    if (d2 < d3) {
+        d = d2;
+        mat_id = 2.0; // Voxel material
+    }
+
+    return vec2<f32>(d, mat_id);
+}
+
+fn getNormal(p: vec3<f32>, time: f32, audio_intensity: f32, mouse: vec2<f32>, rot_speed: f32, voxel_tear: f32) -> vec3<f32> {
+    let e = vec2<f32>(0.001, 0.0);
+    let d = map(p, time, audio_intensity, mouse, rot_speed, voxel_tear).x;
+    let n = d - vec3<f32>(
+        map(p - e.xyy, time, audio_intensity, mouse, rot_speed, voxel_tear).x,
+        map(p - e.yxy, time, audio_intensity, mouse, rot_speed, voxel_tear).x,
+        map(p - e.yyx, time, audio_intensity, mouse, rot_speed, voxel_tear).x
+    );
+    return normalize(n);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let texSize = vec2<i32>(i32(u.config.z), i32(u.config.w));
+    let coord = vec2<i32>(id.xy);
+    if (coord.x >= texSize.x || coord.y >= texSize.y) { return; }
+
+    let uv = (vec2<f32>(coord) - 0.5 * vec2<f32>(texSize)) / vec2<f32>(texSize).y;
+    let time = u.config.x;
+    let audio = u.zoom_config.x;
+    let mouse = u.zoom_params.xy;
+
+    // Parameters
+    let rot_speed = u.config.y; // Slider 1
+    let swarm_density = u.config.z; // Slider 2
+    let voxel_tear = u.zoom_config.y; // Slider 3
+    let iridescence = u.zoom_config.z; // Slider 4
+
+    let ro = vec3<f32>(0.0, 0.0, -4.0);
+    let rd = normalize(vec3<f32>(uv, 1.0));
+
+    var d0 = 0.0;
+    var m = 0.0;
+    var p = vec3<f32>(0.0);
+    var glow = 0.0;
+    for (var i = 0; i < MAX_STEPS; i++) {
+        p = ro + rd * d0;
+        let dS = map(p, time, audio, mouse, rot_speed, voxel_tear);
+        d0 += dS.x;
+        m = dS.y;
+
+        // Accumulate glow from swarm
+        if (dS.x > 0.0) {
+            glow += 0.01 * swarm_density / (dS.x * dS.x + 0.01);
+        }
+
+        if (dS.x < SURF_DIST || d0 > MAX_DIST) { break; }
+    }
+
+    var col = vec3<f32>(0.0);
+    if (d0 < MAX_DIST) {
+        let n = getNormal(p, time, audio, mouse, rot_speed, voxel_tear);
+        let view_dir = normalize(-rd);
+        let ndotv = max(dot(n, view_dir), 0.0);
+
+        // Thin-film interference
+        let interference_color = cos(vec3<f32>(0.0, 2.0, 4.0) + (1.0 - ndotv) * 5.0 * iridescence) * 0.5 + 0.5;
+
+        if (m == 1.0) {
+            col = interference_color * 0.5 + vec3<f32>(0.1, 0.2, 0.3) * ndotv;
+        } else {
+            // Voxel material: Simple procedural neon glow
+            let plasma_col = vec3<f32>(1.0, 0.0, 1.0); // Magenta
+            col = plasma_col * 2.0 + vec3<f32>(1.0) * pow(ndotv, 4.0);
+        }
+    }
+
+    // Add swarm glow
+    col += vec3<f32>(0.0, 1.0, 1.0) * glow * 0.05 * audio;
+
+    // Output final color
+    textureStore(writeTexture, coord, vec4<f32>(col, 1.0));
+}

--- a/shader_definitions/generative/gen-eldritch-tesseract-hive-mind.json
+++ b/shader_definitions/generative/gen-eldritch-tesseract-hive-mind.json
@@ -1,0 +1,17 @@
+{
+  "id": "gen-eldritch-tesseract-hive-mind",
+  "name": "Eldritch Tesseract-Hive Mind",
+  "author": "Jules",
+  "description": "An impossible, non-Euclidean hypercube hive populated by swarms of luminescent algorithmic sentinels, constantly unfolding and fracturing into new geometric dimensions driven by quantum noise and acoustic energy.",
+  "category": "generative",
+  "type": "wgsl",
+  "coordinate": 881,
+  "url": "shaders/gen-eldritch-tesseract-hive-mind.wgsl",
+  "tags": ["tesseract", "fractal", "quantum", "mechanical", "audio-reactive", "swarm"],
+  "parameters": [
+    {"name": "Tesseract Rotation Speed", "default": 0.5, "min": 0.0, "max": 2.0, "step": 0.01},
+    {"name": "Swarm Density", "default": 1.0, "min": 0.1, "max": 5.0, "step": 0.1},
+    {"name": "Voxel Tearing Intensity", "default": 0.5, "min": 0.0, "max": 2.0, "step": 0.05},
+    {"name": "Iridescence Shift", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}
+  ]
+}

--- a/shader_plans/queue.json
+++ b/shader_plans/queue.json
@@ -450,6 +450,13 @@
       "title": "Luminous-Fluid Chladni-Resonator",
       "added": "2026-05-08T15:16:53.042126",
       "completed": "2026-05-09T07:58:14.321343"
+    },
+    {
+      "filename": "2026-05-09_eldritch-tesseract-hive-mind.md",
+      "title": "Eldritch Tesseract-Hive Mind",
+      "added": "2026-05-09T15:44:19.573334",
+      "status": "completed",
+      "completed_at": "2026-05-11T08:36:32.846497"
     }
   ],
   "rejected": [],
@@ -629,11 +636,6 @@
       "filename": "2026-05-08_luminous-fluid-chladni-resonator.md",
       "title": "Luminous-Fluid Chladni-Resonator",
       "added": "2026-05-08T15:16:53.042126"
-    },
-    {
-      "filename": "2026-05-09_eldritch-tesseract-hive-mind.md",
-      "title": "Eldritch Tesseract-Hive Mind",
-      "added": "2026-05-09T15:44:19.573334"
     }
   ],
   "in_progress": null


### PR DESCRIPTION
Implements the Eldritch Tesseract-Hive Mind generative shader based on the oldest approved plan in the queue (2026-05-09). The shader features a 4D to 3D tesseract projection raymarcher with voxel tearing driven by audio intensity, swarm particle glow, thin-film interference, and mouse-driven gravity anomalies. JSON definition was created, shader lists regenerated, uploaded via storage_manager, and the queue was successfully updated.

---
*PR created automatically by Jules for task [2140193149049498185](https://jules.google.com/task/2140193149049498185) started by @ford442*