### PR TITLE
chore: weekly plan 2026-05-16 — AI VJ stack persistence focus

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,8 +1,8 @@
 # image_video_effects — Weekly Plan
 
 ## Today's focus
-**2026-05-09 — Systematic WGSL runtime-error fix pass over the 49 critical shaders in `reports/runtime_errors_report.json`.**
-kimi-cli iterates over every shader with `status: "critical"` (invalid_binding × 8, sampler_mismatch × 15, division_by_zero guards, array_bounds clamps, missing_write stubs). For each shader: read the error payload from the report, open the WGSL source in `public/shaders/`, apply the minimal targeted fix, re-validate with `naga` (or `wgsl-analyzer` if available), update `reports/runtime_errors_report.json` in-place to mark the shader clean. Save progress to `.swarm-state.md` at each iteration boundary. Do not touch `reports/bindgroup_compatibility_report.json` or any TypeScript/React files.
+**2026-05-16 — AI VJ stack persistence + history panel.**
+kimi-cli adds localStorage save/load of generated VJ stacks to `src/AutoDJ.ts` (intercept `onUpdateStack` / `onUpdateParams` callbacks to persist `{vibeText, shaderIds, params, timestamp}[]`), extracts a thin `src/services/vjHistory.ts` service (get/save/clear, max 20 entries), and wires a collapsible "VJ History" panel into `src/components/Controls.tsx` immediately below the vibe-prompt section — showing last N stacks with vibe text, shader IDs, timestamp, a one-click restore button, and a "regenerate variation" button that re-fires `generateFromVibe` with the same vibe string. Do not touch `src/renderer/`, `reports/`, or `public/shaders/`.
 
 ## Ideas
 <!--
@@ -17,7 +17,7 @@ Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 - [x] Shader metadata normalization + full-text search over 700+ library
   Reconcile `params_missing.md`, `SHADER_PARAMETER_AUDIT.md`, and `shader_params_extracted.json` into a single canonical metadata schema so the scanner/rating/AI-VJ paths share one source of truth. Full-day.
   → Completed 2026-05-02 (shaderCatalog.ts built, wired into ShaderBrowserWithRatings + AutoDJ.buildShaderManifest)
-- [ ] AI VJ stack persistence + history panel
+- [in progress — 2026-05-16] AI VJ stack persistence + history panel
   Add localStorage save/load of generated stacks, a "VJ history" panel showing last N stacks with their vibe prompts, and a one-click "regenerate variation" button. Surface live shader IDs in the UI. Half-day.
 - [ ] Per-shader param presets + AI VJ randomizer
   Build a preset system for param combos (keyed off shaderCatalog), add a "randomize params" operator that samples within min/max/step ranges for each shader in the active AI VJ stack. Enables live-performance use. Full-day.
@@ -39,6 +39,7 @@ Routine maintains this automatically — you can add items too.
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- 2026-05-16: WGSL runtime-error fix pass — all 49 critical shaders in `reports/runtime_errors_report.json` fixed and validated via naga. Patterns: bulk canonical binding renames (videoSampler→u_sampler, outTex→writeTexture, etc.) resolved the majority; false-positive invalid_binding flags cleared for 8 multi-pass shaders; array_bounds ripple clamps added where needed. 49/49 naga OK per `.swarm-state.md`.
 - 2026-05-09: Shader metadata normalization — `shaderCatalog.ts` service built (merges 15 category JSONs + shader_params_extracted.json, in-memory full-text index, module-level cache), wired into `ShaderBrowserWithRatings` (search) and `AutoDJ.buildShaderManifest()` (AI VJ path). Single source of truth confirmed in code audit.
 - 2026-05-02: AI VJ Mode — Alucinate full-library manifest (all 15 categories, 918 shaders), LLM param suggestion (`selectShadersFromLLM` returns `{id, params}[]`), `onUpdateParams` callback, `generateFromVibe()` one-shot method, vibe-prompt text input + Generate button in Controls.tsx (kimi-cli swarm, confirmed via `.swarm-state.md` + code audit)
 - 2026-04-18: Storage Manager CORS fix for `test1.1ink.us`; image/video streaming endpoints; sync-images/sync-videos admin endpoints (archived from prior notes)
@@ -50,7 +51,7 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-05-09
-Mode: New Idea
-Focus: Systematic WGSL runtime-error fix pass (49 critical shaders from runtime_errors_report.json)
+Date: 2026-05-16
+Mode: User Idea
+Focus: AI VJ stack persistence + history panel (localStorage save/load, VJ history panel in Controls.tsx, regenerate-variation button)
 Outcome: pending


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Archives last week's WGSL runtime-error fix pass (49/49 shaders fixed, all naga OK)
- Sets today's focus to **AI VJ stack persistence + history panel**
- Marks the idea in-progress in `weekly_plan.md`; updates Last run metadata

## Changes

- `weekly_plan.md` only — no src or shader files touched

## Test plan

- [ ] No build or test changes required (doc-only commit)

https://claude.ai/code/session_01Gip2iUo9ZayectMg43fwRe
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gip2iUo9ZayectMg43fwRe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VJ stacks are now persisted and can be accessed later
  * Added history panel with controls to restore and regenerate previous VJ stacks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/image_video_effects/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->