### PR TITLE
perf(webgpu): gate per-frame feedback copies by shader usage; fix broken downscale pass

### DIFF
--- a/src/renderer/ShaderCompilation.bindingUsage.test.ts
+++ b/src/renderer/ShaderCompilation.bindingUsage.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for analyzeShaderBindings — the static analysis that lets the render
+ * loop skip dataTexA/B→C feedback copies and the history-ring copy for
+ * shaders that never touch those resources.
+ */
+
+import { analyzeShaderBindings, CONSERVATIVE_BINDING_USAGE } from './ShaderCompilation';
+
+const CANONICAL_DECLS = `
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+`;
+
+describe('analyzeShaderBindings', () => {
+  it('reports no data/history usage for a pass-through shader that only declares the bindings', () => {
+    const wgsl = `${CANONICAL_DECLS}
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let c = textureLoad(readTexture, vec2<i32>(gid.xy), 0);
+  textureStore(writeTexture, vec2<i32>(gid.xy), c);
+}`;
+    expect(analyzeShaderBindings(wgsl)).toEqual({
+      writesDataA: false,
+      writesDataB: false,
+      readsDataC: false,
+      usesHistory: false,
+    });
+  });
+
+  it('detects an A-write + C-read feedback simulation', () => {
+    const wgsl = `${CANONICAL_DECLS}
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let prev = textureLoad(dataTextureC, vec2<i32>(gid.xy), 0);
+  textureStore(dataTextureA, vec2<i32>(gid.xy), prev * 0.99);
+  textureStore(writeTexture, vec2<i32>(gid.xy), prev);
+}`;
+    const usage = analyzeShaderBindings(wgsl);
+    expect(usage.writesDataA).toBe(true);
+    expect(usage.writesDataB).toBe(false);
+    expect(usage.readsDataC).toBe(true);
+    expect(usage.usesHistory).toBe(false);
+  });
+
+  it('detects a B-only writer', () => {
+    const wgsl = `${CANONICAL_DECLS}
+fn helper(v: vec4<f32>) -> vec4<f32> { return v; }
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  textureStore(dataTextureB, vec2<i32>(gid.xy), vec4<f32>(1.0));
+}`;
+    const usage = analyzeShaderBindings(wgsl);
+    expect(usage.writesDataA).toBe(false);
+    expect(usage.writesDataB).toBe(true);
+  });
+
+  it('detects usage through aliased binding names (astral-kaleidoscope-morph pattern)', () => {
+    const wgsl = `
+@group(0) @binding(7) var historyBuf: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var unusedBuf:  texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var historyTex: texture_2d<f32>;
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let prev = textureLoad(historyTex, vec2<i32>(gid.xy), 0);
+  textureStore(historyBuf, vec2<i32>(gid.xy), prev);
+}`;
+    const usage = analyzeShaderBindings(wgsl);
+    expect(usage.writesDataA).toBe(true);
+    expect(usage.writesDataB).toBe(false);
+    expect(usage.readsDataC).toBe(true);
+  });
+
+  it('detects the opt-in history ring (binding 13)', () => {
+    const wgsl = `${CANONICAL_DECLS}
+@group(0) @binding(13) var historyTexture: texture_2d_array<f32>;
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let past = textureLoad(historyTexture, vec2<i32>(gid.xy), 3, 0);
+  textureStore(writeTexture, vec2<i32>(gid.xy), past);
+}`;
+    expect(analyzeShaderBindings(wgsl).usesHistory).toBe(true);
+  });
+
+  it('treats a declared binding 13 that is never referenced as unused', () => {
+    const wgsl = `${CANONICAL_DECLS}
+@group(0) @binding(13) var historyTexture: texture_2d_array<f32>;
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  textureStore(writeTexture, vec2<i32>(gid.xy), vec4<f32>(0.0));
+}`;
+    expect(analyzeShaderBindings(wgsl).usesHistory).toBe(false);
+  });
+
+  it('handles multiline declarations with whitespace between decorators', () => {
+    const wgsl = `
+@group(0)
+  @binding(7)
+  var dataTextureA: texture_storage_2d<rgba32float, write>;
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  textureStore(dataTextureA, vec2<i32>(gid.xy), vec4<f32>(1.0));
+}`;
+    expect(analyzeShaderBindings(wgsl).writesDataA).toBe(true);
+  });
+
+  it('is conservative: an unparseable declaration counts as used', () => {
+    // Declaration exists but in a form the name parser does not understand.
+    const wgsl = `
+@group(0) @binding(7) var
+   /* weird comment */ dataTextureA: texture_storage_2d<rgba32float, write>;
+`;
+    // Whether or not the name parses, a declared binding must never be
+    // reported as unused unless we positively saw the name go unreferenced.
+    const usage = analyzeShaderBindings(wgsl);
+    expect(typeof usage.writesDataA).toBe('boolean');
+  });
+
+  it('exports an all-true conservative default', () => {
+    expect(CONSERVATIVE_BINDING_USAGE).toEqual({
+      writesDataA: true,
+      writesDataB: true,
+      readsDataC: true,
+      usesHistory: true,
+    });
+  });
+});
+
+describe('analyzeShaderBindings against real catalog patterns', () => {
+  it('canonical template neither writes data textures nor uses history', () => {
+    // Mirrors public/shaders/_template_canonical_compute.wgsl
+    const wgsl = `${CANONICAL_DECLS}
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let dims = textureDimensions(writeTexture);
+  let uv = (vec2<f32>(gid.xy) + 0.5) / vec2<f32>(dims);
+  let src = textureSampleLevel(readTexture, u_sampler, uv, 0.0);
+  let depth = textureSampleLevel(readDepthTexture, non_filtering_sampler, uv, 0.0).r;
+  textureStore(writeTexture, vec2<i32>(gid.xy), src);
+  textureStore(writeDepthTexture, vec2<i32>(gid.xy), vec4<f32>(depth, 0.0, 0.0, 0.0));
+}`;
+    expect(analyzeShaderBindings(wgsl)).toEqual({
+      writesDataA: false,
+      writesDataB: false,
+      readsDataC: false,
+      usesHistory: false,
+    });
+  });
+});

--- a/src/renderer/ShaderCompilation.ts
+++ b/src/renderer/ShaderCompilation.ts
@@ -46,6 +46,58 @@ export function parseWorkgroupSize(wgslSource: string): { x: number; y: number }
 }
 
 /**
+ * Which optional per-frame texture copies a shader actually needs.
+ * Drives skipping of dataTexA/B→C feedback copies and the history-ring copy
+ * in the render loop when the bound shader never touches those resources.
+ */
+export interface ShaderBindingUsage {
+  writesDataA: boolean;
+  writesDataB: boolean;
+  readsDataC: boolean;
+  usesHistory: boolean;
+}
+
+/** Conservative usage assumed when a shader's source was never analyzed. */
+export const CONSERVATIVE_BINDING_USAGE: ShaderBindingUsage = {
+  writesDataA: true,
+  writesDataB: true,
+  readsDataC: true,
+  usesHistory: true,
+};
+
+function bindingVarName(wgsl: string, binding: number): string | null {
+  const m = wgsl.match(
+    new RegExp(`@group\\(0\\)\\s*@binding\\(${binding}\\)\\s*var(?:<[^>]*>)?\\s+([A-Za-z_][A-Za-z0-9_]*)`),
+  );
+  return m ? m[1] : null;
+}
+
+function usedBeyondDeclaration(wgsl: string, binding: number): boolean {
+  const hasBinding = new RegExp(`@group\\(0\\)\\s*@binding\\(${binding}\\)`).test(wgsl);
+  if (!hasBinding) return false;
+  const name = bindingVarName(wgsl, binding);
+  // Declared but unparseable name: assume used (conservative).
+  if (!name) return true;
+  const refs = wgsl.match(new RegExp(`\\b${name}\\b`, 'g'));
+  return (refs?.length ?? 0) > 1;
+}
+
+/**
+ * Statically determine which feedback resources a shader uses, by variable
+ * name bound at each binding slot (names may be aliased, so the declaration
+ * is parsed rather than assuming canonical names). Errs on the side of
+ * "used" whenever the source is ambiguous.
+ */
+export function analyzeShaderBindings(wgsl: string): ShaderBindingUsage {
+  return {
+    writesDataA: usedBeyondDeclaration(wgsl, 7),
+    writesDataB: usedBeyondDeclaration(wgsl, 8),
+    readsDataC: usedBeyondDeclaration(wgsl, 9),
+    usesHistory: usedBeyondDeclaration(wgsl, 13),
+  };
+}
+
+/**
  * Fallback compute shader used when the requested shader fails to compile
  * Simple pass-through with slight red tint to indicate fallback mode
  */

--- a/src/renderer/ShaderTemplates.ts
+++ b/src/renderer/ShaderTemplates.ts
@@ -43,6 +43,41 @@ fn fs_main(in: VSOut) -> @location(0) vec4f {
 }
 `;
 
+/**
+ * Source→read downscale shader for resolutionScale < 1.0.
+ * Samples the full-resolution rgba32float sourceTex with textureLoad
+ * (nearest — no filterable-float requirement) and writes raw linear values,
+ * matching the identity orientation of copyTextureToTexture at scale = 1.
+ */
+export const SCALE_COPY_WGSL = /* wgsl */ `
+struct VSOut {
+  @builtin(position) pos : vec4f,
+  @location(0)       uv  : vec2f,
+}
+
+@vertex
+fn vs(@builtin(vertex_index) idx: u32) -> VSOut {
+  var p = array<vec2f,3>(
+    vec2f(-1.0, -1.0),
+    vec2f( 3.0, -1.0),
+    vec2f(-1.0,  3.0),
+  );
+  var out: VSOut;
+  out.pos = vec4f(p[idx], 0.0, 1.0);
+  out.uv  = p[idx] * vec2f(0.5, -0.5) + vec2f(0.5);
+  return out;
+}
+
+@group(0) @binding(0) var src: texture_2d<f32>;
+
+@fragment
+fn fs(in: VSOut) -> @location(0) vec4f {
+  let dim   = vec2i(textureDimensions(src));
+  let coord = clamp(vec2i(in.uv * vec2f(dim)), vec2i(0), dim - 1);
+  return textureLoad(src, coord, 0);
+}
+`;
+
 const makeBlitWGSL = (flipY: boolean) => /* wgsl */ `
 struct VSOut {
   @builtin(position) pos : vec4f,

--- a/src/renderer/WebGPURenderer.ts
+++ b/src/renderer/WebGPURenderer.ts
@@ -74,6 +74,7 @@ export class WebGPURenderer implements IRenderer, ShaderSlotRenderer {
 
   private blitPipeline!: GPURenderPipeline;
   private generativeBlitPipeline!: GPURenderPipeline;
+  private scaleCopyPipeline!: GPURenderPipeline;
   private blitBindGroupLayout!: GPUBindGroupLayout;
   private blitBindGroup!: GPUBindGroup;
   private blitReadTex!: GPUTexture;
@@ -219,6 +220,7 @@ export class WebGPURenderer implements IRenderer, ShaderSlotRenderer {
     const blit = createBlitPipeline(d, this.canvasFormat, this.blitReadTex, this.scaledW, this.scaledH);
     this.blitPipeline = blit.blitPipeline;
     this.generativeBlitPipeline = blit.generativeBlitPipeline;
+    this.scaleCopyPipeline = blit.scaleCopyPipeline;
     this.blitBindGroupLayout = blit.blitBindGroupLayout;
     this.blitBindGroup = blit.blitBindGroup;
     this.videoCopyPipeline = blit.videoCopyPipeline;
@@ -309,8 +311,10 @@ export class WebGPURenderer implements IRenderer, ShaderSlotRenderer {
     if (index >= 0 && index < PHYSICAL_SLOT_LIMIT) {
       const mode = this.slots[index]?.mode ?? 'chained';
       this.slots[index] = { shaderId: id, enabled: !!id, mode };
-      console.log(`[WebGPURenderer] Slot ${index} set to "${id}" (enabled: ${!!id}, mode: ${mode})`);
-      console.log(`[WebGPURenderer] Current slots:`, this.slots.map(s => ({ id: s.shaderId, enabled: s.enabled, mode: s.mode })));
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`[WebGPURenderer] Slot ${index} set to "${id}" (enabled: ${!!id}, mode: ${mode})`);
+        console.log(`[WebGPURenderer] Current slots:`, this.slots.map(s => ({ id: s.shaderId, enabled: s.enabled, mode: s.mode })));
+      }
     }
   }
 

--- a/src/renderer/webgpu/WebGPURenderLoop.ts
+++ b/src/renderer/webgpu/WebGPURenderLoop.ts
@@ -6,6 +6,7 @@
 
 import { GPUTimings } from '../Renderer';
 import { resolveMultipassChain } from '../multipassRegistry';
+import { ShaderBindingUsage } from '../ShaderCompilation';
 import {
   createUniformBufferView,
   UniformBufferView,
@@ -18,7 +19,6 @@ import {
   EXTRA_FLOATS,
   HISTORY_DEPTH,
   ShaderSlot,
-  SlotMode,
   WG_SIZE_X,
   WG_SIZE_Y,
 } from './webgpuConstants';
@@ -49,11 +49,7 @@ export interface WebGPURenderLoopState {
   blitBindGroupLayout: GPUBindGroupLayout;
   blitPipeline: GPURenderPipeline;
   generativeBlitPipeline: GPURenderPipeline;
-
-  // Samplers & video copy
-  filterSampler: GPUSampler;
-  videoCopyPipeline: GPURenderPipeline | null;
-  videoCopyBindGroupLayout: GPUBindGroupLayout | null;
+  scaleCopyPipeline: GPURenderPipeline;
 
   // Dimensions
   canvasW: number;
@@ -67,6 +63,7 @@ export interface WebGPURenderLoopState {
   getPipeline: (id: string) => GPUComputePipeline | undefined;
   getWorkgroupSize: (id: string) => { x: number; y: number };
   hasPipeline: (id: string) => boolean;
+  getBindingUsage: (id: string) => ShaderBindingUsage;
 
   // Uniform / audio state
   ripples: { x: number; y: number; startTime: number }[];
@@ -105,6 +102,9 @@ export interface WebGPURenderLoopState {
 
 export class WebGPURenderLoop {
   private uniformView: UniformBufferView = createUniformBufferView();
+  private extraData = new Float32Array(EXTRA_FLOATS);
+  private scaleBindGroup: GPUBindGroup | null = null;
+  private scaleBindGroupTex: GPUTexture | null = null;
 
   startRenderLoop(state: WebGPURenderLoopState): void {
     const loop = () => {
@@ -161,6 +161,24 @@ export class WebGPURenderLoop {
 
     this.writeUniforms(state);
 
+    // Resolve each slot's multipass chain once and aggregate which optional
+    // feedback copies this frame actually needs.
+    let anyReadsC = false;
+    let anyUsesHistory = false;
+    const slotPlans = enabled.map((slot) => {
+      const chain = resolveMultipassChain(slot.shaderId!);
+      let writesDataA = false;
+      let writesDataB = false;
+      for (const id of chain) {
+        const usage = state.getBindingUsage(id);
+        writesDataA = writesDataA || usage.writesDataA;
+        writesDataB = writesDataB || usage.writesDataB;
+        anyReadsC = anyReadsC || usage.readsDataC;
+        anyUsesHistory = anyUsesHistory || usage.usesHistory;
+      }
+      return { slot, chain, writesDataA, writesDataB };
+    });
+
     const encoder = state.device.createCommandEncoder({ label: 'frame' });
 
     if (state.resolutionScale < 1.0) {
@@ -175,17 +193,8 @@ export class WebGPURenderLoop {
           },
         ],
       });
-      scalePass.setPipeline(state.videoCopyPipeline!);
-      scalePass.setBindGroup(
-        0,
-        state.device.createBindGroup({
-          layout: state.videoCopyBindGroupLayout!,
-          entries: [
-            { binding: 0, resource: state.sourceTex.createView() },
-            { binding: 1, resource: state.filterSampler },
-          ],
-        }),
-      );
+      scalePass.setPipeline(state.scaleCopyPipeline);
+      scalePass.setBindGroup(0, this.getScaleBindGroup(state));
       scalePass.draw(3);
       scalePass.end();
     } else {
@@ -196,28 +205,28 @@ export class WebGPURenderLoop {
       );
     }
 
-    const parallelSlots = enabled.filter((s) => s.mode === 'parallel');
-    const chainedSlots = enabled.filter((s) => s.mode === 'chained');
+    const parallelPlans = slotPlans.filter((p) => p.slot.mode === 'parallel');
+    const chainedPlans = slotPlans.filter((p) => p.slot.mode === 'chained');
     const singleChained = enabled.length === 1 && enabled[0].mode === 'chained';
     state.blitReadTex = state.readTex;
 
-    if (state.frameCount % 60 === 0) {
+    if (process.env.NODE_ENV === 'development' && state.frameCount % 60 === 0) {
       console.log(
-        `[WebGPURenderer] Parallel slots: ${parallelSlots.length}, Chained slots: ${chainedSlots.length}`,
+        `[WebGPURenderer] Parallel slots: ${parallelPlans.length}, Chained slots: ${chainedPlans.length}`,
       );
-      if (chainedSlots.length > 0) {
+      if (chainedPlans.length > 0) {
         console.log(
           `[WebGPURenderer] Chained slot order:`,
-          chainedSlots.map((s) => s.shaderId),
+          chainedPlans.map((p) => p.slot.shaderId),
         );
       }
     }
 
-    for (const slot of parallelSlots) {
-      this.dispatchSlot(state, encoder, slot, 'parallel');
+    for (const plan of parallelPlans) {
+      this.dispatchChain(state, encoder, plan.chain, 'parallel');
     }
 
-    if (parallelSlots.length > 0) {
+    if (parallelPlans.length > 0) {
       encoder.copyTextureToTexture(
         { texture: state.writeTex },
         { texture: state.readTex },
@@ -225,12 +234,8 @@ export class WebGPURenderLoop {
       );
     }
 
-    for (let i = 0; i < chainedSlots.length; i++) {
-      const slot = chainedSlots[i];
-      if (state.frameCount % 60 === 0) {
-        console.log(`[WebGPURenderer] Processing chained slot ${i}: ${slot.shaderId}`);
-      }
-      this.dispatchSlot(state, encoder, slot, 'chained');
+    for (const plan of chainedPlans) {
+      this.dispatchChain(state, encoder, plan.chain, 'chained');
 
       if (singleChained) {
         state.blitReadTex = state.writeTex;
@@ -242,29 +247,45 @@ export class WebGPURenderLoop {
         );
       }
 
-      encoder.copyTextureToTexture(
-        { texture: state.dataTexA },
-        { texture: state.dataTexC },
-        [state.scaledW, state.scaledH, 1],
-      );
+      // Data-texture feedback (dataTextureA/B → dataTextureC, binding 9).
+      // Skipped entirely when nothing enabled this frame reads dataTextureC,
+      // and each copy only runs when this slot's shaders write that texture —
+      // so an A-writing simulation is no longer clobbered by a stale B copy.
+      if (anyReadsC) {
+        if (plan.writesDataA) {
+          encoder.copyTextureToTexture(
+            { texture: state.dataTexA },
+            { texture: state.dataTexC },
+            [state.scaledW, state.scaledH, 1],
+          );
+        }
+        if (plan.writesDataB) {
+          encoder.copyTextureToTexture(
+            { texture: state.dataTexB },
+            { texture: state.dataTexC },
+            [state.scaledW, state.scaledH, 1],
+          );
+        }
+      }
+    }
 
+    // History ring copy (binding 13) — opt-in, used by very few shaders.
+    if (anyUsesHistory) {
       encoder.copyTextureToTexture(
-        { texture: state.dataTexB },
-        { texture: state.dataTexC },
+        { texture: state.blitReadTex },
+        { texture: state.historyTex, origin: [0, 0, state.historyHead] },
         [state.scaledW, state.scaledH, 1],
       );
     }
 
-    encoder.copyTextureToTexture(
-      { texture: state.blitReadTex },
-      { texture: state.historyTex, origin: [0, 0, state.historyHead] },
-      [state.scaledW, state.scaledH, 1],
-    );
+    // Encode the canvas blit into the same command buffer: one submit/frame.
+    this.updateBlitBindGroup(state);
+    this.encodeBlit(state, encoder);
 
     state.device.queue.submit([encoder.finish()]);
-    state.historyHead = (state.historyHead + 1) % HISTORY_DEPTH;
-
-    this.blitToCanvas(state);
+    if (anyUsesHistory) {
+      state.historyHead = (state.historyHead + 1) % HISTORY_DEPTH;
+    }
 
     state.frameCount++;
     const now = performance.now() / 1000;
@@ -276,14 +297,24 @@ export class WebGPURenderLoop {
     }
   }
 
-  private dispatchSlot(
+  private getScaleBindGroup(state: WebGPURenderLoopState): GPUBindGroup {
+    if (!this.scaleBindGroup || this.scaleBindGroupTex !== state.sourceTex) {
+      this.scaleBindGroup = createBlitBindGroup(
+        state.device!,
+        state.blitBindGroupLayout,
+        state.sourceTex,
+      );
+      this.scaleBindGroupTex = state.sourceTex;
+    }
+    return this.scaleBindGroup;
+  }
+
+  private dispatchChain(
     state: WebGPURenderLoopState,
     encoder: GPUCommandEncoder,
-    slot: { shaderId: string | null; enabled: boolean; mode: SlotMode },
+    chain: string[],
     labelPrefix: string,
   ): void {
-    if (!slot.shaderId) return;
-    const chain = resolveMultipassChain(slot.shaderId);
     for (const shaderId of chain) {
       const pipeline = state.getPipeline(shaderId);
       if (!pipeline) {
@@ -332,7 +363,7 @@ export class WebGPURenderLoop {
 
     state.device.queue.writeBuffer(state.uniformBuf, 0, u.data);
 
-    const extraData = new Float32Array(EXTRA_FLOATS);
+    const extraData = this.extraData;
     extraData[0] = state.audioBass;
     extraData[1] = state.audioMid;
     extraData[2] = state.audioTreble;
@@ -342,19 +373,18 @@ export class WebGPURenderLoop {
     state.device.queue.writeBuffer(state.extraBuf, 0, extraData);
   }
 
-  private blitToCanvas(state: WebGPURenderLoopState): void {
-    if (!state.device || !state.context || !state.initialized) return;
+  /** Record the canvas blit into an existing encoder (no-op if the swapchain texture is unavailable). */
+  private encodeBlit(state: WebGPURenderLoopState, encoder: GPUCommandEncoder): void {
+    if (!state.context) return;
 
+    let currentTexture: GPUTexture;
     try {
-      const currentTexture = state.context.getCurrentTexture();
-      if (!currentTexture) return;
+      currentTexture = state.context.getCurrentTexture();
     } catch {
       return;
     }
+    if (!currentTexture) return;
 
-    this.updateBlitBindGroup(state);
-
-    const encoder = state.device.createCommandEncoder({ label: 'blit' });
     const pipeline =
       state.inputSource === 'generative'
         ? state.generativeBlitPipeline
@@ -362,7 +392,7 @@ export class WebGPURenderLoop {
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          view: state.context.getCurrentTexture().createView(),
+          view: currentTexture.createView(),
           loadOp: 'clear',
           storeOp: 'store',
           clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -373,6 +403,15 @@ export class WebGPURenderLoop {
     pass.setBindGroup(0, state.blitBindGroup);
     pass.draw(3);
     pass.end();
+  }
+
+  private blitToCanvas(state: WebGPURenderLoopState): void {
+    if (!state.device || !state.context || !state.initialized) return;
+
+    this.updateBlitBindGroup(state);
+
+    const encoder = state.device.createCommandEncoder({ label: 'blit' });
+    this.encodeBlit(state, encoder);
     state.device.queue.submit([encoder.finish()]);
   }
 

--- a/src/renderer/webgpu/WebGPUResourceManager.ts
+++ b/src/renderer/webgpu/WebGPUResourceManager.ts
@@ -4,7 +4,7 @@
  * GPU resource creation for the TypeScript WebGPU renderer.
  */
 
-import { BLIT_WGSL, GENERATIVE_BLIT_WGSL, VIDEO_COPY_WGSL } from '../ShaderTemplates';
+import { BLIT_WGSL, GENERATIVE_BLIT_WGSL, SCALE_COPY_WGSL, VIDEO_COPY_WGSL } from '../ShaderTemplates';
 import { UNIFORM_FLOATS } from '../UniformBuffer';
 import {
   EXTRA_FLOATS,
@@ -45,6 +45,7 @@ export interface WebGPUComputeLayout {
 export interface WebGPUBlitResources {
   blitPipeline: GPURenderPipeline;
   generativeBlitPipeline: GPURenderPipeline;
+  scaleCopyPipeline: GPURenderPipeline;
   blitBindGroupLayout: GPUBindGroupLayout;
   blitBindGroup: GPUBindGroup;
   videoCopyPipeline: GPURenderPipeline | null;
@@ -344,6 +345,22 @@ export function createBlitPipeline(
     entries: [{ binding: 0, resource: blitReadTex.createView() }],
   });
 
+  // Downscale pass for resolutionScale < 1.0: samples the full-res
+  // rgba32float sourceTex via textureLoad (unfilterable-float — works on
+  // every adapter) and writes into the scaled readTex. Reuses the blit
+  // bind-group layout (single sampled texture at binding 0).
+  const scaleModule = device.createShaderModule({
+    label: 'scaleCopyShader',
+    code: SCALE_COPY_WGSL,
+  });
+  const scaleCopyPipeline = device.createRenderPipeline({
+    label: 'scaleCopyPipeline',
+    layout: device.createPipelineLayout({ bindGroupLayouts: [blitBindGroupLayout] }),
+    vertex: { module: scaleModule, entryPoint: 'vs' },
+    fragment: { module: scaleModule, entryPoint: 'fs', targets: [{ format: 'rgba32float' }] },
+    primitive: { topology: 'triangle-list' },
+  });
+
   const supportsExternalTexture = 'importExternalTexture' in device;
   let videoCopyPipeline: GPURenderPipeline | null = null;
   let videoCopyBindGroupLayout: GPUBindGroupLayout | null = null;
@@ -380,6 +397,7 @@ export function createBlitPipeline(
   return {
     blitPipeline,
     generativeBlitPipeline,
+    scaleCopyPipeline,
     blitBindGroupLayout,
     blitBindGroup,
     videoCopyPipeline,

--- a/src/renderer/webgpu/WebGPUShaderManager.ts
+++ b/src/renderer/webgpu/WebGPUShaderManager.ts
@@ -4,7 +4,12 @@
  * Shader loading, compilation, and pipeline cache for the WebGPU renderer.
  */
 
-import { compileShader } from '../ShaderCompilation';
+import {
+  analyzeShaderBindings,
+  compileShader,
+  CONSERVATIVE_BINDING_USAGE,
+  ShaderBindingUsage,
+} from '../ShaderCompilation';
 import { resolveShaderUrl } from '../../utils/resolveShaderUrl';
 import { fetchShaderWgsl } from '../../utils/fetchShaderWgsl';
 
@@ -12,6 +17,7 @@ export class WebGPUShaderManager {
   private pipelines = new Map<string, GPUComputePipeline>();
   private pipelineHashes = new Map<string, string>();
   private workgroupSizes = new Map<string, { x: number; y: number }>();
+  private bindingUsages = new Map<string, ShaderBindingUsage>();
 
   getPipeline(id: string): GPUComputePipeline | undefined {
     return this.pipelines.get(id);
@@ -25,6 +31,10 @@ export class WebGPUShaderManager {
     return this.workgroupSizes.get(id) || { x: 8, y: 8 };
   }
 
+  getBindingUsage(id: string): ShaderBindingUsage {
+    return this.bindingUsages.get(id) ?? CONSERVATIVE_BINDING_USAGE;
+  }
+
   getCacheStats(): { cachedCount: number; cachedIds: string[] } {
     return {
       cachedCount: this.pipelines.size,
@@ -36,6 +46,7 @@ export class WebGPUShaderManager {
     this.pipelines.clear();
     this.pipelineHashes.clear();
     this.workgroupSizes.clear();
+    this.bindingUsages.clear();
   }
 
   compile(
@@ -44,7 +55,7 @@ export class WebGPUShaderManager {
     id: string,
     wgsl: string,
   ): boolean {
-    return compileShader(
+    const ok = compileShader(
       device,
       pipelineLayout,
       id,
@@ -53,6 +64,13 @@ export class WebGPUShaderManager {
       this.pipelineHashes,
       this.workgroupSizes,
     );
+    if (ok) {
+      // Analyzed from the requested source even if the fallback pipeline was
+      // used — the fallback touches strictly fewer resources, so this only
+      // ever errs toward performing a copy.
+      this.bindingUsages.set(id, analyzeShaderBindings(wgsl));
+    }
+    return ok;
   }
 
   async loadShader(

--- a/src/renderer/webgpu/webgpuLoopState.ts
+++ b/src/renderer/webgpu/webgpuLoopState.ts
@@ -32,9 +32,7 @@ export interface WebGPURenderLoopHost {
   blitBindGroupLayout: GPUBindGroupLayout;
   blitPipeline: GPURenderPipeline;
   generativeBlitPipeline: GPURenderPipeline;
-  filterSampler: GPUSampler;
-  videoCopyPipeline: GPURenderPipeline | null;
-  videoCopyBindGroupLayout: GPUBindGroupLayout | null;
+  scaleCopyPipeline: GPURenderPipeline;
   canvasW: number;
   canvasH: number;
   scaledW: number;
@@ -100,9 +98,7 @@ export function createRenderLoopState(host: WebGPURenderLoopHost): WebGPURenderL
     get blitBindGroupLayout() { return h.blitBindGroupLayout; },
     get blitPipeline() { return h.blitPipeline; },
     get generativeBlitPipeline() { return h.generativeBlitPipeline; },
-    get filterSampler() { return h.filterSampler; },
-    get videoCopyPipeline() { return h.videoCopyPipeline; },
-    get videoCopyBindGroupLayout() { return h.videoCopyBindGroupLayout; },
+    get scaleCopyPipeline() { return h.scaleCopyPipeline; },
     get canvasW() { return h.canvasW; },
     get canvasH() { return h.canvasH; },
     get scaledW() { return h.scaledW; },
@@ -112,6 +108,7 @@ export function createRenderLoopState(host: WebGPURenderLoopHost): WebGPURenderL
     getPipeline: (id) => h.shaderManager.getPipeline(id),
     getWorkgroupSize: (id) => h.shaderManager.getWorkgroupSize(id),
     hasPipeline: (id) => h.shaderManager.hasPipeline(id),
+    getBindingUsage: (id) => h.shaderManager.getBindingUsage(id),
     get ripples() { return h.ripples; },
     get mouseX() { return h.mouseX; },
     get mouseYShader() { return h.mouseYShader; },


### PR DESCRIPTION
## Summary

Engine hot-path improvements in the TypeScript WebGPU renderer that benefit **every shader** with **zero WGSL file changes**. At 1080p this removes up to ~66 MB of rgba32float copy traffic per frame for typical single-effect use, fixes a correctness bug in data-texture feedback, and repairs the resolution-downscale path that adaptive quality depends on. Also repairs the committed merge-conflict damage that was breaking `npm run build`.

## Fixes

### 1. Data-texture feedback clobbering (quality bug + wasted bandwidth)
The render loop copied `dataTexA → dataTexC` **then** `dataTexB → dataTexC` after every chained slot — the B copy always overwrote the A copy. The canonical C++ renderer (`wasm_renderer/frame.cpp:298`) copies only A→C. Catalog stats: **956** shaders write `dataTextureA`, **611** read `dataTextureC`, only **68** write `dataTextureB` — so A-feedback simulations were reading stale/zeroed state. Copies are now gated per slot on whether its shaders actually write A/B, and skipped entirely when no enabled shader reads `dataTextureC`. Shaders that write both A and B keep the exact previous behavior (B copied last).

### 2. History-ring copy gated by use
Only **11 of 1295** shaders sample the history texture (binding 13), yet every frame paid a full-resolution rgba32float copy (~33 MB/frame at 1080p). The copy (and ring-head advance) now only happens when an enabled shader actually uses it.

### 3. Broken `resolutionScale < 1` downscale pass
The scale pass bound `sourceTex.createView()` to `videoCopyBindGroupLayout`, whose binding 0 is declared `externalTexture` — an invalid bind group, so the path adaptive quality drives could never render. Added a dedicated `scaleCopyPipeline` (`textureLoad`-based, works without `float32-filterable`) reusing the blit bind-group layout, with the bind group cached by `sourceTex` identity instead of recreated every frame.

### 4. Per-frame CPU overhead
- Per-shader binding usage is derived once at compile time by `analyzeShaderBindings()`, which parses the variable name declared at each binding (handles aliased names like `astral-kaleidoscope-morph`'s `historyBuf`) and errs toward "used" whenever ambiguous; unknown ids fall back to all-true so a needed copy is never skipped.
- The 1 KB `extraBuffer` staging `Float32Array` is now allocated once, not per frame.
- The canvas blit is recorded into the same command encoder as compute work: **one `queue.submit()` per frame instead of two**, and `getCurrentTexture()` is called once instead of twice.
- Per-frame/slot `console.log` spam is gated behind development builds.

### 5. Docs kept in sync
`MULTIPASS_SIM_CONTRACT.md` and `DEVELOPER_CONTEXT.md` updated to describe the usage-gated copies. Also corrected two pre-existing contract errors: passes cannot sample `dataTextureA/B` (bound write-only), and `dataTextureC` refreshes only after a slot's whole chain (one-frame latency), contrary to what the sim contract told authors.

### 6. Build repair (merge-conflict damage)
Merged latest `main` and fixed the remaining fallout of the half-resolved Wave 3 merge (`5113d75`) that broke `craco build`:
- `Controls.tsx`: main's marker cleanup had left **both** the stale 1,660-line monolithic component and the refactored re-export in place → `Duplicate export 'default'`. Restored the intended thin re-export of `ControlsContainer`.
- `useDepthEstimation.ts`: resolved the five committed conflict hunks by taking the typed `origin/main` side (`DepthEstimatorPipeline` instead of `unknown` + casts).

## Testing

- New suite `ShaderCompilation.bindingUsage.test.ts` (10 tests): canonical template, A-write/C-read feedback, B-only writer, aliased binding names, opt-in history, declared-but-unused bindings, multiline declarations, conservative defaults.
- Full Jest suite: **28/28 suites, 251/251 tests pass** (including `Controls.test.tsx`, which was failing before the build repair).
- `tsc --noEmit` clean for `src/`; ESLint clean on all changed files.
- `SKIP_WASM_BUILD=1 npm run build` **compiles successfully** (it failed on `main` with the duplicate-export error).
- Note: this environment has no GPU adapter, so renderer behavior was validated statically against the C++ reference renderer and the shader catalog (usage counts above), not visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCTVUKCUYr3GX5k5j1drsD