### PR TITLE
Add Holographic Bismuth-Core Reactor generative shader

### DIFF
--- a/public/shader-lists/generative.json
+++ b/public/shader-lists/generative.json
@@ -1145,6 +1145,21 @@
     ]
   },
   {
+    "id": "gen-aurora-borealis-synthesis",
+    "name": "Aurora Borealis Synthesis",
+    "description": "Render a 3D volume of swirling aurora light and project it onto the 2D video surface, with audio-driven motion and depth-based mapping.",
+    "category": "generative",
+    "tags": [
+      "aurora",
+      "volumetric",
+      "audio-reactive",
+      "plasma"
+    ],
+    "coordinate": 878,
+    "parameters": [],
+    "url": "shaders/gen-aurora-borealis-synthesis.wgsl"
+  },
+  {
     "id": "gen-auroral-ferrofluid-monolith",
     "name": "Auroral Ferrofluid-Monolith",
     "url": "shaders/gen-auroral-ferrofluid-monolith.wgsl",
@@ -1902,6 +1917,51 @@
     ]
   },
   {
+    "id": "gen-cosmic-clockwork-dyson-sphere",
+    "name": "Cosmic-Clockwork Dyson-Sphere",
+    "description": "A hyper-intricate, colossal megastructure of interlocking golden gears, glowing plasma conduits, and rhythmic mechanical fractal shifts, enclosing a blinding quantum singularity that powers an ancient stellar clock.",
+    "category": "generative",
+    "tags": [
+      "mechanical",
+      "cosmic",
+      "fractal",
+      "audio-reactive",
+      "volumetric"
+    ],
+    "coordinate": 879,
+    "parameters": [
+      {
+        "name": "Mechanical Complexity",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Clock Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 2,
+        "step": 0.01
+      },
+      {
+        "name": "Plasma Intensity",
+        "default": 0.8,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "name": "Gear Ratio",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "url": "shaders/gen-cosmic-clockwork-dyson-sphere.wgsl"
+  },
+  {
     "id": "gen-cosmic-web-filament",
     "name": "Cosmic Web Filament",
     "url": "shaders/gen-cosmic-web-filament.wgsl",
@@ -2341,6 +2401,36 @@
     ]
   },
   {
+    "id": "gen-dynamic-tessellation-ornate-fractal-tiles",
+    "name": "Dynamic Tessellation (Ornate Fractal Tiles)",
+    "category": "generative",
+    "type": "compute",
+    "coordinate": 874,
+    "description": "Compute a screen-space tile grid and replace each tile with a tiny procedurally rendered fractal. The result is a morphing lattice of fractal mini-universes. Now audio-reactive to bass frequencies with meaningful alpha compositing.",
+    "features": [
+      "audio-reactive"
+    ],
+    "parameters": [
+      {
+        "id": "iterations",
+        "name": "Fractal Iterations",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "density",
+        "name": "Tile Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "url": "shaders/gen-dynamic-tessellation-ornate-fractal-tiles.wgsl"
+  },
+  {
     "id": "gen-eldritch-tesseract-hive-mind",
     "coordinate": 881,
     "type": "wgsl",
@@ -2729,6 +2819,51 @@
     ]
   },
   {
+    "id": "gen-holographic-bismuth-core-reactor",
+    "name": "Holographic Bismuth-Core Reactor",
+    "category": "generative",
+    "description": "A hyper-dimensional, endlessly unfolding bismuth core reactor, merging metallic stepped-fractals with liquid-holographic interference patterns.",
+    "coordinate": 882,
+    "tags": [
+      "cosmic",
+      "mechanical",
+      "kifs",
+      "raymarching",
+      "holographic"
+    ],
+    "parameters": [
+      {
+        "name": "Core Size",
+        "default": 0.5,
+        "min": 0.1,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Iridescence Shift",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Pulse Intensity",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "name": "Plasma Density",
+        "default": 0.3,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ],
+    "url": "shaders/gen-holographic-bismuth-core-reactor.wgsl"
+  },
+  {
     "id": "gen-holographic-data-core",
     "name": "Holographic Data Core",
     "url": "shaders/gen-holographic-data-core.wgsl",
@@ -2785,6 +2920,21 @@
         "step": 0.05
       }
     ]
+  },
+  {
+    "id": "gen-holographic-lens-flare-matrix",
+    "name": "Holographic Lens-Flare Matrix",
+    "description": "Generate a matrix of holographic lens flares that follow motion in the video or a synthetic flow field.",
+    "author": "Jules",
+    "tags": [
+      "generative",
+      "holographic",
+      "matrix"
+    ],
+    "coordinate": 875,
+    "category": "generative",
+    "parameters": [],
+    "url": "shaders/gen-holographic-lens-flare-matrix.wgsl"
   },
   {
     "id": "gen-holographic-plasma-geode",
@@ -4474,6 +4624,46 @@
         "step": 0.01
       }
     ]
+  },
+  {
+    "id": "gen-psychedelic-layered-time-stamps",
+    "name": "Psychedelic Layered Time-Stamps",
+    "wgsl_code": "shaders/gen-psychedelic-layered-time-stamps.wgsl",
+    "tags": [
+      "generative",
+      "psychedelic",
+      "time",
+      "layers",
+      "audio-reactive"
+    ],
+    "category": "generative",
+    "description": "Overlay multiple delayed copies of the video, each with a different color offset and evolving distortion.",
+    "coordinate": 877,
+    "source": "Jules",
+    "parameters": [
+      {
+        "name": "Layer Count",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Delay Scale",
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "default": 0.5
+      },
+      {
+        "name": "Distortion Amp",
+        "min": 0,
+        "max": 0.1,
+        "step": 0.001,
+        "default": 0.02
+      }
+    ],
+    "url": "shaders/gen-psychedelic-layered-time-stamps.wgsl"
   },
   {
     "id": "gen-psychedelic-time-warp-kaleidoscope",

--- a/public/shaders/gen-holographic-bismuth-core-reactor.wgsl
+++ b/public/shaders/gen-holographic-bismuth-core-reactor.wgsl
@@ -1,0 +1,144 @@
+// ----------------------------------------------------------------
+// Holographic Bismuth-Core Reactor
+// Category: generative
+// ----------------------------------------------------------------
+
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+
+struct Uniforms {
+  config: vec4<f32>, // x: resolution.x, y: resolution.y, z: time, w: aspect
+  zoom_config: vec4<f32>, // x: mouse.x, y: mouse.y, z: is_clicking, w: audio_intensity
+  zoom_params: vec4<f32>, // param1: Core Size, param2: Iridescence Shift, param3: Pulse Intensity, param4: Plasma Density
+  ripples: array<vec4<f32>, 50>
+};
+
+const MAX_STEPS: i32 = 100;
+const MAX_DIST: f32 = 50.0;
+const SURF_DIST: f32 = 0.001;
+
+// 3D rotation helper
+fn rot3D(axis: vec3<f32>, angle: f32) -> mat3x3<f32> {
+    let a = normalize(axis);
+    let s = sin(angle);
+    let c = cos(angle);
+    let oc = 1.0 - c;
+    return mat3x3<f32>(
+        oc * a.x * a.x + c,           oc * a.x * a.y - a.z * s,  oc * a.z * a.x + a.y * s,
+        oc * a.x * a.y + a.z * s,     oc * a.y * a.y + c,        oc * a.y * a.z - a.x * s,
+        oc * a.z * a.x - a.y * s,     oc * a.y * a.z + a.x * s,  oc * a.z * a.z + c
+    );
+}
+
+// Custom KIFS box SDF for 90-degree steps
+fn sdBox(p: vec3<f32>, b: vec3<f32>) -> f32 {
+    let q = abs(p) - b;
+    return length(max(q, vec3<f32>(0.0))) + min(max(q.x, max(q.y, q.z)), 0.0);
+}
+
+fn map(p_in: vec3<f32>) -> vec2<f32> {
+    var p = p_in;
+
+    // Mouse warp of gravity field
+    let mouse = u.zoom_config.xy;
+    p = rot3D(vec3<f32>(1.0, 0.0, 0.0), mouse.y * 3.14) * p;
+    p = rot3D(vec3<f32>(0.0, 1.0, 0.0), mouse.x * 3.14) * p;
+
+    var s: f32 = 1.0;
+
+    // Audio reactive pulse
+    let pulse = sin(u.config.z * 2.0) * 0.5 + 0.5;
+    let core_scale = u.zoom_params.x * (1.0 + pulse * u.zoom_config.w * u.zoom_params.z);
+
+    // KIFS Bismuth fractals
+    for (var i = 0; i < 4; i++) {
+        p = abs(p) - vec3<f32>(0.5, 0.5, 0.5) * core_scale;
+        p = rot3D(vec3<f32>(0.0, 1.0, 0.0), 1.5708) * p; // 90 deg folding
+        p = rot3D(vec3<f32>(1.0, 0.0, 0.0), 1.5708) * p;
+        p = p * 1.5;
+        s *= 1.5;
+    }
+
+    let d1 = sdBox(p, vec3<f32>(0.3, 0.3, 0.3)) / s;
+
+    // Orbiting micro-crystals
+    var p2 = p_in;
+    p2 = rot3D(vec3<f32>(0.0, 1.0, 0.0), u.config.z) * p2;
+    p2 = p2 - round(p2 / 2.0) * 2.0; // Domain repetition
+    let d2 = sdBox(p2, vec3<f32>(0.05, 0.05, 0.05));
+
+    if (d1 < d2) {
+        return vec2<f32>(d1, 1.0); // ID 1 = Core
+    }
+    return vec2<f32>(d2, 2.0); // ID 2 = Micro-crystals
+}
+
+fn getNormal(p: vec3<f32>) -> vec3<f32> {
+    let e = vec2<f32>(0.001, 0.0);
+    let d = map(p).x;
+    let n = vec3<f32>(
+        d - map(p - vec3<f32>(e.x, e.y, e.y)).x,
+        d - map(p - vec3<f32>(e.y, e.x, e.y)).x,
+        d - map(p - vec3<f32>(e.y, e.y, e.x)).x
+    );
+    return normalize(n);
+}
+
+// Iridescence based on thin-film interference
+fn iridescence(dot_vn: f32) -> vec3<f32> {
+    let t = dot_vn * 2.0 + u.zoom_params.y + u.config.z * 0.5 + u.zoom_config.w * u.zoom_params.z;
+    let r = sin(t * 3.14) * 0.5 + 0.5;
+    let g = sin(t * 3.14 + 2.09) * 0.5 + 0.5;
+    let b = sin(t * 3.14 + 4.18) * 0.5 + 0.5;
+    return vec3<f32>(r, g, b);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let uv = (vec2<f32>(id.xy) - 0.5 * u.config.xy) / u.config.y;
+    if (uv.x > 1.0 || uv.y > 1.0 || uv.x < -1.0 || uv.y < -1.0) { return; }
+
+    var ro = vec3<f32>(0.0, 0.0, -5.0);
+    var rd = normalize(vec3<f32>(uv.x, uv.y, 1.0));
+
+    var p = ro;
+    var dO = 0.0;
+    var res = vec2<f32>(0.0);
+    var accum = 0.0;
+
+    for (var i = 0; i < MAX_STEPS; i++) {
+        p = ro + rd * dO;
+        res = map(p);
+        let dS = res.x;
+        dO += dS;
+
+        // Volumetric plasma accumulation
+        accum += u.zoom_params.w * 0.05 / (1.0 + abs(dS) * 50.0);
+
+        if (dS < SURF_DIST || dO > MAX_DIST) { break; }
+    }
+
+    var col = vec3<f32>(0.0);
+
+    if (dO < MAX_DIST) {
+        let n = getNormal(p);
+        let v = -rd;
+        let dot_vn = max(dot(v, n), 0.0);
+
+        col = iridescence(dot_vn);
+
+        // Add lighting falloff
+        col *= exp(-dO * 0.1);
+    }
+
+    // Add plasma bloom
+    col += vec3<f32>(0.2, 0.6, 1.0) * accum;
+
+    let out_col = vec4<f32>(col, 1.0);
+    let coords = vec2<i32>(id.xy);
+    if (coords.x < i32(u.config.x) && coords.y < i32(u.config.y)) {
+        textureStore(writeTexture, coords, out_col);
+    }
+}

--- a/shader_definitions/generative/gen-holographic-bismuth-core-reactor.json
+++ b/shader_definitions/generative/gen-holographic-bismuth-core-reactor.json
@@ -1,0 +1,14 @@
+{
+  "id": "gen-holographic-bismuth-core-reactor",
+  "name": "Holographic Bismuth-Core Reactor",
+  "category": "generative",
+  "description": "A hyper-dimensional, endlessly unfolding bismuth core reactor, merging metallic stepped-fractals with liquid-holographic interference patterns.",
+  "coordinate": 882,
+  "tags": ["cosmic", "mechanical", "kifs", "raymarching", "holographic"],
+  "parameters": [
+    { "name": "Core Size", "default": 0.5, "min": 0.1, "max": 1.0, "step": 0.01 },
+    { "name": "Iridescence Shift", "default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01 },
+    { "name": "Pulse Intensity", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01 },
+    { "name": "Plasma Density", "default": 0.3, "min": 0.0, "max": 1.0, "step": 0.01 }
+  ]
+}

--- a/shader_plans/queue.json
+++ b/shader_plans/queue.json
@@ -457,6 +457,13 @@
       "added": "2026-05-09T15:44:19.573334",
       "status": "completed",
       "completed_at": "2026-05-10T08:06:56.153090"
+    },
+    {
+      "filename": "2026-05-11_holographic-bismuth-core-reactor.md",
+      "title": "Holographic Bismuth-Core Reactor",
+      "added": "2026-05-11T15:26:13.364552",
+      "status": "completed",
+      "completed_at": "2026-05-13T01:27:50.084790"
     }
   ],
   "rejected": [],
@@ -646,9 +653,6 @@
       "filename": "2026-05-10_luminescent-chrono-fluid-astrolabe.md",
       "title": "Luminescent Chrono-Fluid Astrolabe",
       "added": "2026-05-10T15:17:16.993907"
-      "filename": "2026-05-11_holographic-bismuth-core-reactor.md",
-      "title": "Holographic Bismuth-Core Reactor",
-      "added": "2026-05-11T15:26:13.364552"
     }
   ],
   "in_progress": null


### PR DESCRIPTION
Added the Holographic Bismuth-Core Reactor shader based on the most recent plan in the queue. Implemented KIFS folded 3D raymarching with iridescent properties, generated corresponding list entries, and repaired/updated the queue tracker.

---
*PR created automatically by Jules for task [8845567318956950241](https://jules.google.com/task/8845567318956950241) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new generative shader effects: Aurora Borealis Synthesis, Cosmic Clockwork Dyson Sphere, Dynamic Tessellation Ornate Fractal Tiles, Holographic Bismuth-Core Reactor, Holographic Lens Flare Matrix, and Psychedelic Layered Time Stamps, each with configurable parameters for custom visual control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/image_video_effects/pull/623)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->