### PR TITLE
Fix transformers import.meta / __webpack_module__ production crashes

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -10,10 +10,13 @@ module.exports = {
         },
       });
 
-      // topLevelAwait is required by transformers.js / onnxruntime-web.
-      // Do NOT set outputModule: true or importMeta: false — CRA serves classic
-      // script bundles; leaving import.meta in the output causes a runtime crash:
-      //   Uncaught SyntaxError: Cannot use 'import.meta' outside a module
+      // Shim import.meta inside transformers before webpack parses the package.
+      webpackConfig.module.rules.unshift({
+        test: /\.m?js$/,
+        include: /node_modules[\\/]@xenova[\\/]transformers/,
+        use: path.resolve(__dirname, 'scripts/webpack-import-meta-shim-loader.js'),
+      });
+
       webpackConfig.experiments = {
         ...webpackConfig.experiments,
         topLevelAwait: true,
@@ -27,7 +30,6 @@ module.exports = {
         },
       };
 
-      // Block Node-only backends from being bundled into the browser build.
       webpackConfig.resolve = webpackConfig.resolve || {};
       webpackConfig.resolve.alias = {
         ...webpackConfig.resolve.alias,

--- a/scripts/webpack-import-meta-shim-loader.js
+++ b/scripts/webpack-import-meta-shim-loader.js
@@ -1,0 +1,18 @@
+/**
+ * Strip import.meta from @xenova/transformers before webpack bundles it.
+ * transformers.web.js uses import.meta.url for Node path resolution; in the
+ * browser bundle we only need a harmless stub. Without this, webpack 5 emits
+ * a mix of literal import.meta and __webpack_module__ references that crash
+ * in CRA's classic <script> bundles.
+ */
+module.exports = function importMetaShimLoader(source) {
+  const envStub = '({ NODE_ENV: "production" })';
+  const metaStub = `({ url: "", webpack: undefined, env: ${envStub} })`;
+
+  return source
+    .replace(/Object\(import\.meta\)/g, metaStub)
+    .replace(/import\.meta\.url/g, '""')
+    .replace(/import\.meta\.webpack/g, 'undefined')
+    .replace(/import\.meta\.env/g, envStub)
+    .replace(/import\.meta/g, metaStub);
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production builds crash on load with two related errors from `@xenova/transformers`:

1. `Uncaught SyntaxError: Cannot use 'import.meta' outside a module`
2. `Uncaught ReferenceError: __webpack_module__ is not defined`

## Root cause

`craco.config.js` had conflicting webpack settings for transformers.js:

- `outputModule: true` + `importMeta: false` left literal `import.meta` in classic `<script>` bundles
- Removing `outputModule` without shimming transformers left webpack's *partial* `import.meta` transform, which references `__webpack_module__` — undefined outside ES-module output

## Fix

Add `scripts/webpack-import-meta-shim-loader.js` that runs on `@xenova/transformers` **before** webpack parses it, replacing `import.meta` with a harmless browser stub.

Keep classic CRA output:
- `topLevelAwait: true` (onnxruntime-web)
- `output.environment.dynamicImport: true`
- Node-only stubs: `sharp$`, `onnxruntime-node$` → `false`
- **No** `outputModule` / **no** `importMeta: false` parser hack

## Verification

- `SKIP_WASM_BUILD=1 npm run build` succeeds
- Production `main.*.js`: `import.meta` count **0**, `__webpack_module__` count **0**
- `node --check` on bundle passes
- Unit tests: **178 passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adf878b6-bf41-4757-b23b-57e9709c3e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adf878b6-bf41-4757-b23b-57e9709c3e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

