### PR TITLE
Improve WebGPU adapter/device error logging

### DIFF
--- a/wasm_renderer/renderer.cpp
+++ b/wasm_renderer/renderer.cpp
@@ -202,11 +202,14 @@ bool WebGPURenderer::CreateDevice() {
 
     WGPUAdapter rawAdapter = nullptr;
     auto adapterCallback = [](WGPURequestAdapterStatus status, WGPUAdapter adapter,
-                               WGPUStringView /*message*/, void* userdata1, void* /*userdata2*/) {
+                               WGPUStringView message, void* userdata1, void* /*userdata2*/) {
         if (status == WGPURequestAdapterStatus_Success) {
             *static_cast<WGPUAdapter*>(userdata1) = adapter;
         } else {
-            printf("❌ Adapter request failed\n");
+            printf("❌ Adapter request failed! Status: %d\n", status);
+            if (message.data && message.length > 0) {
+                printf("   Message: %.*s\n", (int)message.length, message.data);
+            }
         }
     };
 
@@ -284,11 +287,14 @@ bool WebGPURenderer::CreateDevice() {
 
     WGPUDevice rawDevice = nullptr;
     auto deviceCallback = [](WGPURequestDeviceStatus status, WGPUDevice device,
-                              WGPUStringView /*message*/, void* userdata1, void* /*userdata2*/) {
+                              WGPUStringView message, void* userdata1, void* /*userdata2*/) {
         if (status == WGPURequestDeviceStatus_Success) {
             *static_cast<WGPUDevice*>(userdata1) = device;
         } else {
-            printf("❌ Device request failed\n");
+            printf("❌ Device request failed! Status: %d\n", status);
+            if (message.data && message.length > 0) {
+                printf("   Message: %.*s\n", (int)message.length, message.data);
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- Adapter and device failure callbacks now print the numeric status code and the error message string from WebGPU/Dawn
- Previously both callbacks printed only a generic `❌ ... request failed` line with no detail

## Test plan
- [ ] Rebuild with `emcmake cmake` / `emmake make`
- [ ] Open app with `?renderer=wasm` in a browser that supports WebGPU
- [ ] On failure, check the browser console / Emscripten stdout for the status code and Dawn error message
- [ ] Run `navigator.gpu.requestAdapter()` in DevTools console to confirm JS-side WebGPU availability

https://claude.ai/code/session_01Citq7qzdtfWkZHp4fctQ97

---
_Generated by [Claude Code](https://claude.ai/code/session_01Citq7qzdtfWkZHp4fctQ97)_