### PR TITLE
fix: default to WebGPU renderer, remove WASM from auto-fallback chain

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -278,6 +278,15 @@ function MainApp() {
 
     // --- Refs ---
     const rendererRef = useRef<Renderer | null>(null);
+
+    // --- Renderer backend state ---
+    const [activeRendererType, setActiveRendererType] = useState<'webgpu' | 'wasm' | 'js'>('webgpu');
+    const handleSwitchRenderer = useCallback(async (type: 'webgpu' | 'wasm' | 'js') => {
+        const manager = rendererRef.current as any;
+        if (!manager?.switchRenderer) return;
+        const ok = await manager.switchRenderer(type);
+        if (ok) setActiveRendererType(type);
+    }, []);
     const fileInputImageRef = useRef<HTMLInputElement>(null);
     const fileInputVideoRef = useRef<HTMLInputElement>(null);
     const channelRef = useRef<BroadcastChannel | null>(null);
@@ -1413,6 +1422,9 @@ function MainApp() {
                         onStopRecording={stopRecording}
                         // Dev Tools props
                         onOpenShaderScanner={() => setShowShaderScanner(true)}
+                        // Renderer switch props
+                        activeRendererType={activeRendererType}
+                        onSwitchRenderer={handleSwitchRenderer}
                         // Storage Browser props
                         onOpenStorageBrowser={() => setShowStorageBrowser(true)}
                     />

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -91,6 +91,9 @@ interface ControlsProps {
     onExitLiveStream?: () => void;
     // Dev Tools Props
     onOpenShaderScanner?: () => void;
+    // Renderer Switch Props
+    activeRendererType?: 'webgpu' | 'wasm' | 'js';
+    onSwitchRenderer?: (type: 'webgpu' | 'wasm' | 'js') => void;
     // Storage Browser Props
     onOpenStorageBrowser?: () => void;
 }
@@ -143,6 +146,8 @@ const Controls: React.FC<ControlsProps> = ({
     onLiveStreamLoaded,
     onExitLiveStream,
     onOpenShaderScanner,
+    activeRendererType = 'webgpu',
+    onSwitchRenderer,
     onOpenStorageBrowser
 }) => {
     // --- Coordinate System State ---
@@ -1212,6 +1217,37 @@ const Controls: React.FC<ControlsProps> = ({
                             }}>
                                 Tests WGSL compilation on all shaders
                             </div>
+                            {onSwitchRenderer && (
+                                <div style={{ marginTop: '10px' }}>
+                                    <div style={{ fontSize: '10px', color: '#a0a0b0', marginBottom: '5px', textAlign: 'center' }}>
+                                        Renderer Backend
+                                    </div>
+                                    <div style={{ display: 'flex', gap: '4px' }}>
+                                        {(['webgpu', 'wasm', 'js'] as const).map(type => (
+                                            <button
+                                                key={type}
+                                                onClick={() => onSwitchRenderer(type)}
+                                                style={{
+                                                    flex: 1,
+                                                    fontSize: '10px',
+                                                    padding: '4px 0',
+                                                    background: activeRendererType === type
+                                                        ? 'rgba(255,215,0,0.25)'
+                                                        : 'transparent',
+                                                    border: `1px solid ${activeRendererType === type ? '#FFD700' : 'rgba(255,215,0,0.3)'}`,
+                                                    color: activeRendererType === type ? '#FFD700' : '#a0a0b0',
+                                                    borderRadius: '4px',
+                                                    cursor: 'pointer',
+                                                    textTransform: 'uppercase',
+                                                    letterSpacing: '0.05em',
+                                                }}
+                                            >
+                                                {type}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>

--- a/src/renderer/RendererManager.ts
+++ b/src/renderer/RendererManager.ts
@@ -84,15 +84,10 @@ export class RendererManager {
       return true;
     }
 
-    // 2. Try compiled WASM renderer (requires a real Emscripten binary)
-    const wasmSuccess = await this.switchRenderer('wasm');
-    if (wasmSuccess) {
-      console.log('✅ Using WASM renderer with shader support');
-      return true;
-    }
-
-    // 3. Canvas2D fallback — no shader effects, but app stays functional
-    console.warn('⚠️ WebGPU and WASM unavailable — falling back to Canvas2D (shaders disabled)');
+    // 2. Canvas2D fallback — no shader effects, but app stays functional.
+    // WASM renderer is NOT an automatic fallback; use switchRenderer('wasm') explicitly
+    // or pass ?renderer=wasm in the URL to opt in.
+    console.warn('⚠️ WebGPU unavailable — falling back to Canvas2D (shaders disabled)');
     return this.switchRenderer('js');
   }
 


### PR DESCRIPTION
RendererManager.init() now falls directly from WebGPU → Canvas2D on GPU unavailability. WASM is opt-in only via ?renderer=wasm URL param or the new renderer toggle in Dev Tools. Adds webgpu/wasm/js toggle buttons to the Dev Tools panel in Controls, wired through App.tsx.

https://claude.ai/code/session_01FsAXbD43rBNhV2oKXJKgbZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renderer backend switching now available in Dev Tools UI with options for WebGPU, WASM, and Canvas2D
  * Active renderer backend is visually highlighted for easy identification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/image_video_effects/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->