### PR TITLE
Fix failed to fetch for July 4 fireworks shaders

### DIFF
--- a/src/renderer/WASMRenderer.ts
+++ b/src/renderer/WASMRenderer.ts
@@ -2,6 +2,7 @@ import { Renderer, RendererConfig, ShaderSlotRenderer } from './Renderer';
 import * as WasmBridge from '../wasm/wasm_bridge.js';
 import { reportError } from './ErrorHandling';
 import { InputSource } from './types';
+import { fetchShaderWgsl } from '../utils/fetchShaderWgsl';
 
 type SlotMode = 'chained' | 'parallel';
 
@@ -123,7 +124,9 @@ export class WASMRenderer implements Renderer, ShaderSlotRenderer {
    * Must be called before setActiveShader().
    */
   async loadShader(id: string, url: string): Promise<boolean> {
-    return WasmBridge.loadShaderFromURL(id, url);
+    const wgsl = await fetchShaderWgsl(id, url);
+    if (!wgsl) return false;
+    return WasmBridge.loadShader(id, wgsl);
   }
 
   /** Switch to a previously loaded shader (legacy single-shader API). */
@@ -328,7 +331,9 @@ export class WASMRenderer implements Renderer, ShaderSlotRenderer {
   }
 
   async reloadShaderFromURL(id: string, url: string): Promise<boolean> {
-    return WasmBridge.reloadShaderFromURL(id, url);
+    const wgsl = await fetchShaderWgsl(id, url);
+    if (!wgsl) return false;
+    return WasmBridge.reloadShader(id, wgsl);
   }
 
   /** Test hook: pin uniforms and render one WASM frame. */

--- a/src/renderer/WebGPURenderer.ts
+++ b/src/renderer/WebGPURenderer.ts
@@ -36,6 +36,7 @@ import { compileShader } from './ShaderCompilation';
 import { BLIT_WGSL, GENERATIVE_BLIT_WGSL, VIDEO_COPY_WGSL } from './ShaderTemplates';
 import { PHYSICAL_SLOT_LIMIT } from './slotOrchestrator';
 import { resolveShaderUrl } from '../utils/resolveShaderUrl';
+import { fetchShaderWgsl } from '../utils/fetchShaderWgsl';
 
 // ── Constants matching C++ renderer ─────────────────────────────────────────
 
@@ -760,27 +761,14 @@ export class WebGPURenderer implements Renderer, ShaderSlotRenderer {
   // ── Shader management ──────────────────────────────────────────────────────
 
   async loadShader(id: string, url: string): Promise<boolean> {
-    // Helper: fetch a URL, returning text on success or null on any failure.
-    const tryFetch = async (u: string): Promise<string | null> => {
-      try {
-        const r = await fetch(u);
-        return r.ok ? await r.text() : null;
-      } catch { return null; }
-    };
-
-    // Resolve the provided URL against the configured shader base URL.
     const resolvedUrl = resolveShaderUrl(url);
 
     // If subgroup operations are supported, probe the -sg sibling variant first.
-    // The -sg file uses `enable subgroups;` and subgroupAdd/Shuffle ops that
-    // cannot be inlined alongside non-subgroup code in the same module.
-    // We compile it under the same base ID so all downstream code (setSlotShader,
-    // pipeline cache, bind-group lookups) requires zero changes.
     if (this.supportsSubgroups && !id.endsWith('-sg') && resolvedUrl.endsWith('.wgsl')) {
       const sgUrl = resolvedUrl.replace(/\.wgsl$/, '-sg.wgsl');
-      const wgsl = await tryFetch(sgUrl) ?? await tryFetch(resolveShaderUrl(`shaders/${id}-sg.wgsl`));
-      if (wgsl) {
-        const ok = this.compileShader(id, wgsl);
+      const sgWgsl = await fetchShaderWgsl(`${id}-sg`, sgUrl);
+      if (sgWgsl) {
+        const ok = this.compileShader(id, sgWgsl);
         if (ok) {
           if (process.env.NODE_ENV !== 'production') {
             console.log(`[WebGPU] "${id}": loaded subgroup variant (-sg.wgsl)`);
@@ -788,14 +776,12 @@ export class WebGPURenderer implements Renderer, ShaderSlotRenderer {
           return true;
         }
       }
-      // -sg variant absent or failed to compile — fall through to base variant below
       if (process.env.NODE_ENV !== 'production') {
         console.log(`[WebGPU] "${id}": no -sg variant found, using base variant`);
       }
     }
 
-    // Base variant (also serves as silent fallback when -sg is absent or fails)
-    const wgsl = await tryFetch(resolvedUrl) ?? await tryFetch(resolveShaderUrl(`shaders/${id}.wgsl`));
+    const wgsl = await fetchShaderWgsl(id, url);
     if (!wgsl) return false;
     return this.compileShader(id, wgsl);
   }

--- a/src/services/shaderApi.ts
+++ b/src/services/shaderApi.ts
@@ -5,6 +5,7 @@
 
 import { STORAGE_API_URL, API_BASE_URL, SHADER_FILES_BASE_URL } from '../config/appConfig';
 import { resolveShaderUrl } from '../utils/resolveShaderUrl';
+import { fetchShaderWgsl } from '../utils/fetchShaderWgsl';
 
 const API_BASE = process.env.REACT_APP_API_BASE_URL || API_BASE_URL;
 
@@ -527,16 +528,10 @@ class ShaderApiService {
     const cached = this.cache.get(`code:${shaderId}`);
     if (cached) return cached;
 
-    try {
-      const response = await fetch(`${this.baseUrl}/api/shaders/${shaderId}/code`);
-      if (!response.ok) throw new Error('API error');
-      const { code } = await response.json() as { id: string; code: string; name?: string };
-      this.cache.set(`code:${shaderId}`, code);
-      return code;
-    } catch (error) {
-      const response = await fetch(resolveShaderUrl(`shaders/${shaderId}.wgsl`));
-      return await response.text();
-    }
+    const code = await fetchShaderWgsl(shaderId);
+    if (!code) throw new Error(`Failed to fetch shader code for ${shaderId}`);
+    this.cache.set(`code:${shaderId}`, code);
+    return code;
   }
 
   clearCache() {

--- a/src/utils/fetchShaderWgsl.test.ts
+++ b/src/utils/fetchShaderWgsl.test.ts
@@ -1,0 +1,48 @@
+import { fetchShaderWgsl } from './fetchShaderWgsl';
+
+describe('fetchShaderWgsl', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns WGSL from storage API JSON when static host 404s', async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('test.1ink.us')) {
+        return new Response('not found', { status: 404 });
+      }
+      if (url.includes('/api/shaders/gen-fireworks-nocturne/code')) {
+        return new Response(JSON.stringify({ code: '@compute fn main() {}' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('./shaders/gen-fireworks-nocturne.wgsl')) {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch;
+
+    const code = await fetchShaderWgsl(
+      'gen-fireworks-nocturne',
+      'https://test.1ink.us/image_video_effects/shaders/gen-fireworks-nocturne.wgsl'
+    );
+
+    expect(code).toBe('@compute fn main() {}');
+  });
+
+  it('prefers same-origin public shader before remote hosts', async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('./shaders/liquid.wgsl')) {
+        return new Response('@compute fn main() { /* local */ }', { status: 200 });
+      }
+      return new Response('remote', { status: 200 });
+    }) as typeof fetch;
+
+    const code = await fetchShaderWgsl('liquid', 'shaders/liquid.wgsl');
+    expect(code).toContain('local');
+  });
+});

--- a/src/utils/fetchShaderWgsl.ts
+++ b/src/utils/fetchShaderWgsl.ts
@@ -1,0 +1,56 @@
+import { STORAGE_API_URL } from '../config/appConfig';
+import { resolveShaderUrl } from './resolveShaderUrl';
+
+async function tryFetchWgsl(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      const data = await response.json() as { code?: string };
+      return typeof data.code === 'string' ? data.code : null;
+    }
+
+    const text = await response.text();
+    return text.trim().length > 0 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch WGSL source for a shader, trying several hosting locations.
+ *
+ * Order:
+ * 1. Caller-provided URL (absolute or resolved)
+ * 2. Same-origin public/shaders copy (local dev + full app deploys)
+ * 3. Static CDN base (test.1ink.us)
+ * 4. Storage manager API (/api/shaders/{id}/code)
+ */
+export async function fetchShaderWgsl(id: string, url?: string): Promise<string | null> {
+  const candidates: string[] = [
+    `./shaders/${id}.wgsl`,
+  ];
+
+  if (url) {
+    candidates.push(url);
+    if (!/^https?:\/\//i.test(url)) {
+      candidates.push(resolveShaderUrl(url));
+    }
+  } else {
+    candidates.push(resolveShaderUrl(`shaders/${id}.wgsl`));
+  }
+
+  candidates.push(`${STORAGE_API_URL}/api/shaders/${id}/code`);
+
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    const wgsl = await tryFetchWgsl(candidate);
+    if (wgsl) return wgsl;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Shader scan reported **91 failures**:
- **87×** `Failed to fetch: 404` — CDN (`test.1ink.us/shaders/`) missing files that exist locally in `public/shaders/` and/or on `storage.noahcohn.com/api/shaders/{id}/code`
- **4×** subgroup compile errors (`*-sg` variants on GPUs without `subgroups` feature)

Includes all 21 July 4 fireworks plus ~66 other recent shaders (chrono kitsune, nebula phoenix, hybrid effects, etc.).

## Root cause

`deploy_app_only.py` skips the `shaders/` directory. The app, scanner, and validator only fetched static CDN URLs — never same-origin `public/shaders` or the storage API.

## Fix

**`fetchShaderWgsl()`** fallback chain (shared utility):
1. `./shaders/{id}.wgsl` — same-origin / local dev
2. Provided URL + CDN resolution
3. `storage.noahcohn.com/api/shaders/{id}/code`

Wired through:
- `WebGPURenderer.loadShader`
- `WASMRenderer.loadShader` / `reloadShaderFromURL`
- `ShaderApi.getShaderCode`
- **`ShaderScanner`** (fixes scan 404s)
- **`ShaderValidator`**
- **`StorageService`** static fallback

**Subgroup variants:** Scanner now skips `*-sg` shaders when the GPU lacks subgroup support (expected on many devices).

## Expected scan results after fix

| Category | Count | Notes |
|---|---|---|
| Was 404, now loads | ~85 | Local `public/shaders` + storage API |
| Still missing | 2 | `test`, `test-real-shader-456` — junk entries, no WGSL anywhere |
| Skipped (-sg) | 4 | `pp-sharpen-sg`, `rd-on-video-pass1-sg`, etc. |

## Verification

- Unit tests for `fetchShaderWgsl`
- Storage API confirmed 200 for fireworks + `gen-prismatic-cyber-chrono-nebula-peacock`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adf878b6-bf41-4757-b23b-57e9709c3e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adf878b6-bf41-4757-b23b-57e9709c3e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared shader-loading flow that can retrieve WGSL code from multiple locations, improving shader loading reliability.
  * Updated renderer and shader service paths to use the new shared loading behavior.
* **Bug Fixes**
  * Shader loading now falls back more gracefully when a source location is unavailable, reducing failed load attempts.
* **Tests**
  * Added coverage for shader fetch fallback and local-vs-remote request preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->