### PR TITLE
Fix JSON parsing error in kaleido-scope-grokcf1.json

### DIFF
--- a/public/shader-lists/geometric.json
+++ b/public/shader-lists/geometric.json
@@ -291,6 +291,54 @@
     "name": "Adaptive Mosaic"
   },
   {
+    "id": "kaleido-scope-grokcf1",
+    "name": "Kaleido-Scope Prism grokcf1",
+    "url": "shaders/kaleido-scope-grokcf1.wgsl",
+    "category": "geometric",
+    "description": "Kaleidoscope with spring-damper mouse follow, attack/release audio envelope, and temporal feedback trails.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "temporal"
+    ],
+    "params": [
+      {
+        "id": "segments",
+        "name": "Segments",
+        "default": 0.3,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "speed",
+        "name": "Rotation",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "zoom",
+        "name": "Zoom",
+        "default": 0.5,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "id": "offset",
+        "name": "Ring Offset",
+        "default": 0,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "tags": [
+      "geometric",
+      "pattern",
+      "audio",
+      "feedback"
+    ]
+  },
+  {
     "id": "kaleido-scope",
     "name": "Kaleido-Scope",
     "url": "shaders/kaleido-scope.wgsl",

--- a/shader_definitions/geometric/kaleido-scope-grokcf1.json
+++ b/shader_definitions/geometric/kaleido-scope-grokcf1.json
@@ -3,7 +3,7 @@
   "name": "Kaleido-Scope Prism grokcf1",
   "url": "shaders/kaleido-scope-grokcf1.wgsl",
   "category": "geometric",
-  "description": "Kaleidoscope with spring-damper mouse follow, attack/release audio envelope, and temporal feedback trails."
+  "description": "Kaleidoscope with spring-damper mouse follow, attack/release audio envelope, and temporal feedback trails.",
   "features": [
     "mouse-driven",
     "audio-reactive",


### PR DESCRIPTION
## Summary
Fixed JSON syntax error in `shader_definitions/geometric/kaleido-scope-grokcf1.json` by adding a missing comma after the `description` property.

## Issue
The script `generate_shader_lists.js` was failing with:
```
SyntaxError: Expected ',' or '}' after property value in JSON at position 278 (line 7 column 3)
```

## Fix
Added missing comma on line 6 after the description property value, before the features array.

## Verification
The `generate_shader_lists.js` script now runs successfully without JSON parsing errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XAduS7neufSvyjr4zZz34)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new kaleidoscope geometric shader with dynamic audio-reactive and temporal effects. The shader includes customizable parameters for segments, rotation speed, zoom level, and offset positioning to enable users to fine-tune and personalize the visual appearance and behavior of this geometric shader effect.

* **Chores**
  * Updated shader catalog metadata and definitions for new additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/image_video_effects/pull/661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->