### PR TITLE
docs: clarify that shader upgrades must add visual effects, not just fix plumbing

### DIFF
--- a/agents/CLOUD_UPGRADE.md
+++ b/agents/CLOUD_UPGRADE.md
@@ -45,6 +45,18 @@ struct Uniforms {
 
 ## 2. What "Upgraded" Means
 
+### 2.0 First Principle — The Upgrade Is Visual
+
+> **Upgrading means changing what the viewer sees.** The point of an upgrade is
+> to add visual effects, detail, or creative alterations of the output that were
+> not there before — new color/lighting, depth, motion, texture, generative
+> structure, or interactivity. Everything in §2.1–2.5 below (correct bindings,
+> the workgroup boundary guard, branchless safety, depth/data writes, `naga`
+> validation, JSON updates) is the **floor** — necessary plumbing, not the
+> upgrade. A shader that newly compiles, writes depth, and has meaningful alpha
+> but renders the same picture as before is **not** upgraded. If the diff does
+> not make the output look meaningfully richer or different, the work is not done.
+
 A shader is `upgraded-rgba` when it satisfies **all** of the following criteria.
 
 ### 2.1 RGBA Awareness (25 pts)

--- a/notes/shaders_upgrade_plan.md
+++ b/notes/shaders_upgrade_plan.md
@@ -7,6 +7,18 @@
 
 ---
 
+## What "Upgrade" Means Here
+
+> **An upgrade adds to the visual output — it is not a refactor.** The goal of
+> upgrading a shader is to introduce *new* visual effects, richer detail, or
+> creative alterations of the image that were not there before (new lighting,
+> color, motion, depth, texture, generative structure, interactivity, etc.).
+> Fixing bindings, adding the workgroup barrier, clamping UVs, or passing
+> `naga` validation are **prerequisites**, not the upgrade itself. A shader
+> that compiles cleanly but looks the same as before has **not** been upgraded.
+> The size tiers below only decide *order of work*; every shader touched should
+> come out visibly more interesting than it went in.
+
 ## Executive Summary
 
 This document catalogs all WGSL shaders by file size to prioritize upgrade efforts. **Smaller shaders are recommended for first priority** as they represent simpler codebases that can be updated more quickly and with lower risk.


### PR DESCRIPTION
## Why

Audited the plan `.md` files to confirm they express that **"upgrading a shader" means adding visual effects / detail / creative alterations of the output that weren't there before** — not merely adding correct bindings, the workgroup barrier, depth writes, etc.

Most docs already say this clearly (`agents/EFFECT_UPGRADE_SWARM.md`, `agents/upgrade_swarm.md`, all `shader_plans/*_upgrades.md`, the prompt templates, `agents/4_AGENT_SWARM_PROMPT.md`, and the auto-repair prompt in `scripts/scan-shaders-naga.py`). Two did not:

1. **`notes/shaders_upgrade_plan.md`** — a pure file-size prioritization catalog that never defined what an upgrade *is*; its rationale read as refactoring/maintenance.
2. **`agents/CLOUD_UPGRADE.md` §2 "What Upgraded Means"** — the canonical rubric weighted RGBA alpha, no-div-zero safety, compilation, depth/data writes, and JSON, with only 15 pts for combining techniques. A shader could score highly while looking unchanged.

## Change

Added a short, explicit "the upgrade is visual" first principle to both files, framing the technical criteria (bindings, boundary guard, branchless safety, `naga` validation, JSON) as the **floor** rather than the upgrade itself — a shader that compiles cleanly but renders the same picture has not been upgraded.

Docs-only; no shader or code behavior changes.

https://claude.ai/code/session_01CvD1q6vooH52NnNLq4pj4A

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvD1q6vooH52NnNLq4pj4A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade guides to clarify that visual improvements are the primary criterion for upgrades, with technical correctness items treated as prerequisite baseline requirements rather than upgrade criteria themselves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->