### PR TITLE
Fix 69 WGSL shader compile errors from scanner report

### DIFF
--- a/public/shaders/_template_shared_memory.wgsl
+++ b/public/shaders/_template_shared_memory.wgsl
@@ -168,12 +168,12 @@ fn main(
 ) {
   let resolution = u.config.zw;
   let uv = vec2<f32>(gid.xy) / resolution;
-  
-  // Bounds check
-  if (gid.x >= u32(resolution.x) || gid.y >= u32(resolution.y)) {
-    return;
-  }
-  
+
+  // Bounds check — out-of-bounds threads must still participate in the
+  // workgroupBarrier inside loadTileToSharedMemory (barriers require uniform
+  // control flow), so we only skip the final store for them.
+  let inBounds = gid.x < u32(resolution.x) && gid.y < u32(resolution.y);
+
   // ═══════════════════════════════════════════════════════════════════════════════
   // STEP 1: Load data into shared memory
   // ═══════════════════════════════════════════════════════════════════════════════
@@ -194,5 +194,7 @@ fn main(
   // STEP 3: Write output
   // ═══════════════════════════════════════════════════════════════════════════════
   let color = vec3<f32>(newHeight * 0.5 + 0.5);
-  textureStore(writeTexture, gid.xy, vec4<f32>(color, 1.0));
+  if (inBounds) {
+    textureStore(writeTexture, gid.xy, vec4<f32>(color, 1.0));
+  }
 }

--- a/public/shaders/aero-chromatics-prismatic.wgsl
+++ b/public/shaders/aero-chromatics-prismatic.wgsl
@@ -16,9 +16,6 @@
 
 @group(0) @binding(0) var u_sampler: sampler;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
 @group(0) @binding(1) var readTexture: texture_2d<f32>;
 @group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(3) var<uniform> u: Uniforms;

--- a/public/shaders/alpha-fluid-simulation-paint.wgsl
+++ b/public/shaders/alpha-fluid-simulation-paint.wgsl
@@ -81,7 +81,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
     // === DIFFUSION (viscosity now seasonal) ===
     // bass = thicker fluid (honey), treble = thinner (water)
-    let visc = mix(0.0008, 0.0022, u.zoom_params.x) * (0.6 + bass * 0.7 - treble * 0.4);
+    let bass = plasmaBuffer[0].x;
+    let treble = plasmaBuffer[0].z;
+    let visc = mix(0.0008f, 0.0022f, u.zoom_params.x) * (0.6 + bass * 0.7 - treble * 0.4);
     let left = textureSampleLevel(dataTextureC, u_sampler, clamp(uv - vec2<f32>(ps.x, 0.0), vec2<f32>(0.0), vec2<f32>(1.0)), 0.0);
     let right = textureSampleLevel(dataTextureC, u_sampler, clamp(uv + vec2<f32>(ps.x, 0.0), vec2<f32>(0.0), vec2<f32>(1.0)), 0.0);
     let down = textureSampleLevel(dataTextureC, u_sampler, clamp(uv - vec2<f32>(0.0, ps.y), vec2<f32>(0.0), vec2<f32>(1.0)), 0.0);

--- a/public/shaders/alpha-spectral-decompose.wgsl
+++ b/public/shaders/alpha-spectral-decompose.wgsl
@@ -15,9 +15,6 @@
 
 @group(0) @binding(0) var u_sampler: sampler;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
 @group(0) @binding(1) var readTexture: texture_2d<f32>;
 @group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(3) var<uniform> u: Uniforms;

--- a/public/shaders/alpha-watercolor-wetness.wgsl
+++ b/public/shaders/alpha-watercolor-wetness.wgsl
@@ -37,6 +37,12 @@ struct Uniforms {
   ripples: array<vec4<f32>, 50>,
 };
 
+fn hash12(p: vec2<f32>) -> f32 {
+    var p3 = fract(vec3<f32>(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
 @compute @workgroup_size(16, 16, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let res = u.config.zw;

--- a/public/shaders/ambient-liquid-coupled.wgsl
+++ b/public/shaders/ambient-liquid-coupled.wgsl
@@ -90,8 +90,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
   // === LIVING MEMBRANE PRESSURE (new high-signal behavior) ===
   // Read previous membrane pressure from dataTextureB
-  let prevPressure = textureSampleLevel(dataTextureB, u_sampler, uv, 0.0).r;
-  let prevBass = textureSampleLevel(dataTextureB, u_sampler, vec2<f32>(0.0), 0.0).g; // stored bass history at origin
+  let prevPressure = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0).r;
+  let prevBass = textureSampleLevel(dataTextureC, u_sampler, vec2<f32>(0.0), 0.0).g; // stored bass history at origin
 
   // Bass-driven surface tension (high bass = high tension = slow healing)
   let bass = plasmaBuffer[0].x;
@@ -121,7 +121,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   }
 
   // Mouse force (now modulated by membrane pressure)
-  let mouseRadius = mix(0.03, 0.18, 0.5);
+  let mouseRadius = mix(0.03f, 0.18f, 0.5f);
   let influence = smoothstep(mouseRadius, 0.0, dist);
   let membraneResistance = 1.0 - (pressure * 0.18); // high pressure = more resistant surface
   vel = vel + mouseVel * influence * 0.5 * membraneResistance;
@@ -162,7 +162,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
   // === LIVING MEMBRANE DISPLACEMENT (high-signal creative upgrade) ===
   // Read the membrane pressure we just wrote (or previous frame)
-  let membranePressure = textureSampleLevel(dataTextureB, u_sampler, uv, 0.0).r;
+  let membranePressure = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0).r;
 
   let rate = 0.5;
   let waveTime = time * rate;

--- a/public/shaders/artistic_painterly_oil.wgsl
+++ b/public/shaders/artistic_painterly_oil.wgsl
@@ -246,7 +246,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     color = mix(color, color * vec3<f32>(1.02, 0.98, 0.96), glaze);
 
     // Treble adds fine surface texture / broken color (classic oil technique)
-    let brokenColor = (hash12(coord + time * 3.0) - 0.5) * treble * 0.06 * paintWetness;
+    let brokenColor = (hash12(vec2<f32>(coord) + time * 3.0) - 0.5) * treble * 0.06 * paintWetness;
     color += brokenColor;
 
     // Specular highlight contributes to perceived solidity

--- a/public/shaders/bismuth-crystallizer.wgsl
+++ b/public/shaders/bismuth-crystallizer.wgsl
@@ -21,20 +21,6 @@
 @group(0) @binding(11) var comparison_sampler: sampler_comparison;
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
-
-// Grok: Audio drives crystal "growth temperature" and iridescence
-let crystalTemp = 1.0 + mids * 0.5 + treble * 0.4;
-
-// Grok visual flourish: Audio drives growth speed and iridescence intensity
-// Bass = slower, heavier crystal formation with deep color
-// Treble = rapid, delicate facet growth with strong rainbow play
-
-// Apply temperature to final color for richer metallic iridescence
-col = col * mix(vec3<f32>(0.9, 0.95, 1.1), vec3<f32>(1.15, 0.95, 0.75), crystalTemp * 0.6);
-
 struct Uniforms {
   config: vec4<f32>,
   zoom_config: vec4<f32>,
@@ -161,6 +147,12 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let transmitted = crystal_look * (vec3<f32>(1.0) - fresnel) * oxidePurity;
     
     var final_color = mix(img_color, reflected + transmitted, mix_amt);
+
+    // Grok: Audio drives crystal "growth temperature" and iridescence
+    let mids = plasmaBuffer[0].y;
+    let treble = plasmaBuffer[0].z;
+    let crystalTemp = 1.0 + mids * 0.5 + treble * 0.4;
+    final_color = final_color * mix(vec3<f32>(0.9, 0.95, 1.1), vec3<f32>(1.15, 0.95, 0.75), crystalTemp * 0.6);
 
     // ═══════════════════════════════════════════════════════════════
     // Transmission Alpha

--- a/public/shaders/byte-mosh.wgsl
+++ b/public/shaders/byte-mosh.wgsl
@@ -106,7 +106,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let prevAge = prevState.b * 63.0;
   let prevMode = round(prevState.a * 3.0);
 
-  let blockSeed = (blockOriginU.x + 1u) * 257u ^ (blockOriginU.y + 1u) * 263u ^ u32(time * 60.0 + 1.0);
+  let blockSeed = ((blockOriginU.x + 1u) * 257u) ^ ((blockOriginU.y + 1u) * 263u) ^ u32(time * 60.0 + 1.0);
   lfsr = lfsr_advance(lfsr ^ blockSeed, 3u);
   let rand0 = f32(lfsr & 0xffffu) / 65535.0;
   lfsr = lfsr_step(lfsr);

--- a/public/shaders/chroma-lens-iridescence.wgsl
+++ b/public/shaders/chroma-lens-iridescence.wgsl
@@ -120,6 +120,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         var thickness = filmThicknessBase * (0.7 + depth * 0.6 + noiseVal * turbulence);
         let iridescent = thinFilmColor(thickness, cosTheta, filmIOR) * intensity;
         let fresnel = pow(1.0 - cosTheta, 3.0);
+        let ndist = dist / radius;
         let lensColor = mix(color.rgb, iridescent, fresnel * 0.7 * (1.0 - ndist));
         color = vec4<f32>(lensColor, 1.0);
     }

--- a/public/shaders/chromatic-folds-bilateral.wgsl
+++ b/public/shaders/chromatic-folds-bilateral.wgsl
@@ -177,7 +177,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // Feedback blend
     let prev = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0).rgb;
     let feedbackStrength = 0.85;
-    let finalColor = mix(foldedColor, prev, feedbackStrength);
+    var finalColor = mix(foldedColor, prev, feedbackStrength);
 
     // Psychedelic hue shift post-processing
     if (hueShiftAmt > 0.0) {

--- a/public/shaders/chrono-voronoi-mycelium.wgsl
+++ b/public/shaders/chrono-voronoi-mycelium.wgsl
@@ -78,7 +78,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     
     // Read previous temporal layers
     let prevLayer1 = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0);
-    let prevLayer2 = textureSampleLevel(dataTextureA, u_sampler, uv, 0.0);
+    let prevLayer2 = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0);
     
     // Multi-scale Voronoi growth
     let scale1 = 8.0 + seasonVolatile * 6.0;

--- a/public/shaders/chronos-brush-explosion.wgsl
+++ b/public/shaders/chronos-brush-explosion.wgsl
@@ -110,7 +110,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         }
     }
 
-    let intensity = 1.0 + mouseDown * 1.5;
+    let intensity = 1.0 + f32(mouseDown) * 1.5;
 
     // Sample frozen canvas with chromatic displacement
     let frozenR = textureSampleLevel(dataTextureC, u_sampler, clamp(rUV + rOffset * intensity, vec2<f32>(0.0), vec2<f32>(1.0)), 0.0).r;

--- a/public/shaders/concentric-spin.wgsl
+++ b/public/shaders/concentric-spin.wgsl
@@ -71,9 +71,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let gapFade = u.zoom_params.w;
   let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
   let parallax = (depth - 0.5) * 0.05;
-  let target = u.zoom_config.yz * vec2<f32>(aspect, 1.0);
+  let targetPos = u.zoom_config.yz * vec2<f32>(aspect, 1.0);
   let prevLag = textureSampleLevel(dataTextureC, non_filtering_sampler, uv, 0.0).rg;
-  let lag = mix(select(target, prevLag, t > 0.1), target, 0.08);
+  let lag = mix(select(targetPos, prevLag, t > 0.1), targetPos, 0.08);
   let center = lag + vec2<f32>(parallax, parallax);
   let p = uv * vec2<f32>(aspect, 1.0) - center;
   let r = length(p);
@@ -93,7 +93,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   if(edge > smoothW + 0.05 && gapFade > 0.7) {
     let base = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
     textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(base.rgb, base.a));
-    textureStore(dataTextureA, global_id.xy, vec4<f32>(lag, 0.0, 0.0, 0.0));
+    textureStore(dataTextureA, global_id.xy, vec4<f32>(lag, 0.0, 0.0));
     textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
     return;
   }
@@ -129,6 +129,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   col = col + vec3<f32>(sheen);
   let alpha = clamp(gapMask * (1.0 - gapFade * 0.5) + bloom * 0.3 + pulse * 0.5, 0.0, 1.0);
   textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(col, alpha));
-  textureStore(dataTextureA, global_id.xy, vec4<f32>(lag, 0.0, 0.0, 0.0));
+  textureStore(dataTextureA, global_id.xy, vec4<f32>(lag, 0.0, 0.0));
   textureStore(writeDepthTexture, global_id.xy, vec4<f32>(depth, 0.0, 0.0, 0.0));
 }

--- a/public/shaders/coral-growth.wgsl
+++ b/public/shaders/coral-growth.wgsl
@@ -80,7 +80,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         let closest = origin + normalize(dir) * proj;
         let d = length(cellUV - closest);
         let branchWidth = 0.02 * (1.0 - proj / max(currentLen, 0.001));
-        let branch = smoothstep(branchWidth, 0.0, d);
+        var branch = smoothstep(branchWidth, 0.0, d);
 
         // Sub-branches
         if (proj > currentLen * 0.5) {

--- a/public/shaders/crystal-facets.wgsl
+++ b/public/shaders/crystal-facets.wgsl
@@ -177,6 +177,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let treble = audio.z;
 
     // Bass pulses internal light transport (like light moving through the crystal)
+    let time = u.config.x;
     let causticPulse = 1.0 + bass * 0.6 + sin(time * 6.0 + facetID) * treble * 0.3;
     
     // Mids add subtle color temperature shift inside the facets

--- a/public/shaders/cyber-lattice.wgsl
+++ b/public/shaders/cyber-lattice.wgsl
@@ -78,8 +78,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let warpP = gridP + vec2<f32>(wind, 0.0);
 
     // Shockwave from mouse click
-    let clickRipple = 0.0;
-    let clickPhase = 0.0;
+    var clickRipple = 0.0;
+    var clickPhase = 0.0;
     if (mouseDown > 0.5) {
       let clickDist = length(p - vanish);
       clickPhase = clickDist * 20.0 - time * 15.0;
@@ -106,7 +106,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     iridescent = mix(iridescent, vec3<f32>(1.0, 0.0, 1.0), film.b * 0.5);
 
     let totalGlow = glowIntensity * (0.4 + 0.6 * mouseInfluence + bass * 0.3);
-    let latticeColor = mix(baseColor.rgb, iridescent, gridMask * totalGlow);
+    var latticeColor = mix(baseColor.rgb, iridescent, gridMask * totalGlow);
 
     // Invert interference colors inside shockwave ring
     if (mouseDown > 0.5 && abs(fract(clickPhase / 6.28318530718) - 0.5) < 0.1) {

--- a/public/shaders/cyber-organic-ecosystem.wgsl
+++ b/public/shaders/cyber-organic-ecosystem.wgsl
@@ -84,11 +84,11 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let prevState = textureLoad(dataTextureC, coord, 0);
   var s1 = prevState.r;
   var s2 = prevState.g;
-  var resource = prevState.b;
+  var resourceLevel = prevState.b;
   var toxin = prevState.a;
 
   if (time < 0.1) {
-    s1 = 0.0; s2 = 0.0; resource = 0.5; toxin = 0.0;
+    s1 = 0.0; s2 = 0.0; resourceLevel = 0.5; toxin = 0.0;
     let n1 = fract(sin(dot(uv, vec2<f32>(12.9898, 78.233))) * 43758.5453);
     if (n1 > 0.92) { s1 = 0.8; }
     let n2 = fract(sin(dot(uv + vec2<f32>(5.0), vec2<f32>(93.0, 17.0))) * 271.0);
@@ -97,7 +97,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
   s1 = clamp(s1, 0.0, 2.0);
   s2 = clamp(s2, 0.0, 2.0);
-  resource = clamp(resource, 0.0, 2.0);
+  resourceLevel = clamp(resourceLevel, 0.0, 2.0);
   toxin = clamp(toxin, 0.0, 2.0);
 
   let left = textureSampleLevel(dataTextureC, u_sampler, clamp(uv - vec2<f32>(ps.x, 0.0), vec2<f32>(0.0), vec2<f32>(1.0)), 0.0);
@@ -107,21 +107,21 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
   let lapS1 = left.r + right.r + down.r + up.r - 4.0 * s1;
   let lapS2 = left.g + right.g + down.g + up.g - 4.0 * s2;
-  let lapResource = left.b + right.b + down.b + up.b - 4.0 * resource;
+  let lapResource = left.b + right.b + down.b + up.b - 4.0 * resourceLevel;
   let lapToxin = left.a + right.a + down.a + up.a - 4.0 * toxin;
 
-  let growthRate1 = mix(0.02, 0.08, 0.5);
-  let growthRate2 = mix(0.015, 0.06, 0.4);
+  let growthRate1 = mix(0.02f, 0.08f, 0.5f);
+  let growthRate2 = mix(0.015f, 0.06f, 0.4f);
   let dt = 0.5;
 
-  let food1 = s1 * resource * growthRate1;
-  let food2 = s2 * resource * growthRate2;
+  let food1 = s1 * resourceLevel * growthRate1;
+  let food2 = s2 * resourceLevel * growthRate2;
   let competition = s1 * s2 * 0.1;
   let toxinProduction1 = s1 * 0.005;
   let toxinProduction2 = s2 * 0.003;
   let toxinDamage = toxin * 0.02;
 
-  resource += 0.001 - food1 - food2 + lapResource * 0.1;
+  resourceLevel += 0.001 - food1 - food2 + lapResource * 0.1;
   s1 += food1 - competition - toxinDamage + lapS1 * 0.05;
   s2 += food2 - competition - toxinDamage + lapS2 * 0.05;
   toxin += toxinProduction1 + toxinProduction2 - toxin * 0.01 + lapToxin * 0.08;
@@ -131,14 +131,14 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
   s1 = clamp(s1, 0.0, 2.0);
   s2 = clamp(s2, 0.0, 2.0);
-  resource = clamp(resource, 0.0, 2.0);
+  resourceLevel = clamp(resourceLevel, 0.0, 2.0);
   toxin = clamp(toxin, 0.0, 2.0);
 
   // Mouse nurtures
   let mouseDist = length(uv - mouse);
   let mouseDown = u.zoom_config.w;
   let mouseInfluence = smoothstep(0.1, 0.0, mouseDist) * mouseDown;
-  resource += mouseInfluence * 0.5;
+  resourceLevel += mouseInfluence * 0.5;
   toxin -= mouseInfluence * 0.3;
   toxin = max(toxin, 0.0);
 
@@ -158,12 +158,12 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   s1 = clamp(s1, 0.0, 2.0);
   s2 = clamp(s2, 0.0, 2.0);
 
-  textureStore(dataTextureA, coord, vec4<f32>(s1, s2, resource, toxin));
+  textureStore(dataTextureA, coord, vec4<f32>(s1, s2, resourceLevel, toxin));
 
   // === VISUALIZATION ===
   let colorS1 = vec3<f32>(0.0, 0.8, 1.0) * min(s1, 1.0);
   let colorS2 = vec3<f32>(1.0, 0.2, 0.6) * min(s2, 1.0);
-  let colorResource = vec3<f32>(0.2, 0.7, 0.2) * min(resource, 1.0) * 0.3;
+  let colorResource = vec3<f32>(0.2, 0.7, 0.2) * min(resourceLevel, 1.0) * 0.3;
   let colorToxin = vec3<f32>(0.3, 0.0, 0.4) * min(toxin, 1.0) * 0.5;
   var ecosystemColor = colorS1 + colorS2 + colorResource + colorToxin;
   ecosystemColor = clamp(ecosystemColor, vec3<f32>(0.0), vec3<f32>(1.0));

--- a/public/shaders/cyber-ripples-coupled.wgsl
+++ b/public/shaders/cyber-ripples-coupled.wgsl
@@ -67,13 +67,13 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let px = vec2<f32>(1.0) / resolution;
 
   // Read previous fluid state
-  let prevVel = textureSampleLevel(dataTextureC, u_sampler, uv).xy;
-  let prevDens = textureSampleLevel(dataTextureC, u_sampler, uv).a;
+  let prevVel = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0).xy;
+  let prevDens = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0).a;
 
   // Advect
   let backUV = uv - prevVel * px * 2.0;
-  let advectedVel = textureSampleLevel(dataTextureC, u_sampler, backUV).xy;
-  let advectedDens = textureSampleLevel(dataTextureC, u_sampler, backUV).a;
+  let advectedVel = textureSampleLevel(dataTextureC, u_sampler, backUV, 0.0).xy;
+  let advectedDens = textureSampleLevel(dataTextureC, u_sampler, backUV, 0.0).a;
 
   var vel = advectedVel * viscosity;
   var dens = advectedDens * viscosity;
@@ -81,7 +81,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   // Mouse force
   let toMouse = (uv - mousePos) * vec2<f32>(aspect, 1.0);
   let mDist = length(toMouse);
-  let mouseRadius = mix(0.03, 0.15, 0.5);
+  let mouseRadius = mix(0.03f, 0.15f, 0.5f);
   let influence = smoothstep(mouseRadius, 0.0, mDist);
   vel = vel + mouseVel * influence * 0.5;
 

--- a/public/shaders/cyber-scan.wgsl
+++ b/public/shaders/cyber-scan.wgsl
@@ -85,7 +85,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let g = sourceColor.g;
 
     let chromaSource = vec3<f32>(r, g, b);
-    let rgb = mix(chromaSource, scanColor, intensity * 0.5);
+    var rgb = mix(chromaSource, scanColor, intensity * 0.5);
     rgb = mix(rgb, smear, trail * 0.3);
     rgb = rgb + scanColor * intensity * 0.8 * depthColorize;
 

--- a/public/shaders/deep-workgroup-multi-effect-blend.wgsl
+++ b/public/shaders/deep-workgroup-multi-effect-blend.wgsl
@@ -82,12 +82,9 @@ fn main(
     let resX = u32(u.config.z);
     let resY = u32(u.config.w);
 
-    // Guard: discard out-of-bounds threads
-    if (gid.x >= resX || gid.y >= resY) {
-        shared_tile[lid.z][lid.y][lid.x] = vec4<f32>(0.0);
-        workgroupBarrier();
-        return;
-    }
+    // Out-of-bounds threads still participate in the workgroup barrier below
+    // (barriers must be in uniform control flow); they only skip the final store.
+    let inBounds = gid.x < resX && gid.y < resY;
 
     let time        = u.config.x;
     let uv          = (vec2<f32>(gid.xy) + 0.5) / vec2<f32>(f32(resX), f32(resY));
@@ -174,7 +171,7 @@ fn main(
     workgroupBarrier();
 
     // ── Z=0 blends all four results and writes the final pixel ───────────────
-    if (lid.z == 0u) {
+    if (lid.z == 0u && inBounds) {
         let edge_out     = shared_tile[0][lid.y][lid.x];
         let bloom_out    = shared_tile[1][lid.y][lid.x];
         let hue_out      = shared_tile[2][lid.y][lid.x];

--- a/public/shaders/digital-decay.wgsl
+++ b/public/shaders/digital-decay.wgsl
@@ -84,7 +84,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // Block grid — variable size (4 / 8 / 16 px based on rawBlock)
     let blockPx   = floor(mix(4.0, 64.0, rawBlock));
     let blockUV   = vec2<i32>(i32(floor(uv.x*resolution.x/blockPx)), i32(floor(uv.y*resolution.y/blockPx)));
-    let blockId   = f32(blockUV.x*73856093 ^ blockUV.y*19349663);
+    let blockId   = f32((blockUV.x*73856093) ^ (blockUV.y*19349663));
     let blockTime = floor(time * (2.0 + bass * 3.0) * hash11(blockId+1.0));
     let blockHash = hash21(vec2<f32>(f32(blockUV.x), f32(blockUV.y)) + blockTime);
 

--- a/public/shaders/digital-glitch-explosion.wgsl
+++ b/public/shaders/digital-glitch-explosion.wgsl
@@ -145,7 +145,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   // Bitwise corruption per channel
   if (effectiveIntensity > 0.01) {
     let pixelSeed = hash33(vec3<f32>(uv * 1000.0, time));
-    let channels = array<f32, 3>(r, g, b);
+    var channels = array<f32, 3>(r, g, b);
     for (var ch: i32 = 0; ch < 3; ch = ch + 1) {
       var byteVal = floatToByte(channels[ch]);
       let channelSeed = hash21(uv + vec2<f32>(f32(ch) * 100.0, time));

--- a/public/shaders/digital-glitch-pass2.wgsl
+++ b/public/shaders/digital-glitch-pass2.wgsl
@@ -10,9 +10,6 @@
 
 @group(0) @binding(0) var u_sampler: sampler;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
 @group(0) @binding(1) var readTexture: texture_2d<f32>;
 @group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(3) var<uniform> u: Uniforms;

--- a/public/shaders/dimension-slicer-guided.wgsl
+++ b/public/shaders/dimension-slicer-guided.wgsl
@@ -137,8 +137,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // Chromatic aberration on filtered result
     let r = textureSampleLevel(readTexture, u_sampler, warpedUV + vec2<f32>(aberration, 0.0) * inSlice, 0.0).r;
     let g = filtered.g;
-    let b = textureSampleLevel(readTexture, u_sampler, warpedUV - vec2<f32>(aberration, 0.0) * inSlice, 0.0).b;
-    finalColor = vec3<f32>(r, g, b);
+    let bChan = textureSampleLevel(readTexture, u_sampler, warpedUV - vec2<f32>(aberration, 0.0) * inSlice, 0.0).b;
+    finalColor = vec3<f32>(r, g, bChan);
 
     // Mix between guided result and original based on depth influence
     let original = textureSampleLevel(readTexture, u_sampler, warpedUV, 0.0).rgb;

--- a/public/shaders/divine-light-iridescence.wgsl
+++ b/public/shaders/divine-light-iridescence.wgsl
@@ -129,7 +129,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let finalDivine = divineColor * rayAccum * rayIntensity;
 
     let finalColor = baseSample.rgb + finalDivine;
-    let alpha = luminanceKeyAlpha(finalDivine, rayAccum * rayIntensity, u.zoom_params);
+    let alpha = luminanceKeyAlpha(finalDivine, rayAccum * rayIntensity, u.zoom_params.x);
 
     textureStore(writeTexture, vec2<i32>(gid.xy), vec4<f32>(finalColor, max(baseSample.a, alpha)));
 

--- a/public/shaders/electric-eel-storm.wgsl
+++ b/public/shaders/electric-eel-storm.wgsl
@@ -140,7 +140,7 @@ fn lightningBolt(uv: vec2<f32>, start: vec2<f32>, time: f32, seed: f32, treble: 
 
   for (var i: i32 = 0; i < segments; i = i + 1) {
     let fi = f32(i);
-    let nextPos = pos + downward * (0.06 + hash21(vec2<f32>(fi, seed)) * 0.04);
+    var nextPos = pos + downward * (0.06 + hash21(vec2<f32>(fi, seed)) * 0.04);
     nextPos.x += sin(fi * 3.0 + seed * 5.0 + time * 10.0) * 0.03 * (1.0 + treble);
 
     let arc = lightningArc(uv, pos, nextPos, time, seed + fi);

--- a/public/shaders/fractal-ice-palace.wgsl
+++ b/public/shaders/fractal-ice-palace.wgsl
@@ -76,44 +76,66 @@ fn smoothstepf32(edge0: f32, edge1: f32, x: f32) -> f32 {
 }
 
 // Recursive ice branch distance field
+struct IceBranchNode {
+  origin: vec2<f32>,
+  angle: f32,
+  len: f32,
+  width: f32,
+  depth: i32,
+};
+
+// Iterative (stack-based) binary-tree traversal — WGSL forbids recursion.
+// max() over every node is equivalent to the original recursive max().
 fn iceBranch(p: vec2<f32>, origin: vec2<f32>, angle: f32, len: f32,
-             width: f32, depth: i32, maxDepth: i32, time: f32,
+             width: f32, startDepth: i32, maxDepth: i32, time: f32,
              bass: f32, mids: f32) -> vec4<f32> {
-  if (depth >= maxDepth) {
-    return vec4<f32>(0.0);
-  }
-
-  let end = origin + vec2<f32>(cos(angle), sin(angle)) * len;
-  let d = sdSegment(p, origin, end);
-  let branchStr = smoothstepf32(width, 0.0, d);
-
-  // Shake from bass
-  let shake = sin(time * 3.0 + f32(depth) * 1.7) * bass * 0.02 * f32(depth + 1);
-
   var result = vec4<f32>(0.0);
-  if (branchStr > 0.001) {
-    // Chromatic: blue core, cyan edge, white tip
-    let core = smoothstepf32(width * 0.6, 0.0, d);
-    let edge = smoothstepf32(width, width * 0.5, d);
-    let tip = smoothstepf32(len * 0.7, len, length(p - origin));
-    let r = edge * 0.4 + tip * 0.8;
-    let g = core * 0.6 + edge * 0.9 + tip * 0.95;
-    let b = core * 1.0 + edge * 0.8 + tip * 0.9;
-    result = vec4<f32>(r, g, b, branchStr) * (0.7 + f32(maxDepth - depth) * 0.1);
-  }
+  var stack: array<IceBranchNode, 32>;
+  var sp = 0;
+  stack[0] = IceBranchNode(origin, angle, len, width, startDepth);
+  sp = 1;
 
-  // Recursive branching
-  if (depth < maxDepth - 1 && len > 0.02) {
-    let branchAngle1 = angle + 0.55 + sin(time * 0.5 + f32(depth)) * 0.1 + shake;
-    let branchAngle2 = angle - 0.55 + cos(time * 0.4 + f32(depth)) * 0.1 - shake;
-    let newLen = len * (0.62 + mids * 0.05);
-    let newWidth = width * 0.65;
-    let child1 = iceBranch(p, end, branchAngle1, newLen, newWidth,
-                           depth + 1, maxDepth, time, bass, mids);
-    let child2 = iceBranch(p, end, branchAngle2, newLen, newWidth,
-                           depth + 1, maxDepth, time, bass, mids);
-    result = max(result, child1);
-    result = max(result, child2);
+  loop {
+    if (sp <= 0) { break; }
+    sp = sp - 1;
+    let node = stack[sp];
+    let depth = node.depth;
+    if (depth >= maxDepth) { continue; }
+
+    let end = node.origin + vec2<f32>(cos(node.angle), sin(node.angle)) * node.len;
+    let d = sdSegment(p, node.origin, end);
+    let branchStr = smoothstepf32(node.width, 0.0, d);
+
+    // Shake from bass
+    let shake = sin(time * 3.0 + f32(depth) * 1.7) * bass * 0.02 * f32(depth + 1);
+
+    if (branchStr > 0.001) {
+      // Chromatic: blue core, cyan edge, white tip
+      let core = smoothstepf32(node.width * 0.6, 0.0, d);
+      let edge = smoothstepf32(node.width, node.width * 0.5, d);
+      let tip = smoothstepf32(node.len * 0.7, node.len, length(p - node.origin));
+      let r = edge * 0.4 + tip * 0.8;
+      let g = core * 0.6 + edge * 0.9 + tip * 0.95;
+      let b = core * 1.0 + edge * 0.8 + tip * 0.9;
+      let nodeColor = vec4<f32>(r, g, b, branchStr) * (0.7 + f32(maxDepth - depth) * 0.1);
+      result = max(result, nodeColor);
+    }
+
+    // Push child branches
+    if (depth < maxDepth - 1 && node.len > 0.02) {
+      let branchAngle1 = node.angle + 0.55 + sin(time * 0.5 + f32(depth)) * 0.1 + shake;
+      let branchAngle2 = node.angle - 0.55 + cos(time * 0.4 + f32(depth)) * 0.1 - shake;
+      let newLen = node.len * (0.62 + mids * 0.05);
+      let newWidth = node.width * 0.65;
+      if (sp < 31) {
+        stack[sp] = IceBranchNode(end, branchAngle1, newLen, newWidth, depth + 1);
+        sp = sp + 1;
+      }
+      if (sp < 31) {
+        stack[sp] = IceBranchNode(end, branchAngle2, newLen, newWidth, depth + 1);
+        sp = sp + 1;
+      }
+    }
   }
 
   return result;

--- a/public/shaders/fractal-noise-dissolve.wgsl
+++ b/public/shaders/fractal-noise-dissolve.wgsl
@@ -104,7 +104,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     // Edge glow from audio
     let edgeGlow = vec3<f32>(0.5 + bass * 0.3, 0.3, 0.8) * edge * bass * 0.5;
-    let finalColor = baseColor.rgb * mask + burn + edgeGlow;
+    var finalColor = baseColor.rgb * mask + burn + edgeGlow;
     finalColor = finalColor * depthFade;
     let alpha = clamp(baseColor.a * mask + edge * 0.42 + bass * 0.05, 0.04, 1.0);
     let depthOut = clamp(textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r + edge * 0.06, 0.0, 1.0);

--- a/public/shaders/gen-abyssal-chrono-coral.wgsl
+++ b/public/shaders/gen-abyssal-chrono-coral.wgsl
@@ -162,6 +162,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // === SEDIMENT DISTURBANCE (mouse click bloom events) ===
     let clickCount = u.config.y;
     let lastClickTime = u.zoom_config.x; // reuse zoom_config.x as recent click time proxy
+    let time = u.config.x;
     let sedimentDisturbance = smoothstep(0.0, 1.8, time - lastClickTime) * 0.6;
 
     var t = 0.0;

--- a/public/shaders/gen-alien-flora-ecosystem.wgsl
+++ b/public/shaders/gen-alien-flora-ecosystem.wgsl
@@ -70,21 +70,21 @@ fn rotate2D(p: vec2<f32>, angle: f32) -> vec2<f32> {
 
 // ═══ CHUNK: ecosystem state per cell (from alpha-multi-state-ecosystem.wgsl) ═══
 fn ecosystemState(cellId: vec2<f32>, time: f32, growthRate1: f32, growthRate2: f32) -> vec4<f32> {
-    // Procedural ecosystem: R=s1, G=s2, B=resource, A=toxin
+    // Procedural ecosystem: R=s1, G=s2, B=resourceLevel, A=toxin
     let n1 = hash(cellId + vec2<f32>(1.0, 2.0));
     let n2 = hash(cellId + vec2<f32>(3.0, 4.0));
     let n3 = hash(cellId + vec2<f32>(5.0, 6.0));
     
     var s1 = n1 * 0.6 + 0.1 * sin(time * growthRate1 * 2.0 + cellId.x);
     var s2 = n2 * 0.5 + 0.1 * cos(time * growthRate2 * 2.0 + cellId.y);
-    var resource = 0.4 + 0.3 * n3;
+    var resourceLevel = 0.4 + 0.3 * n3;
     var toxin = 0.05 * (s1 + s2);
     
     // Competition damping
     s1 = clamp(s1 * (1.0 - s2 * 0.3), 0.0, 1.0);
     s2 = clamp(s2 * (1.0 - s1 * 0.3), 0.0, 1.0);
     
-    return vec4<f32>(s1, s2, resource, toxin);
+    return vec4<f32>(s1, s2, resourceLevel, toxin);
 }
 
 fn calculateThickness(d: f32, normal: vec3<f32>, p: vec3<f32>) -> f32 {
@@ -213,6 +213,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     var color = vec3<f32>(0.0);
     var alpha = 1.0;
+    var lifeForceOut = 0.0;
     let fogColor = vec3<f32>(0.02, 0.05, 0.1);
     let lightDir = normalize(vec3<f32>(0.5, 0.8, -0.5));
 
@@ -231,7 +232,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         let cellId = floor(p.xz / density);
         let eco = ecosystemState(cellId, u.config.x, growthRate1, growthRate2);
 
-        // Mouse nurturing: add resource near mouse world position
+        // Mouse nurturing: add resourceLevel near mouse world position
         let mouseWorldX = (u.zoom_config.y - 0.5) * 40.0;
         let mouseWorldZ = (u.zoom_config.z - 0.5) * 40.0 + time * 10.0;
         let mouseWorld = vec2<f32>(mouseWorldX, mouseWorldZ);
@@ -248,12 +249,12 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
         var s1 = eco.r + mouseNurture * 0.3;
         var s2 = eco.g + mouseNurture * 0.2;
-        var resource = eco.b + mouseNurture * 0.2;
+        var resourceLevel = eco.b + mouseNurture * 0.2;
 
         // Seasonal modulation
         s1 *= (1.0 - seasonHarsh * 0.3);
         s2 *= (1.0 - seasonHarsh * 0.25);
-        resource += seasonBloom * 0.4;
+        resourceLevel += seasonBloom * 0.4;
         s1 += seasonVolatile * 0.15;  // Treble causes more chaotic species mixing
 
         s1 = clamp(s1, 0.0, 1.0);
@@ -275,8 +276,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
             let glow = u.zoom_params.z;
             baseColor = baseColor * glow;
         } else if (mat == 1.0) {
-            // Terrain tinted by resource level
-            baseColor = mix(vec3<f32>(0.08, 0.15, 0.08), vec3<f32>(0.15, 0.35, 0.15), resource);
+            // Terrain tinted by resourceLevel level
+            baseColor = mix(vec3<f32>(0.08, 0.15, 0.08), vec3<f32>(0.15, 0.35, 0.15), resourceLevel);
             // Toxin purple tint
             baseColor = mix(baseColor, vec3<f32>(0.3, 0.0, 0.4), eco.a * 0.3);
         }
@@ -293,6 +294,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         let fogAmount = 1.0 - exp(-t * 0.05);
         color = mix(color, fogColor, fogAmount);
         alpha = calculateOrganicAlpha(mat, thickness, n, lightDir);
+        lifeForceOut = (s1 + s2) * 0.4 + seasonBloom * 0.3;
         if (mat == 2.0 && u.zoom_params.z > 0.7) {
             alpha = mix(alpha, 0.75, 0.3);
         }
@@ -302,7 +304,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     }
 
     // Grok upgrade: Better alpha for compositing + seasonal life force
-    let lifeForce = (s1 + s2) * 0.4 + seasonBloom * 0.3;
+    let lifeForce = lifeForceOut;
     let finalAlpha = clamp(alpha * (0.8 + lifeForce), 0.0, 1.1);
     let a = clamp(finalAlpha, 0.0, 1.0);
     textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(color * a, a));

--- a/public/shaders/gen-alpha-aurora.wgsl
+++ b/public/shaders/gen-alpha-aurora.wgsl
@@ -155,6 +155,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let mids = plasmaBuffer[0].y;
   let treble = plasmaBuffer[0].z;
   let rms = plasmaBuffer[0].w;
+  let audio = vec3<f32>(bass, mids, treble);
 
   // Parameters
   let bandSpeed = mix(0.1, 0.8, u.zoom_params.x);

--- a/public/shaders/gen-astro-kinetic-chrono-orrery.wgsl
+++ b/public/shaders/gen-astro-kinetic-chrono-orrery.wgsl
@@ -9,9 +9,6 @@
 // ═══════════════════════════════════════════════════════════════════
 @group(0) @binding(0) var u_sampler: sampler;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
 @group(0) @binding(1) var readTexture: texture_2d<f32>;
 @group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(3) var<uniform> u: Uniforms;

--- a/public/shaders/gen-auroral-ferrofluid-monolith.wgsl
+++ b/public/shaders/gen-auroral-ferrofluid-monolith.wgsl
@@ -159,6 +159,8 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     if (fragCoord.x >= res.x || fragCoord.y >= res.y) { return; }
 
     let uv = (fragCoord - 0.5 * res) / res.y;
+    let bass = plasmaBuffer[0].x;
+    let treble = plasmaBuffer[0].z;
 
     // Camera
     let ro = vec3<f32>(0.0, 0.0, 8.0);

--- a/public/shaders/gen-bifurcation-diagram.wgsl
+++ b/public/shaders/gen-bifurcation-diagram.wgsl
@@ -185,11 +185,11 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         col = col * audioBoost;
         
         // Treble adds fine spectral detail / shimmer
-        let shimmer = sin(density * 40.0 + time * 5.0) * treble * 0.15;
+        let shimmer = sin(density * 40.0 + t * 5.0) * treble * 0.15;
         col += vec3<f32>(0.1, 0.15, 0.2) * max(shimmer, 0.0);
     } else {
         // Background with subtle audio-reactive nebula
-        let nebula = sin(uv.y * 8.0 + time * 0.3) * 0.02;
+        let nebula = sin(uv.y * 8.0 + t * 0.3) * 0.02;
         col = vec3<f32>(0.015 + nebula * bass, 0.018, 0.025 + nebula * treble * 0.5);
     }
     

--- a/public/shaders/gen-bioluminescent-abyss.wgsl
+++ b/public/shaders/gen-bioluminescent-abyss.wgsl
@@ -299,11 +299,13 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     var alpha = 1.0;
     let fogColor = vec3<f32>(0.0, 0.02, 0.05);
     let lightDir = normalize(vec3<f32>(0.2, 1.0, 0.2));
-    let bass = plasmaBuffer[0].x;
 
     if (t < 100.0) {
         var p = ro + rd * t;
         let n = calcNormal(p);
+
+        // Grok upgrade: mouse as submarine spotlight (hoisted for whole hit block)
+        let mouseSpot = smoothstep(0.4, 0.05, length(p.xz - vec2<f32>(mouse.x*10.0 - 5.0, mouse.y*8.0 - 4.0))) * u.zoom_config.w;
 
         let diff = max(dot(n, lightDir), 0.0);
 
@@ -329,7 +331,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
             isGlowing = true;
             
             // Grok upgrade: Audio seasons + mouse as submarine spotlight
-            let mouseSpot = smoothstep(0.4, 0.05, length(p.xz - vec2<f32>(mouse.x*10.0 - 5.0, mouse.y*8.0 - 4.0))) * u.zoom_config.w;
             let seasonGlow = seasonBloom * 0.6 + seasonVolatile * 0.9;
             glowIntensity = u.zoom_params.z * (0.7 + seasonGlow + mouseSpot * 1.8 + bass * 0.25);
             

--- a/public/shaders/gen-celestial-prism-orchid.wgsl
+++ b/public/shaders/gen-celestial-prism-orchid.wgsl
@@ -94,6 +94,9 @@ fn sdCapsule(p: vec3<f32>, a: vec3<f32>, b: vec3<f32>, r: f32) -> f32 {
 var<private> g_time: f32;
 var<private> g_mouse: vec2<f32>;
 var<private> g_audio: f32;
+var<private> g_bloomDensity: f32;
+var<private> g_pollinator: f32;
+var<private> g_windVec: vec2<f32>;
 
 // Map function with KIFS and organic distortion
 fn map(p: vec3<f32>) -> vec2<f32> {
@@ -133,13 +136,15 @@ fn map(p: vec3<f32>) -> vec2<f32> {
 
     // Audio-Reactive + Seasonal Blooming (deep flourish)
     // bass + season drive heavy petal flare; pollinator wind adds directional bias
-    let bloom = (g_audio * 0.5 + (bloomDensity - 1.0) * 0.3) * (1.0 + pollinator * 0.4);
+    let bloom = (g_audio * 0.5 + (g_bloomDensity - 1.0) * 0.3) * (1.0 + g_pollinator * 0.4);
     let scale = 1.0 + bloom;
     pos /= scale;
 
     // Pollinator wind gust applies subtle directional warp to petals (visceral mouse "touch")
-    pos.xy += windVec * 0.8 * (1.0 + sin(g_time * 2.3) * 0.2);
-    pos.z += windVec.y * 0.4;
+    let windGust = 0.8 * (1.0 + sin(g_time * 2.3) * 0.2);
+    pos.x += g_windVec.x * windGust;
+    pos.y += g_windVec.y * windGust;
+    pos.z += g_windVec.y * 0.4;
 
     // Refractive Petal KIFS
     // Procedurally generates endless overlapping crystalline petals
@@ -261,6 +266,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     // Seasonal climate: 0=harsh winter (sparse), 0.5=bloom spring, 1.0=volatile summer storm
     let season = fract(g_time * 0.03 + bass * 0.4);
     let bloomDensity = mix(0.6, 1.4, smoothstep(0.2, 0.8, season) + bass * 0.6);
+    g_bloomDensity = bloomDensity;
     let colorWarmth = mids * 0.6 + (1.0 - season) * 0.3;
     let shimmer = treble * (0.8 + 0.4 * sin(g_time * 14.0));
 
@@ -274,7 +280,9 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let mouseDir = normalize(g_mouse - vec2<f32>(0.0));
     let mouseDist = length(g_mouse);
     let pollinator = smoothstep(0.8, 0.1, mouseDist) * (0.5 + bass * 0.5); // strong when mouse near center + bass
+    g_pollinator = pollinator;
     let windVec = mouseDir * pollinator * (0.8 + treble * 0.6); // directional gust toward/away from mouse
+    g_windVec = windVec;
 
     // Setup camera
     var ro = vec3<f32>(0.0, 0.0, -8.0 + g_time * 0.2);
@@ -347,11 +355,11 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
             let dispersion = vec3<f32>(spec_r, spec_g, spec_b);
 
             // Visual flourish: Richer prismatic dispersion + seasonal audio-reactive iridescence + shimmer
-            let dynamicIri = iridescence * (1.0 + colorWarmth * 0.5) * (1.0 + sin(time * 3.0 + dist_to_core) * shimmer * 0.6);
+            let dist_to_core = length(p);
+            let dynamicIri = iridescence * (1.0 + colorWarmth * 0.5) * (1.0 + sin(g_time * 3.0 + dist_to_core) * shimmer * 0.6);
             col = dynamicIri * fresnel + dispersion * (1.3 + bass * 0.9 + pollinator * 0.4);
 
             // Blend in some core illumination based on distance
-            let dist_to_core = length(p);
             let core_illum = vec3<f32>(1.0, 0.6, 0.2) * (1.0 / (1.0 + dist_to_core * dist_to_core)) * coreIntensity;
             col += core_illum * (0.5 + bass * 0.4 + shimmer * 0.3);
         }

--- a/public/shaders/gen-chromatic-acid-drip.wgsl
+++ b/public/shaders/gen-chromatic-acid-drip.wgsl
@@ -179,7 +179,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     let mouseUV = vec2<f32>((mousePos.x / res.x - 0.5) * aspect, mousePos.y / res.y - 0.5);
     let mouseDist = length(scaledUV - mouseUV);
-    let mouseAttraction = mouseDown > 0.5 ? exp(-mouseDist * 6.0) * 2.0 : 0.0;
+    let mouseAttraction = select(0.0, exp(-mouseDist * 6.0) * 2.0, mouseDown > 0.5);
 
     var field = metaballField(scaledUV * (0.8 + scale), t);
     field += mouseAttraction * 3.0;

--- a/public/shaders/gen-cosmic-web-filament.wgsl
+++ b/public/shaders/gen-cosmic-web-filament.wgsl
@@ -124,6 +124,8 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
   var uv = (vec2<f32>(id.xy) / res - 0.5) * vec2<f32>(res.x / res.y, 1.0) * u.zoom_config.z;
   var mouse = u.zoom_config.yz;
   let bass = plasmaBuffer[0].x;
+  let mids = plasmaBuffer[0].y;
+  let treble = plasmaBuffer[0].z;
   let warpStrength = u.zoom_params.x * 3.0 + bass * 0.5;
   let densityParam = u.zoom_params.y * 3.5 + 0.5;
   let speed = u.zoom_params.z * 2.0;

--- a/public/shaders/gen-electric-kaleidoscope-storm.wgsl
+++ b/public/shaders/gen-electric-kaleidoscope-storm.wgsl
@@ -96,6 +96,8 @@ fn lightningBolt(
 }
 
 // Recursive branching bolt
+// Iterative (loop-based) single-chain expansion — WGSL forbids recursion.
+// Original chained intensity as bolt_k * 0.6^k; color accumulated unweighted.
 fn branchingBolt(
     uv: vec2<f32>,
     start: vec2<f32>,
@@ -106,41 +108,51 @@ fn branchingBolt(
     depth: i32,
     color: ptr<function, vec3<f32>>
 ) -> f32 {
-    let end = start + vec2<f32>(cos(angle), sin(angle)) * len;
-    let bolt = lightningBolt(uv, start, end, seed, time);
-    
-    // Bolt color intensity
-    let flicker = hash1(seed * 7.0 + time * 20.0);
-    let branchCol = vec3<f32>(
-        0.3 + flicker * 0.7,
-        0.7 + flicker * 0.3,
-        1.0
-    );
-    
-    if (flicker > 0.3) {
-        *color += branchCol * bolt * (0.5 + 0.5 * flicker);
-    }
-    
-    var intensity = bolt;
-    
-    // Branch
-    if (depth > 0) {
-        let branchSeed = seed + 100.0;
-        let branchFlicker = hash1(branchSeed + time * 15.0);
-        
-        if (branchFlicker > 0.5) {
-            let midPoint = (start + end) * 0.5;
-            let branchAngle = angle + (hash1(branchSeed) - 0.5) * 1.2;
-            let branchLen = len * (0.4 + hash1(branchSeed * 3.0) * 0.3);
-            
-            intensity += branchingBolt(
-                uv, midPoint, branchAngle, branchLen,
-                branchSeed, time, depth - 1, color
-            ) * 0.6;
+    var curStart = start;
+    var curAngle = angle;
+    var curLen = len;
+    var curSeed = seed;
+    var curDepth = depth;
+    var weight = 1.0;
+    var totalIntensity = 0.0;
+
+    loop {
+        let end = curStart + vec2<f32>(cos(curAngle), sin(curAngle)) * curLen;
+        let bolt = lightningBolt(uv, curStart, end, curSeed, time);
+
+        // Bolt color intensity
+        let flicker = hash1(curSeed * 7.0 + time * 20.0);
+        let branchCol = vec3<f32>(
+            0.3 + flicker * 0.7,
+            0.7 + flicker * 0.3,
+            1.0
+        );
+
+        if (flicker > 0.3) {
+            *color += branchCol * bolt * (0.5 + 0.5 * flicker);
         }
+
+        totalIntensity += bolt * weight;
+
+        // Branch (single chain)
+        if (curDepth <= 0) { break; }
+        let branchSeed = curSeed + 100.0;
+        let branchFlicker = hash1(branchSeed + time * 15.0);
+        if (branchFlicker <= 0.5) { break; }
+
+        let midPoint = (curStart + end) * 0.5;
+        let branchAngle = curAngle + (hash1(branchSeed) - 0.5) * 1.2;
+        let branchLen = curLen * (0.4 + hash1(branchSeed * 3.0) * 0.3);
+
+        curStart = midPoint;
+        curAngle = branchAngle;
+        curLen = branchLen;
+        curSeed = branchSeed;
+        curDepth = curDepth - 1;
+        weight = weight * 0.6;
     }
-    
-    return intensity;
+
+    return totalIntensity;
 }
 
 // Kaleidoscope sector folding

--- a/public/shaders/gen-erosion-strata.wgsl
+++ b/public/shaders/gen-erosion-strata.wgsl
@@ -118,7 +118,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   col = mix(col, vec3<f32>(0.15, 0.12, 0.08), erAmt * 0.5);
   col += vec3<f32>(0.6, 0.55, 0.4) * vein;
   col += vec3<f32>(0.2, 0.35, 0.5) * sss;
-  col += vec3<f32>(1.0, 0.95, 0.8) * h12(gid.xy + fract(t * 10.0)) * treble * vein * 3.0;
+  col += vec3<f32>(1.0, 0.95, 0.8) * h12(vec2<f32>(gid.xy) + fract(t * 10.0)) * treble * vein * 3.0;
   col *= mix(1.0, 0.6, wet);
   col += vec3<f32>(0.05, 0.08, 0.12) * wet;
   let striation = sin(lf * freq * 18.84956 + li * 2.0) * 0.5 + 0.5;

--- a/public/shaders/gen-holographic-rainbow-surface.wgsl
+++ b/public/shaders/gen-holographic-rainbow-surface.wgsl
@@ -161,7 +161,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let fresnel = pow(1.0 - max(dot(normal, viewDir), 0.0), 3.0);
     let edgeColor = holographicColor(fresnel * 2.0, time * 0.2 + colorShift);
 
-    let mouseEffect = mouseDown > 0.5 ? 1.0 : 0.0;
+    let mouseEffect = select(0.0, 1.0, mouseDown > 0.5);
     let mouseUV = vec2<f32>(mousePos.x / res.x * aspect - (aspect - 1.0) * 0.5, mousePos.y / res.y);
     let mouseDist = length(centeredUV - mouseUV);
     let mouseWave = sin(mouseDist * 25.0 - time * 6.0) * exp(-mouseDist * 8.0) * mouseEffect;

--- a/public/shaders/gen-lichtenberg-storm.wgsl
+++ b/public/shaders/gen-lichtenberg-storm.wgsl
@@ -118,7 +118,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   col += vec3<f32>(0.224, 1.0, 0.078) * hot * (1.0 + bass);
   col += vec3<f32>(1.0) * energy * energy * 2.0 * glow;
   col += vec3<f32>(0.0, 1.0, 1.0) * smoothstep(0.15, 0.0, energy) * 0.3 * glow;
-  col += vec3<f32>(1.0) * h12(gid.xy + fract(t * 20.0)) * treble * hot * 4.0;
+  col += vec3<f32>(1.0) * h12(vec2<f32>(gid.xy) + fract(t * 20.0)) * treble * hot * 4.0;
   let tipBloom = hot * (1.0 + bass * 0.5 + treble * 0.8);
   col += vec3<f32>(0.8, 0.9, 1.0) * tipBloom * glow;
   let decayCol = mix(vec3<f32>(0.2, 0.0, 0.4), vec3<f32>(0.0, 0.6, 0.3), prev);

--- a/public/shaders/gen-multi-scale-evolutionary-cellular-gardens.wgsl
+++ b/public/shaders/gen-multi-scale-evolutionary-cellular-gardens.wgsl
@@ -67,7 +67,7 @@ fn smoothNoise(p: vec2<f32>) -> f32 {
 // Returns growth impulse for a species given its neighbourhood average
 // and the current "genetic" ruleset encoded in rulePhase
 fn growthKernel(selfDensity: f32, neighborAvg: f32, rulePhase: f32,
-                resource: f32, fertility: f32) -> f32 {
+                resourceLevel: f32, fertility: f32) -> f32 {
     // Evolving activation threshold (shifts with rulePhase)
     let activateThreshold = 0.15 + rulePhase * 0.3;
     let inhibitThreshold = 0.7 - rulePhase * 0.15;
@@ -76,8 +76,8 @@ fn growthKernel(selfDensity: f32, neighborAvg: f32, rulePhase: f32,
     let activation = smoothstep(activateThreshold - 0.05, activateThreshold + 0.05, neighborAvg);
     let inhibition = smoothstep(inhibitThreshold, inhibitThreshold + 0.15, neighborAvg);
 
-    let growthImpulse = activation * (1.0 - inhibition) * resource * fertility;
-    let decayRate = 0.02 + (1.0 - resource) * 0.03;
+    let growthImpulse = activation * (1.0 - inhibition) * resourceLevel * fertility;
+    let decayRate = 0.02 + (1.0 - resourceLevel) * 0.03;
 
     return growthImpulse - selfDensity * decayRate;
 }
@@ -97,7 +97,7 @@ fn sampleNeighbourhood(uv: vec2<f32>, ps: vec2<f32>, scale: f32) -> vec4<f32> {
 }
 
 // ─── Species coloring ─────────────────────────────────────────────
-fn speciesColor(s1: f32, s2: f32, s3: f32, resource: f32,
+fn speciesColor(s1: f32, s2: f32, s3: f32, resourceLevel: f32,
                 rulePhase: f32, t: f32) -> vec3<f32> {
     // Species 1: green-teal coral growth
     let c1 = vec3<f32>(0.1, 0.7, 0.5) * s1;
@@ -106,7 +106,7 @@ fn speciesColor(s1: f32, s2: f32, s3: f32, resource: f32,
     // Species 3: golden-amber crystalline lichen
     let c3 = vec3<f32>(0.8, 0.6, 0.1) * s3;
     // Resource substrate glow
-    let rCol = vec3<f32>(0.15, 0.25, 0.15) * resource * 0.5;
+    let rCol = vec3<f32>(0.15, 0.25, 0.15) * resourceLevel * 0.5;
 
     // Iridescent shift based on rule evolution
     let shift = sin(rulePhase * TAU + t * 0.3) * 0.15;
@@ -147,7 +147,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let s1 = state.r;       // Species 1 density
     let s2 = state.g;       // Species 2 density
     let s3 = state.b;       // Species 3 density
-    let resource = state.a; // Local resource level
+    let resourceLevel = state.a; // Local resourceLevel level
 
     // Evolving rule phase — slowly drifts with time and audio mutation pressure
     // This makes the CA rules themselves change over the life of the system
@@ -168,9 +168,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let avgRes = nearNeighbours.a * nearWeight + farNeighbours.a * farWeight;
 
     // Apply evolving growth kernels per species
-    let grow1 = growthKernel(s1, avgS1, rulePhase, resource, fertility);
-    let grow2 = growthKernel(s2, avgS2, rulePhase2, resource, fertility * 0.9);
-    let grow3 = growthKernel(s3, avgS3, rulePhase3, resource, fertility * 0.85) * diversity;
+    let grow1 = growthKernel(s1, avgS1, rulePhase, resourceLevel, fertility);
+    let grow2 = growthKernel(s2, avgS2, rulePhase2, resourceLevel, fertility * 0.9);
+    let grow3 = growthKernel(s3, avgS3, rulePhase3, resourceLevel, fertility * 0.85) * diversity;
 
     // Inter-species competition
     let comp12 = s1 * s2 * competition;
@@ -190,7 +190,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // Resource dynamics: slowly regenerates, consumed by all species
     let totalConsumption = (newS1 + newS2 + newS3) * 0.012;
     let regeneration = 0.015 * fertility + avgRes * 0.01;
-    var newRes = resource + regeneration - totalConsumption;
+    var newRes = resourceLevel + regeneration - totalConsumption;
 
     // Mouse interaction: seeds invasive burst or creates protected zone
     if (mouseInfluence > 0.01) {

--- a/public/shaders/gen-neon-acid-geometry.wgsl
+++ b/public/shaders/gen-neon-acid-geometry.wgsl
@@ -124,7 +124,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let mouseDown = u.zoom_config.w;
     let mouseNorm = (mouse - resolution * 0.5) / min(resolution.x, resolution.y);
 
-    let audioIntensity = u.zoom_params.x;
+    var audioIntensity = u.zoom_params.x;
     let speed = u.zoom_params.y;
     let scale = u.zoom_params.z;
     let colorShift = u.zoom_params.w;
@@ -135,7 +135,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let treble = plasmaBuffer[0].z;
 
     let audioSpeed = speed * (0.8 + bass * 0.7);
-    let audioIntensity = audioIntensity * (0.85 + treble * 0.6);
+    audioIntensity = audioIntensity * (0.85 + treble * 0.6);
     let audioColor = colorShift + mids * 0.25;
 
     var col = vec3<f32>(0.0);

--- a/public/shaders/gen-neon-tropical-paradise.wgsl
+++ b/public/shaders/gen-neon-tropical-paradise.wgsl
@@ -217,7 +217,7 @@ fn bioWater(uv: vec2<f32>, time: f32, mouseNorm: vec2<f32>, mouseDown: f32, inte
   let nearSurface = smoothstep(0.04, 0.0, abs(uv.y - surfaceLine));
   
   // Bioluminescent sparkles
-  let sparkle = pow(noise2d(vec2<f32>(uv.x * 50.0 * scale, uv.y * 30.0 - time * 0.5)), 8.0);
+  var sparkle = pow(noise2d(vec2<f32>(uv.x * 50.0 * scale, uv.y * 30.0 - time * 0.5)), 8.0);
   sparkle += pow(noise2d(vec2<f32>(uv.x * 80.0 * scale + 100.0, uv.y * 50.0 + time * 0.3)), 10.0) * 0.5;
   
   // Mouse ripple

--- a/public/shaders/gen-neon-tropical-paradise.wgsl
+++ b/public/shaders/gen-neon-tropical-paradise.wgsl
@@ -33,6 +33,7 @@ struct Uniforms {
 };
 
 const PI: f32 = 3.14159265;
+const TAU: f32 = 6.28318530718;
 
 // ---- NOISE FUNCTIONS ----
 fn hash2(p: vec2<f32>) -> vec2<f32> {
@@ -172,7 +173,7 @@ fn neonFlower(uv: vec2<f32>, center: vec2<f32>, time: f32, petals: i32, scale: f
   let a = atan2(d.y, d.x);
   
   let petalShape = abs(sin(a * f32(petals) * 0.5)) * scale;
-  let flower = smoothstep(petalShape + 0.02, petalShape * 0.5, r) * step(0.0, r);
+  var flower = smoothstep(petalShape + 0.02, petalShape * 0.5, r) * step(0.0, r);
   flower = max(flower, smoothstep(0.04 * scale, 0.01, r));
   
   let flowerHue = time * 0.1 + center.x * 3.0;

--- a/public/shaders/gen-prismatic-ion-cascade.wgsl
+++ b/public/shaders/gen-prismatic-ion-cascade.wgsl
@@ -119,7 +119,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     let sparkleSeed = hash21(floor(uv * resolution * 0.5) + floor(time * 8.0));
     let sparkle = step(0.985, sparkleSeed) * bandMask * treble * 1.5;
-    let finalRGB = clamp(composed + vec3<f32>(sparkle), vec3<f32>(0.0), vec3<f32>(4.0));
+    var finalRGB = clamp(composed + vec3<f32>(sparkle), vec3<f32>(0.0), vec3<f32>(4.0));
 
     // Depth-scaled ion intensity
     let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;

--- a/public/shaders/gen-prismatic-void-weaver-ouroboros.wgsl
+++ b/public/shaders/gen-prismatic-void-weaver-ouroboros.wgsl
@@ -175,8 +175,8 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
         // Lighting
         let diff = max(dot(n, l), 0.0);
         let viewDir = normalize(ro - p);
-        let ref = reflect(-l, n);
-        let spec = pow(max(dot(viewDir, ref), 0.0), 32.0);
+        let refl = reflect(-l, n);
+        let spec = pow(max(dot(viewDir, refl), 0.0), 32.0);
 
         // Chromatic dispersion color
         let matCol = vec3<f32>(

--- a/public/shaders/gen-superfluid-quantum-foam.wgsl
+++ b/public/shaders/gen-superfluid-quantum-foam.wgsl
@@ -35,7 +35,7 @@ fn hash13(p3: vec3<f32>) -> f32 {
 fn hash33(p3: vec3<f32>) -> vec3<f32> {
   var p = fract(p3 * vec3(0.1031, 0.1030, 0.0973));
   p += dot(p, p.yxz + 33.33);
-  return fract((p.xxy + p.yyxx) * p.zyx);
+  return fract((p.xxy + p.yxx) * p.zyx);
 }
 
 fn curlNoise(p: vec3<f32>) -> vec3<f32> {

--- a/public/shaders/gen-supernova-remnant.wgsl
+++ b/public/shaders/gen-supernova-remnant.wgsl
@@ -130,14 +130,14 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let chaos = mix(0.1, 0.8, u.zoom_params.z) * (1.0 + mids * 0.6);  // Mids increase turbulence
     let gasOpacity = u.zoom_params.w;
 
+    // Aspect correction
+    let aspect = resolution.x / resolution.y;
+    let p = (uv - 0.5) * vec2<f32>(aspect, 1.0);
+
     // Mouse as external gravitational mass (pulls/pushes the expanding shells)
     let mousePos = (u.zoom_config.yz - 0.5) * 2.0;
     let mouseInfluence = u.zoom_config.w;
     let gravPull = (p - vec2<f32>(mousePos.x, mousePos.y)) * mouseInfluence * 0.25;
-    
-    // Aspect correction
-    let aspect = resolution.x / resolution.y;
-    let p = (uv - 0.5) * vec2<f32>(aspect, 1.0);
     
     // Apply turbulence displacement + gravitational mouse perturbation
     let turb = turbulence(p + 0.5, t, chaos);

--- a/public/shaders/infinite-fractal-feedback-hdr.wgsl
+++ b/public/shaders/infinite-fractal-feedback-hdr.wgsl
@@ -140,7 +140,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     }
     bloom *= bloomIntensity;
 
-    let hdrColor = finalColor + bloom;
+    var hdrColor = finalColor + bloom;
 
     // Mouse bloom boost
     let mouseDist = length(uv - mousePos);

--- a/public/shaders/interactive-fresnel.wgsl
+++ b/public/shaders/interactive-fresnel.wgsl
@@ -62,7 +62,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let viewDir = select(vec2<f32>(0.0), diff / max(lenD, 0.0001), lenD > 0.0001);
 
     let numRings = max(1.0, ringCount * bass_env(bass, mids));
-    let totalShift = vec2<f32>(0.0);
+    var totalShift = vec2<f32>(0.0);
 
     for (var i = 0.0; i < 5.0; i = i + 1.0) {
         let ringIdx = i;

--- a/public/shaders/interactive-glitch-cubes.wgsl
+++ b/public/shaders/interactive-glitch-cubes.wgsl
@@ -28,6 +28,10 @@ struct Uniforms {
   ripples: array<vec4<f32>, 50>,
 };
 
+fn hash(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453123);
+}
+
 @compute @workgroup_size(16, 16, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let resolution = u.config.zw;
@@ -106,7 +110,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let prev = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0);
     let prevHeight = prev.b;
     let settledHeight = mix(height, prevHeight * 0.92, 0.05 + mids * 0.02);
-    let settledColor = mix(color, prev.rgb * 0.9, 0.03 + bass * 0.01);
+    var settledColor = mix(color, prev.rgb * 0.9, 0.03 + bass * 0.01);
 
     // Audio sparkle on cube faces
     if (isFace) {
@@ -118,6 +122,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let depthAlpha = mix(alpha, 1.0, depth * 0.3);
 
     textureStore(writeTexture, vec2<i32>(global_id.xy), vec4<f32>(settledColor, depthAlpha));
-    textureStore(dataTextureA, vec2<i32>(global_id.xy), vec4<f32>(settledColor, settledHeight, depthAlpha, 1.0));
+    textureStore(dataTextureA, vec2<i32>(global_id.xy), vec4<f32>(settledColor, settledHeight));
     textureStore(writeDepthTexture, vec2<i32>(global_id.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
 }

--- a/public/shaders/lighthouse-reveal.wgsl
+++ b/public/shaders/lighthouse-reveal.wgsl
@@ -8,9 +8,6 @@
 
 @group(0) @binding(0) var u_sampler: sampler;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
 @group(0) @binding(1) var readTexture: texture_2d<f32>;
 @group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(3) var<uniform> u: Uniforms;

--- a/public/shaders/liquid-tensor-vortex.wgsl
+++ b/public/shaders/liquid-tensor-vortex.wgsl
@@ -31,7 +31,7 @@ struct Uniforms {
 fn hash2(p: vec2<f32>) -> vec2<f32> {
   var pp = fract(p * vec2(0.1031, 0.1030));
   pp += dot(pp, pp.yx + 33.33);
-  return fract((pp.xxy + pp.yyxx) * pp.yx);
+  return fract((pp.xy + pp.yx) * pp.yx);
 }
 
 fn vnoise(p: vec2<f32>) -> f32 {

--- a/public/shaders/multi-scale-evolutionary-cellular-gardens.wgsl
+++ b/public/shaders/multi-scale-evolutionary-cellular-gardens.wgsl
@@ -53,7 +53,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let state = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0);
     let s1 = state.r;
     let s2 = state.g;
-    let resource = state.b;
+    let resourceLevel = state.b;
 
     let mutationRate = 0.3 + mids * 0.9;
     let competition = 0.2 + bass * 0.6;
@@ -73,7 +73,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
     var newS1 = s1 + (avgRes * growth1 - competition * s1 * s2);
     var newS2 = s2 + (avgRes * growth2 - competition * s1 * s2 * 0.8);
-    var newRes = resource * 0.98 + 0.01 - (newS1 + newS2) * 0.008;
+    var newRes = resourceLevel * 0.98 + 0.01 - (newS1 + newS2) * 0.008;
 
     let mouseDist = length(uv - mouse);
     let mouseNurture = smoothstep(0.2, 0.0, mouseDist) * mouseDown * 0.6;

--- a/public/shaders/neon-flashlight.wgsl
+++ b/public/shaders/neon-flashlight.wgsl
@@ -8,9 +8,6 @@
 
 @group(0) @binding(0) var u_sampler: sampler;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
 @group(0) @binding(1) var readTexture: texture_2d<f32>;
 @group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(3) var<uniform> u: Uniforms;
@@ -51,6 +48,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let uv = vec2<f32>(global_id.xy) / resolution;
     let pixelSize = 1.0 / resolution;
     let time = u.config.x;
+    let bass = plasmaBuffer[0].x;
+    let mids = plasmaBuffer[0].y;
+    let treble = plasmaBuffer[0].z;
     // ═══ AUDIO REACTIVITY ═══
     let audioOverall = u.zoom_config.x;
     let audioBass = audioOverall * 1.5;

--- a/public/shaders/neon-pulse-stream.wgsl
+++ b/public/shaders/neon-pulse-stream.wgsl
@@ -122,7 +122,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     let composite = bg * (1.0 - pulse * 0.7) + streamColor;
 
-    let sparkle = 0.0;
+    var sparkle = 0.0;
     var sparkleCol = vec3<f32>(0.0);
     if (treble > 0.4 && bgLuma > 0.5) {
       let sparkNoise = hash21(uv * 500.0 + time * 30.0);

--- a/public/shaders/neural-synapse-web.wgsl
+++ b/public/shaders/neural-synapse-web.wgsl
@@ -88,7 +88,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
       let proj = dot(p - nodePos, dir);
       let orth = abs(dot(p - nodePos, perp));
       let onLine = proj > 0.0 && proj < len;
-      let lineGlow = exp(-orth * orth * 200.0) * onLine;
+      let lineGlow = exp(-orth * orth * 200.0) * f32(onLine);
       let sigTravel = fract((proj / len) - time * pulseSpeed * 0.3);
       let signal = smoothstep(0.85, 1.0, sigTravel) + smoothstep(0.0, 0.15, sigTravel);
       synapseField = synapseField + lineGlow;

--- a/public/shaders/pixelation-drift.wgsl
+++ b/public/shaders/pixelation-drift.wgsl
@@ -76,7 +76,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let pixelatedUV = floor(driftedUV * resolution / pixelSize) * pixelSize / resolution;
 
     // Chromatic pixel separation: RGB sample at different pixel offsets
-    let chromaShift = pixelSize / resolution * treble * 0.5;
+    let chromaShift = pixelSize / resolution.x * treble * 0.5;
     let rUV = pixelatedUV + vec2<f32>(chromaShift, 0.0);
     let gUV = pixelatedUV;
     let bUV = pixelatedUV - vec2<f32>(chromaShift, 0.0);

--- a/public/shaders/reactive-glass-grid.wgsl
+++ b/public/shaders/reactive-glass-grid.wgsl
@@ -80,7 +80,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let gColor = textureSampleLevel(readTexture, u_sampler, gUV, 0.0);
     let edge = 1.0 - smoothstep(edgeSmooth, 0.5, length(localUV));
     let gridGlow = vec3<f32>(0.1 + caustic, 0.25 + treble * 0.08 + caustic * 0.5, 0.35 + caustic * 0.3) * edge * influence * glowIntensity * 1.5;
-    let finalColor = vec3<f32>(
+    var finalColor = vec3<f32>(
         textureSampleLevel(readTexture, u_sampler, rUV, 0.0).r,
         gColor.g,
         textureSampleLevel(readTexture, u_sampler, bUV, 0.0).b

--- a/public/shaders/ripple-blocks.wgsl
+++ b/public/shaders/ripple-blocks.wgsl
@@ -33,7 +33,7 @@ struct Uniforms {
 fn hash2(p: vec2<f32>) -> vec2<f32> {
   var pp = fract(p * vec2(0.1031, 0.1030));
   pp += dot(pp, pp.yx + 33.33);
-  return fract((pp.xxy + pp.yyxx) * pp.yx);
+  return fract((pp.xy + pp.yx) * pp.yx);
 }
 
 fn vnoise(p: vec2<f32>) -> f32 {

--- a/public/shaders/spec-blackbody-thermal.wgsl
+++ b/public/shaders/spec-blackbody-thermal.wgsl
@@ -97,7 +97,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let prev = textureSampleLevel(dataTextureC, u_sampler, uv, 0.0);
     let prevEmber = prev.rgb * prev.a * 15000.0;
     let emberDecay = mix(0.85, 0.98, glowAmount);
-    let persistentEmber = blackbodyColor(prevEmber * emberDecay) * thermalIntensity * glowAmount;
+    let persistentEmber = blackbodyColor(dot(prevEmber, vec3<f32>(0.299, 0.587, 0.114)) * emberDecay) * thermalIntensity * glowAmount;
     thermalColor = max(thermalColor, persistentEmber);
 
     // Glow around bright regions with audio reactivity

--- a/public/shaders/synthwave-grid-warp.wgsl
+++ b/public/shaders/synthwave-grid-warp.wgsl
@@ -22,10 +22,6 @@
 @group(0) @binding(11) var comparison_sampler: sampler_comparison;
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
-let bass = plasmaBuffer[0].x;
-let mids = plasmaBuffer[0].y;
-let treble = plasmaBuffer[0].z;
-
 struct Uniforms {
   config: vec4<f32>,
   zoom_config: vec4<f32>,
@@ -139,6 +135,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let resolution = u.config.zw;
   if (global_id.x >= u32(resolution.x) || global_id.y >= u32(resolution.y)) { return; }
   let uv = vec2<f32>(global_id.xy) / resolution;
+  let bass = plasmaBuffer[0].x;
+  let mids = plasmaBuffer[0].y;
+  let treble = plasmaBuffer[0].z;
 
   let camY = mix(0.5, 3.0, u.zoom_params.x);
   let fogDensity = mix(0.1, 2.0, u.zoom_params.y);

--- a/public/shaders/temporal-distortion-field.wgsl
+++ b/public/shaders/temporal-distortion-field.wgsl
@@ -35,7 +35,8 @@ fn hash(p: vec2<f32>) -> f32 {
     return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453);
 }
 
-fn fbmWarp(p: vec2<f32>, time: f32) -> vec2<f32> {
+fn fbmWarp(p_in: vec2<f32>, time: f32) -> vec2<f32> {
+    var p = p_in;
     var v = vec2<f32>(0.0);
     var amp = 0.5;
     var freq = 1.0;

--- a/public/shaders/tone-histogram-apply.wgsl
+++ b/public/shaders/tone-histogram-apply.wgsl
@@ -51,7 +51,7 @@ fn main(
   @builtin(local_invocation_index) lidx: u32,
 ) {
   let res = u.config.zw;
-  if (gid.x >= u32(res.x) || gid.y >= u32(res.y)) { return; }
+  let inBounds = gid.x < u32(res.x) && gid.y < u32(res.y);
 
   let uv = (vec2<f32>(gid.xy) + 0.5) / res;
   let coord = vec2<i32>(gid.xy);
@@ -109,9 +109,11 @@ fn main(
 
   let outColor = hsv2rgb(hsv);
 
-  textureStore(writeTexture, coord, vec4<f32>(outColor, 1.0));
-  textureStore(dataTextureA, coord, vec4<f32>(wgExposure / 3.5, wgMeanLuma, wgPeakBinNorm, wgSaturation));
+  if (inBounds) {
+    textureStore(writeTexture, coord, vec4<f32>(outColor, 1.0));
+    textureStore(dataTextureA, coord, vec4<f32>(wgExposure / 3.5, wgMeanLuma, wgPeakBinNorm, wgSaturation));
 
-  let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
-  textureStore(writeDepthTexture, coord, vec4<f32>(depth, 0.0, 0.0, 0.0));
+    let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+    textureStore(writeDepthTexture, coord, vec4<f32>(depth, 0.0, 0.0, 0.0));
+  }
 }

--- a/public/shaders/vhs-tracking-mouse.wgsl
+++ b/public/shaders/vhs-tracking-mouse.wgsl
@@ -82,7 +82,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // Scanline dropouts
     let dropoutNoise = rand(vec2<f32>(uv.x * 200.0, time * 10.0));
     let dropout = step(0.96 - bar_intensity * 0.1, dropoutNoise);
-    color = mix(color, vec3<f32>(0.05), dropout * in_bar);
+    color = mix(color, vec3<f32>(0.05), dropout * f32(in_bar));
 
     // Tape hiss / grain
     let n = rand(uv + vec2<f32>(time, time));

--- a/public/shaders/viscous-drag-bilateral.wgsl
+++ b/public/shaders/viscous-drag-bilateral.wgsl
@@ -137,8 +137,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
   let center = textureSampleLevel(readTexture, u_sampler, sampleUV, 0.0);
   var accumColor = vec3<f32>(0.0);
   var accumWeight = 0.0;
-  let radius = i32(ceil(finalSigma * 2.5));
-  let maxRadius = min(radius, 7);
+  let kernelRadius = i32(ceil(finalSigma * 2.5));
+  let maxRadius = min(kernelRadius, 7);
 
   for (var dy = -maxRadius; dy <= maxRadius; dy++) {
     for (var dx = -maxRadius; dx <= maxRadius; dx++) {

--- a/public/shaders/vortex-warp-coupled.wgsl
+++ b/public/shaders/vortex-warp-coupled.wgsl
@@ -148,7 +148,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
       squareDiff.x * c - squareDiff.y * s,
       squareDiff.x * s + squareDiff.y * c
     );
-    let rotatedDiff = vec2<f32>(rotatedSquareDiff.x / aspect, rotatedDiff.y);
+    let rotatedDiff = vec2<f32>(rotatedSquareDiff.x / aspect, rotatedSquareDiff.y);
     finalUV = mousePos + rotatedDiff;
   }
 


### PR DESCRIPTION
## Summary

Fixes **69 of the 76** shader errors from the latest shader-scanner export. Each fix was verified locally with the `naga` WGSL validator (installed via `cargo install naga-cli`).

The remaining 7 are intentionally **not** changed (see below).

## What was wrong & how it was fixed

Grouped by error class:

- **Module-scope `let` reading a runtime buffer** (8 shaders, e.g. `neon-flashlight`, `aero-chromatics-prismatic`, `bismuth-crystallizer`): audio-reactive `let bass = plasmaBuffer[0].x;` lines had been injected at module scope (illegal — can't read a storage buffer outside a function). Moved the reads into the function(s) that use them, or removed dead duplicates.
- **`let` reassigned (`cannot assign to 'let X'`)** (~15 shaders): changed the offending bindings to `var` (e.g. `sparkle`, `finalColor`, `clickPhase`, `rgb`, array-of-`f32` indexed writes).
- **Reserved keywords** (`target`, `resource`, `ref`): renamed to non-reserved identifiers.
- **Redeclarations** (`bass`, `b`, `radius`, `audioIntensity`): renamed/dedup'd the second declaration.
- **Unresolved identifiers** (`time`, `bass`/`mids`/`treble`, `audio`, `ndist`, `TAU`, `bloomDensity`, `windVec`, …): added the missing local reads, defined `const TAU`, or promoted main-locals to `var<private>` globals to match each shader's existing pattern. Also fixed several use-before-declaration ordering bugs.
- **Missing helper functions** (`hash`, `hash12`): added standard implementations.
- **Operator / type mismatches**: `bool * f32` → `f32(bool) * f32`; `vec2<u32> + f32` → `vec2<f32>(...)`; malformed hash swizzles producing `vec3 + vec4`; ternary `?:` (not valid WGSL) → `select(...)`.
- **Function arg type mismatches**: passed the correct scalar component (e.g. `u.zoom_params.x`, channel luminance) instead of a vector.
- **Parameter reassignment**: copied the immutable function param into a local `var`.
- **Illegal texture sampling**: `textureSampleLevel` on a write-only storage texture → read the readable `dataTextureC`; added missing `level` args.
- **Operator precedence**: added parentheses where `*` and `^` mix (Tint requires it).
- **`workgroupBarrier` in non-uniform control flow** (`tone-histogram-apply`, `deep-workgroup-multi-effect-blend`, `_template_shared_memory`): removed early `return` before the barrier so all invocations reach it uniformly; out-of-bounds threads now only skip the final store.
- **Recursion (forbidden in WGSL)**: rewrote `iceBranch` (binary tree) and `branchingBolt` (single chain) as iterative explicit-stack / loop versions that produce equivalent output.

## Not changed (intentional)

- **`test`, `test-shader-123`, `test-real-shader-456`** — 404 in the scan; these files don't exist in the repo.
- **`pp-sharpen-sg`, `rd-on-video-pass1-sg`, `slime-mold-on-video-sg`, `spec-histogram-equalize-sg`** — these `-sg` variants use `enable subgroups;` and, per their own header comments, are *designed* to fail compilation on devices without subgroup support so the renderer can probe and fall back to the base (non-`-sg`) shader. Stripping subgroups would defeat their purpose.

## Verification

All 69 fixed shaders pass `naga`. Note `naga` does not enforce two browser-only (Tint/Dawn) rules — operator-precedence parentheses and `workgroupBarrier` uniformity — so those were fixed directly from the browser's error messages using the standard correct patterns.

https://claude.ai/code/session_01FViNUTZUCuHg53Lf3rTym1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FViNUTZUCuHg53Lf3rTym1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed synchronization issues in compute shaders to ensure all threads properly participate in synchronization points.
  * Corrected bounds checking to prevent invalid texture writes while maintaining thread synchronization.
  * Fixed type casting issues in audio and mouse interaction calculations.
  * Resolved variable mutability issues in shader computations.

* **Improvements**
  * Refactored recursive shader algorithms to iterative implementations for improved performance.
  * Enhanced audio reactivity parameter organization across visual effects.
  * Updated noise and hash function characteristics for improved visual patterns.
  * Improved consistency of type handling in mathematical expressions throughout shaders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->