### PR TITLE
Pipeline hygiene: fix tsc gate + full-stack verification pass

### DIFF
--- a/src/__tests__/WASMRenderer.input.test.ts
+++ b/src/__tests__/WASMRenderer.input.test.ts
@@ -56,7 +56,7 @@ describe('WASMRenderer input sources', () => {
     jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
       drawImage: jest.fn(),
       getImageData: jest.fn().mockReturnValue({ data: fakeImageData, width: 640, height: 480 }),
-    } as unknown as CanvasRenderingContext2D);
+    } as unknown as GPUCanvasContext);
 
     for (const source of ['video', 'webcam', 'live'] as const) {
       jest.clearAllMocks();


### PR DESCRIPTION
## Summary
- Fixes the one blocking `tsc --noEmit` error: `src/__tests__/WASMRenderer.input.test.ts` cast a `getContext` mock to `CanvasRenderingContext2D`, but the WebGPU-typed overload resolves to `GPUCanvasContext` (TS2345). Changed the cast target — test-only, one line.
- Otherwise this is a verification-only pass across the local build → deploy → backend pipeline; no feature work.

## Pipeline hygiene results (pass/fail)

| Stage | Result | Notes |
|---|---|---|
| 1. Typecheck gate | ⚠️ Fixed target error, but not fully clean | Target `TS2345` resolved. Remaining errors are pre-existing and out of scope: `typescript@^4.9.5` can't parse the `const T extends ...` type-parameter syntax (TS 5.0+ feature) in `@huggingface/transformers`'s `.d.ts` (aliased as `@xenova/transformers`). `skipLibCheck` doesn't suppress it since these are parse errors, not type errors. |
| 2. Build | ✅ Pass | `npm ci` succeeded clean-room this run (no sharp/libvips proxy failure encountered). `craco build` compiled successfully; `main.js` gzipped = **2.7 MB** (known code-splitting backlog item, unchanged). `wasm_renderer/build.sh` WASM step still fails without `emcc` (pre-existing, #848) — skipped via `SKIP_WASM_BUILD=1` as directed. |
| 3. Tests | ✅ Pass | 21 suites / **178** tests passed (baseline cited was 173; count is now slightly higher, likely from tests added since that baseline — no failures). |
| 4. Deploy dry-run | ⚠️ Read-only review found a real issue | `deploy.py`'s file manifest/targets look correct (zips `build/`, skips `.git`/`node_modules`/`__pycache__`/`shaders`, posts to `storage.noahcohn.com/api/deploy/<project>/bundle` with `target_site` from `DEPLOY_TARGET` env, defaulting to `test` → `test.1ink.us`). **However, `DEPLOY_TOKEN` is a hardcoded plaintext secret committed in the file**, not read from env despite the adjacent comment suggesting `export DEPLOY_TOKEN=...`. This is a real credential in version control — flagging as a security finding, not silently noting it. |
| 5. Backend sanity | ✅ Pass | `python -m py_compile` clean on `storage_manager/app.py`, `deploy.py`, and the `scripts/storage_manager_*.py` variants. `ALLOWED_ORIGINS` in `storage_manager/app.py` still includes `https://test.1ink.us` (plus `go.1ink.us`, `noahcohn.com`, `localhost:3000`). No live VPS contact made. |
| 6. Shader sync dry-run | ✅ Pass | `npm run sync:shaders:dry`: 1180 defs found, 1157 tracked, 1142 already synced, **1 to upload** (`gen-chrono-kitsune-prism-weaver`), **37 missing local WGSL files** (orphans). Close to the last-audit figures (~39/1); no writes performed. |

## New backlog item worth adding
- **`deploy.py` has a hardcoded `DEPLOY_TOKEN` secret** committed to the repo instead of being read from env — this is a live credential in version control and should be rotated/moved to an env var read (`os.getenv("DEPLOY_TOKEN")`).

## Test plan
- [x] `npx tsc --noEmit` — target error resolved (remaining errors are pre-existing/out of scope, see table)
- [x] `SKIP_WASM_BUILD=1 npm run build` — compiles successfully
- [x] `CI=true npx react-scripts test --watchAll=false` — 21/21 suites, 178/178 tests pass
- [x] `deploy.py` reviewed, not executed
- [x] `storage_manager/app.py` + related scripts `py_compile` clean, not deployed
- [x] `npm run sync:shaders:dry` — dry-run only, no writes


---
_Generated by [Claude Code](https://claude.ai/code/session_01UUVNkrvMMgri4H8K3HT1Sh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the renderer input test to use the expected canvas context type in its mock, keeping the same image-drawing behavior while better matching runtime expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->