### PR TITLE
Fix import.meta runtime crash in production bundle

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   webpack: {
     configure: (webpackConfig) => {
@@ -8,22 +10,35 @@ module.exports = {
         },
       });
 
+      // topLevelAwait is required by transformers.js / onnxruntime-web.
+      // Do NOT set outputModule: true or importMeta: false — CRA serves classic
+      // script bundles; leaving import.meta in the output causes a runtime crash:
+      //   Uncaught SyntaxError: Cannot use 'import.meta' outside a module
       webpackConfig.experiments = {
         ...webpackConfig.experiments,
         topLevelAwait: true,
-        outputModule: true
       };
 
-      webpackConfig.module.rules.push({
-        test: /\.m?js$/,
-        parser: {
-          javascript: {
-            importMeta: false
-          }
-        }
-      });
+      webpackConfig.output = {
+        ...webpackConfig.output,
+        environment: {
+          ...(webpackConfig.output.environment || {}),
+          dynamicImport: true,
+        },
+      };
 
-      webpackConfig.ignoreWarnings = [/Failed to parse source map/, /Critical dependency: 'import.meta'/];
+      // Block Node-only backends from being bundled into the browser build.
+      webpackConfig.resolve = webpackConfig.resolve || {};
+      webpackConfig.resolve.alias = {
+        ...webpackConfig.resolve.alias,
+        'sharp$': false,
+        'onnxruntime-node$': false,
+      };
+
+      webpackConfig.ignoreWarnings = [
+        /Failed to parse source map/,
+        /Critical dependency: 'import.meta'/,
+      ];
       return webpackConfig;
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production builds crash on load with:

```
Uncaught SyntaxError: Cannot use 'import.meta' outside a module (at main.*.js:…)
```

## Root cause

`craco.config.js` had two conflicting webpack settings for `@xenova/transformers`:

1. `experiments.outputModule: true` — emits ES module syntax
2. `parser.javascript.importMeta: false` — disables webpack's `import.meta` replacement

CRA serves the bundle via a classic `<script>` tag (not `type="module"`), so any leftover `import.meta` is a hard runtime syntax error.

## Fix

- Remove `outputModule: true` and `importMeta: false`
- Keep `topLevelAwait: true` (required by onnxruntime-web)
- Enable `output.environment.dynamicImport: true` so transformers' dynamic imports still bundle
- Stub Node-only deps: `sharp$` and `onnxruntime-node$` → `false`

## Verification

- `SKIP_WASM_BUILD=1 npm run build` succeeds
- `import.meta` count in `build/static/js/main.*.js`: **0** (was 1)
- `node --check` on production bundle passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adf878b6-bf41-4757-b23b-57e9709c3e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adf878b6-bf41-4757-b23b-57e9709c3e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

