### PR TITLE
Add two new generative shaders

### DIFF
--- a/public/shader-lists/generative.json
+++ b/public/shader-lists/generative.json
@@ -2235,6 +2235,61 @@
     ]
   },
   {
+    "id": "gen-crystalline-mandala-bloom",
+    "name": "Crystalline Mandala Bloom",
+    "url": "shaders/gen-crystalline-mandala-bloom.wgsl",
+    "category": "generative",
+    "description": "Audio-reactive kaleidoscopic mandala that folds the source image through a rotating polar symmetry. Crystalline petal SDFs, hue-rotated chroma, concentric bass-rings, and treble sparkles bloom outward from a mouse-anchored center.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "generative",
+      "mandala",
+      "kaleidoscope",
+      "crystal",
+      "bloom",
+      "audio-reactive"
+    ],
+    "coordinate": 885,
+    "params": [
+      {
+        "id": "symmetry",
+        "name": "Symmetry Segments",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "facet_zoom",
+        "name": "Facet Zoom",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "bloom_strength",
+        "name": "Bloom Strength",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "hue_rotation",
+        "name": "Hue Rotation",
+        "default": 0,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      }
+    ]
+  },
+  {
     "id": "gen-cyber-terminal",
     "name": "Procedural Cyber Terminal (ASCII)",
     "url": "shaders/gen-cyber-terminal.wgsl",
@@ -4865,6 +4920,61 @@
         "default": 1,
         "min": 0,
         "max": 3,
+        "step": 0.01
+      }
+    ]
+  },
+  {
+    "id": "gen-prismatic-ion-cascade",
+    "name": "Prismatic Ion Cascade",
+    "url": "shaders/gen-prismatic-ion-cascade.wgsl",
+    "category": "generative",
+    "description": "Mouse-anchored cascade of prismatic ion streams. Curl-warped angular bands radiate from the cursor with chromatic spectral split, fbm-driven shimmer, and audio-reactive flicker. Bass pulses the radial core, mids drive flow speed, treble adds sparkle.",
+    "features": [
+      "mouse-driven",
+      "audio-reactive",
+      "upgraded-rgba"
+    ],
+    "tags": [
+      "generative",
+      "prismatic",
+      "ion",
+      "cascade",
+      "spectral",
+      "audio-reactive"
+    ],
+    "coordinate": 884,
+    "params": [
+      {
+        "id": "stream_density",
+        "name": "Stream Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "cascade_speed",
+        "name": "Cascade Speed",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "spectral_spread",
+        "name": "Spectral Spread",
+        "default": 0.4,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "id": "ion_thickness",
+        "name": "Ion Thickness",
+        "default": 0.35,
+        "min": 0,
+        "max": 1,
         "step": 0.01
       }
     ]

--- a/public/shaders/gen-crystalline-mandala-bloom.wgsl
+++ b/public/shaders/gen-crystalline-mandala-bloom.wgsl
@@ -1,0 +1,139 @@
+// ═══════════════════════════════════════════════════════════════════
+//  Crystalline Mandala Bloom
+//  Category: generative
+//  Features: mouse-driven, audio-reactive, upgraded-rgba
+//  Complexity: Medium
+//  Upgraded: 2026-05-23
+// ═══════════════════════════════════════════════════════════════════
+
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn rotate(a: f32) -> mat2x2<f32> {
+    let c = cos(a);
+    let s = sin(a);
+    return mat2x2<f32>(c, -s, s, c);
+}
+
+// Polar kaleidoscope fold
+fn kaleido(p: vec2<f32>, segments: f32) -> vec2<f32> {
+    let segAngle = 6.28318530718 / max(segments, 1.0);
+    var a = atan2(p.y, p.x);
+    let r = length(p);
+    a = abs(a - segAngle * floor(a / segAngle + 0.5));
+    return vec2<f32>(cos(a), sin(a)) * r;
+}
+
+fn hash21(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (f32(global_id.x) >= resolution.x || f32(global_id.y) >= resolution.y) { return; }
+
+    let coord = vec2<i32>(global_id.xy);
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let time = u.config.x;
+
+    let bass = plasmaBuffer[0].x;
+    let mids = plasmaBuffer[0].y;
+    let treble = plasmaBuffer[0].z;
+
+    // Params: x=symmetry segments, y=facet zoom, z=bloom strength, w=hue rotation
+    let segments = floor(4.0 + u.zoom_params.x * 16.0);
+    let facetZoom = 1.0 + u.zoom_params.y * 4.5;
+    let bloomStrength = 0.5 + u.zoom_params.z * 2.5;
+    let hueRot = u.zoom_params.w * 6.28318530718;
+
+    // Mouse moves the mandala center
+    let mouse = vec2<f32>(u.zoom_config.y, u.zoom_config.z);
+    let aspect = resolution.x / max(resolution.y, 1.0);
+    var p = vec2<f32>((uv.x - mouse.x) * aspect, uv.y - mouse.y);
+
+    // Audio-modulated rotation and scale (technique 1: rotating polar fold)
+    let spinRate = 0.2 + mids * 0.5;
+    p = rotate(time * spinRate + bass * 1.2) * p;
+    p = p * facetZoom * (1.0 + bass * 0.25);
+
+    // Kaleidoscopic symmetry
+    let k = kaleido(p, segments);
+
+    // Sample original image through the folded coordinate (technique 2: image-into-mandala)
+    let sampleUV = clamp(k * 0.5 + vec2<f32>(0.5), vec2<f32>(0.0), vec2<f32>(1.0));
+    let folded = textureSampleLevel(readTexture, u_sampler, sampleUV, 0.0);
+
+    // Radial crystalline facets (technique 3: SDF petals)
+    let r = length(k);
+    let a = atan2(k.y, k.x);
+    let petalCount = floor(segments * 0.5 + 3.0);
+    let petalPhase = cos(a * petalCount + time * (0.6 + mids * 0.8));
+    let petalRadius = 0.35 + 0.18 * petalPhase + treble * 0.04;
+    let petalSDF = smoothstep(petalRadius + 0.02, petalRadius - 0.02, r);
+
+    // Concentric rings pulsing with bass
+    let ringPhase = sin(r * 18.0 - time * 2.5 * (1.0 + bass * 0.5));
+    let ring = smoothstep(0.85, 1.0, abs(ringPhase));
+
+    // Hue-rotation matrix applied to folded color
+    let cosH = cos(hueRot + time * 0.15);
+    let sinH = sin(hueRot + time * 0.15);
+    let lum = dot(folded.rgb, vec3<f32>(0.299, 0.587, 0.114));
+    let chroma = folded.rgb - vec3<f32>(lum);
+    let rotChroma = vec3<f32>(
+        chroma.r * cosH + chroma.g * (-sinH) + chroma.b * sinH,
+        chroma.r * sinH + chroma.g * cosH + chroma.b * (-sinH),
+        chroma.r * (-sinH) + chroma.g * sinH + chroma.b * cosH
+    );
+    let foldedTinted = vec3<f32>(lum) + rotChroma;
+
+    // Crystalline highlight color
+    let crystalCold = vec3<f32>(0.6, 0.9, 1.2);
+    let crystalWarm = vec3<f32>(1.1, 0.55, 0.85);
+    let crystalColor = mix(crystalCold, crystalWarm, 0.5 + 0.5 * sin(time * 0.4 + r * 4.0));
+
+    // Bloom around petals (audio-modulated)
+    let bloom = exp(-r * 2.5) * bloomStrength * (1.0 + treble * 0.6);
+
+    // Composite
+    var rgb = foldedTinted * (0.45 + petalSDF * 0.9);
+    rgb += crystalColor * petalSDF * 0.6;
+    rgb += crystalColor * ring * 0.35 * (1.0 + mids * 0.5);
+    rgb += vec3<f32>(0.35, 0.5, 0.75) * bloom;
+
+    // Sparkle stars
+    let starSeed = hash21(floor(k * 60.0));
+    let star = step(0.992, starSeed) * (0.6 + treble * 1.2);
+    rgb += vec3<f32>(star);
+
+    let finalRGB = clamp(rgb, vec3<f32>(0.0), vec3<f32>(4.0));
+
+    // Meaningful alpha: petal mask + bloom + ring + base
+    let alpha = clamp(folded.a * 0.2 + petalSDF * 0.6 + ring * 0.3 + bloom * 0.25 + bass * 0.1, 0.0, 1.0);
+
+    // Depth: petals are near, surround is far
+    let depth = clamp(1.0 - petalSDF * 0.6 - bloom * 0.2, 0.0, 1.0);
+
+    textureStore(writeTexture, coord, vec4<f32>(finalRGB, alpha));
+    textureStore(writeDepthTexture, coord, vec4<f32>(depth, 0.0, 0.0, 0.0));
+    textureStore(dataTextureA, coord, vec4<f32>(finalRGB, alpha));
+}

--- a/public/shaders/gen-prismatic-ion-cascade.wgsl
+++ b/public/shaders/gen-prismatic-ion-cascade.wgsl
@@ -1,0 +1,136 @@
+// ═══════════════════════════════════════════════════════════════════
+//  Prismatic Ion Cascade
+//  Category: generative
+//  Features: mouse-driven, audio-reactive, upgraded-rgba
+//  Complexity: Medium
+//  Upgraded: 2026-05-23
+// ═══════════════════════════════════════════════════════════════════
+
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+  config: vec4<f32>,
+  zoom_config: vec4<f32>,
+  zoom_params: vec4<f32>,
+  ripples: array<vec4<f32>, 50>,
+};
+
+fn hash21(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453);
+}
+
+fn noise2(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let a = hash21(i);
+    let b = hash21(i + vec2<f32>(1.0, 0.0));
+    let c = hash21(i + vec2<f32>(0.0, 1.0));
+    let d = hash21(i + vec2<f32>(1.0, 1.0));
+    let uu = f * f * (3.0 - 2.0 * f);
+    return mix(mix(a, b, uu.x), mix(c, d, uu.x), uu.y);
+}
+
+fn fbm(p: vec2<f32>) -> f32 {
+    var v = 0.0;
+    var amp = 0.5;
+    var freq = p;
+    for (var i = 0; i < 5; i++) {
+        v += amp * noise2(freq);
+        freq = freq * 2.03;
+        amp = amp * 0.5;
+    }
+    return v;
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let resolution = u.config.zw;
+    if (f32(global_id.x) >= resolution.x || f32(global_id.y) >= resolution.y) { return; }
+
+    let coord = vec2<i32>(global_id.xy);
+    let uv = vec2<f32>(global_id.xy) / resolution;
+    let time = u.config.x;
+
+    let bass = plasmaBuffer[0].x;
+    let mids = plasmaBuffer[0].y;
+    let treble = plasmaBuffer[0].z;
+
+    // Params: x=streamDensity, y=cascadeSpeed, z=spectralSpread, w=ionThickness
+    let streamDensity = 4.0 + u.zoom_params.x * 16.0;
+    let cascadeSpeed = 0.3 + u.zoom_params.y * 2.0;
+    let spectralSpread = 0.02 + u.zoom_params.z * 0.15;
+    let ionThickness = 0.005 + u.zoom_params.w * 0.06;
+
+    // Mouse-driven origin: cascades pour from mouse position
+    let mouse = vec2<f32>(u.zoom_config.y, u.zoom_config.z);
+    let aspect = resolution.x / max(resolution.y, 1.0);
+    let p = vec2<f32>((uv.x - mouse.x) * aspect, uv.y - mouse.y);
+
+    // Distance and angle from cascade origin
+    let r = length(p);
+    let theta = atan2(p.y, p.x);
+
+    // Vertical-biased streams that warp toward mouse (technique 1: streaming bands)
+    let warp = fbm(vec2<f32>(theta * 2.0, time * cascadeSpeed * (1.0 + mids * 0.4)));
+    let bandPhase = theta * streamDensity + warp * 3.0 + time * cascadeSpeed * (1.0 + bass * 0.5);
+    let bandWave = sin(bandPhase);
+    let bandMask = smoothstep(1.0 - ionThickness * 20.0, 1.0, abs(bandWave));
+
+    // Falloff from origin (audio-pulsing radius)
+    let radialPulse = 1.0 + bass * 0.6;
+    let coreFall = exp(-r * (3.0 - radialPulse));
+    let outerFall = exp(-r * 1.4);
+
+    // Technique 2: prismatic spectral split — sample three offset phase positions
+    let split = spectralSpread * (1.0 + treble * 0.8);
+    let phaseR = sin(bandPhase + split * 6.28);
+    let phaseG = sin(bandPhase);
+    let phaseB = sin(bandPhase - split * 6.28);
+
+    let maskR = smoothstep(1.0 - ionThickness * 20.0, 1.0, abs(phaseR));
+    let maskG = smoothstep(1.0 - ionThickness * 20.0, 1.0, abs(phaseG));
+    let maskB = smoothstep(1.0 - ionThickness * 20.0, 1.0, abs(phaseB));
+
+    let ionR = maskR * (coreFall + outerFall * 0.4);
+    let ionG = maskG * (coreFall + outerFall * 0.4);
+    let ionB = maskB * (coreFall + outerFall * 0.4);
+
+    // Temporal turbulence shimmer (technique 3: fbm-driven flicker tied to time)
+    let shimmer = fbm(p * 6.0 + vec2<f32>(time * 0.5, -time * 0.7)) * 0.5 + 0.5;
+    let flicker = mix(0.7, 1.3, shimmer) * (1.0 + treble * 0.4);
+
+    var ionColor = vec3<f32>(ionR, ionG, ionB) * flicker;
+
+    // Ambient prismatic haze blended with original frame
+    let baseSample = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+    let haze = vec3<f32>(0.05, 0.08, 0.18) * outerFall * (1.0 + bass * 0.5);
+    let composed = baseSample.rgb * 0.35 + ionColor * 2.2 + haze;
+
+    // Sparkle dots near peaks
+    let sparkleSeed = hash21(floor(uv * resolution * 0.5) + floor(time * 8.0));
+    let sparkle = step(0.985, sparkleSeed) * bandMask * treble * 1.5;
+    let finalRGB = clamp(composed + vec3<f32>(sparkle), vec3<f32>(0.0), vec3<f32>(4.0));
+
+    // Meaningful alpha: encodes ion stream presence + radial falloff + audio + base alpha
+    let ionStrength = (ionR + ionG + ionB) / 3.0;
+    let alpha = clamp(baseSample.a * 0.25 + ionStrength * 0.6 + coreFall * 0.3 + bass * 0.1, 0.0, 1.0);
+
+    // Depth: closer near cascade origin
+    let depth = clamp(1.0 - coreFall, 0.0, 1.0);
+
+    textureStore(writeTexture, coord, vec4<f32>(finalRGB, alpha));
+    textureStore(writeDepthTexture, coord, vec4<f32>(depth, 0.0, 0.0, 0.0));
+    textureStore(dataTextureA, coord, vec4<f32>(finalRGB, alpha));
+}

--- a/shader_definitions/generative/gen-crystalline-mandala-bloom.json
+++ b/shader_definitions/generative/gen-crystalline-mandala-bloom.json
@@ -1,0 +1,16 @@
+{
+  "id": "gen-crystalline-mandala-bloom",
+  "name": "Crystalline Mandala Bloom",
+  "url": "shaders/gen-crystalline-mandala-bloom.wgsl",
+  "category": "generative",
+  "description": "Audio-reactive kaleidoscopic mandala that folds the source image through a rotating polar symmetry. Crystalline petal SDFs, hue-rotated chroma, concentric bass-rings, and treble sparkles bloom outward from a mouse-anchored center.",
+  "features": ["mouse-driven", "audio-reactive", "upgraded-rgba"],
+  "tags": ["generative", "mandala", "kaleidoscope", "crystal", "bloom", "audio-reactive"],
+  "coordinate": 885,
+  "params": [
+    {"id": "symmetry", "name": "Symmetry Segments", "default": 0.5, "min": 0, "max": 1, "step": 0.01},
+    {"id": "facet_zoom", "name": "Facet Zoom", "default": 0.4, "min": 0, "max": 1, "step": 0.01},
+    {"id": "bloom_strength", "name": "Bloom Strength", "default": 0.5, "min": 0, "max": 1, "step": 0.01},
+    {"id": "hue_rotation", "name": "Hue Rotation", "default": 0.0, "min": 0, "max": 1, "step": 0.01}
+  ]
+}

--- a/shader_definitions/generative/gen-prismatic-ion-cascade.json
+++ b/shader_definitions/generative/gen-prismatic-ion-cascade.json
@@ -1,0 +1,16 @@
+{
+  "id": "gen-prismatic-ion-cascade",
+  "name": "Prismatic Ion Cascade",
+  "url": "shaders/gen-prismatic-ion-cascade.wgsl",
+  "category": "generative",
+  "description": "Mouse-anchored cascade of prismatic ion streams. Curl-warped angular bands radiate from the cursor with chromatic spectral split, fbm-driven shimmer, and audio-reactive flicker. Bass pulses the radial core, mids drive flow speed, treble adds sparkle.",
+  "features": ["mouse-driven", "audio-reactive", "upgraded-rgba"],
+  "tags": ["generative", "prismatic", "ion", "cascade", "spectral", "audio-reactive"],
+  "coordinate": 884,
+  "params": [
+    {"id": "stream_density", "name": "Stream Density", "default": 0.5, "min": 0, "max": 1, "step": 0.01},
+    {"id": "cascade_speed", "name": "Cascade Speed", "default": 0.5, "min": 0, "max": 1, "step": 0.01},
+    {"id": "spectral_spread", "name": "Spectral Spread", "default": 0.4, "min": 0, "max": 1, "step": 0.01},
+    {"id": "ion_thickness", "name": "Ion Thickness", "default": 0.35, "min": 0, "max": 1, "step": 0.01}
+  ]
+}


### PR DESCRIPTION
- gen-prismatic-ion-cascade: mouse-anchored prismatic ion streams with fbm-warped angular bands, chromatic spectral split, and audio-reactive flicker. Bass pulses the radial core, mids drive flow speed, treble adds sparkle.

- gen-crystalline-mandala-bloom: kaleidoscopic mandala folding the source image through rotating polar symmetry. Crystalline petal SDFs, hue-rotated chroma, concentric bass-rings, and treble sparkles bloom outward from a mouse-anchored center.

Both follow the upgraded-rgba spec: 13-binding header, meaningful per-pixel alpha, plasmaBuffer audio reactivity, writeDepthTexture and dataTextureA writes, clamped UVs, and divide-by-zero guards.

Both pass naga validation; generate_shader_lists and check_duplicates both pass (906 unique IDs, no duplicates).