### PR TITLE
docs: update feedback-copy contract docs for usage-gated copies

### DIFF
--- a/agents/swarm-tasks/advanced-physics/MULTIPASS_SIM_CONTRACT.md
+++ b/agents/swarm-tasks/advanced-physics/MULTIPASS_SIM_CONTRACT.md
@@ -6,18 +6,21 @@ How to run physics sims **without** new bind groups or a graph runner.
 
 ## What exists today
 
-### Frame feedback (automatic)
+### Frame feedback (automatic, usage-gated)
 
-After each chained slot dispatch, `WebGPURenderer` copies:
+After each chained slot's full pass chain, `WebGPURenderLoop` copies data textures for the *next* frame. Since the usage-gating change, only the copies the frame actually needs are recorded (derived per shader at compile time by `analyzeShaderBindings()` in `src/renderer/ShaderCompilation.ts`):
 
-- `dataTextureA` → `dataTextureC`
-- `dataTextureB` → `dataTextureC` (second copy overwrites — use **one** primary feedback channel per effect)
+- `dataTextureA` → `dataTextureC` — only when a shader in the slot's chain writes `dataTextureA`
+- `dataTextureB` → `dataTextureC` — only when a shader in the slot's chain writes `dataTextureB`; it runs after the A copy, so if you write **both**, B wins — use **one** primary feedback channel per effect
+- Both copies are skipped when no enabled shader reads `dataTextureC`
 
-See `src/renderer/WebGPURenderer.ts` (~1560) and `src/renderer/slotOrchestrator.ts`.
+Just write your state and read `dataTextureC` — the gating is invisible to shader authors. The same applies to the history ring (binding 13): the per-frame history copy only happens when an enabled shader actually samples `historyTexture`.
+
+See `src/renderer/webgpu/WebGPURenderLoop.ts` and `src/renderer/slotOrchestrator.ts`.
 
 ### Linear multipass (same frame)
 
-`resolveMultipassChain()` runs passes **sequentially in one command encoder** with the **same** bind group. Pass *N+1* can sample what pass *N* wrote to `dataTextureA` / `dataTextureB` in the same frame.
+`resolveMultipassChain()` runs passes **sequentially in one command encoder** with the **same** bind group. Note that `dataTextureA` / `dataTextureB` are bound **write-only** and `dataTextureC` refreshes only *after* the slot's whole chain — so pass *N+1* **cannot** read what pass *N* wrote this frame; cross-pass state travels through `dataTextureC` with one frame of latency.
 
 Registry: `node scripts/buildMultipassRegistry.js` → `src/renderer/multipassRegistry.ts`
 
@@ -52,16 +55,16 @@ Secondary pass WGSL files use `_` prefix or `-passN` suffix — **no** separate 
 | `extraBuffer` (10) | Particle indices, broken springs, RNG seeds | storage |
 | `plasmaBuffer` (12) | Audio bands | read |
 
-**Ping-pong within one frame (Tier B — no graph runner):**
+**Ping-pong across frames (Tier B — no graph runner):**
 
 ```
 Pass 1: read dataTextureC (t-1)  → write dataTextureA (integrate)
-Pass 2: read dataTextureA        → write dataTextureB (inject forces)
-Pass 3: read dataTextureB        → write writeTexture + dataTextureA (render + commit)
-End of frame: dataTextureA → dataTextureC (automatic)
+Pass 2: read dataTextureC (t-1)  → write dataTextureB (scratch — NOT readable by later passes)
+Pass 3: read dataTextureC (t-1)  → write writeTexture + dataTextureA (render + commit)
+End of slot: dataTextureA → dataTextureC (automatic — feeds next frame)
 ```
 
-Three logical buffers (prev / work / next) map onto A + B + C across time.
+A and B are write-only within a frame; every pass reads the *previous frame's* committed state from `dataTextureC`. State written to A becomes visible in C on the next frame (one-frame latency). True same-frame pass-to-pass handoff needs the Tier C graph runner below.
 
 ---
 

--- a/notes/DEVELOPER_CONTEXT.md
+++ b/notes/DEVELOPER_CONTEXT.md
@@ -48,7 +48,7 @@ It features a **Dual-Window** mode where a secondary "Remote" window can control
 **Why it's complex:** The renderer supports a "Stack" of 3 compute shaders.
 1.  **Chaining:** Output of Shader 1 -> Input of Shader 2.
 2.  **History:** Shaders can read the *previous frame's* output via `dataTextureC` (Binding 9) and write to `dataTextureA` (Binding 7).
-**Agent Warning:** The `dataTextureA` -> `dataTextureC` copy happens *once* at the end of the frame. If multiple shaders in the stack try to write to the history buffer (`dataTextureA`), they will overwrite each other. **Only one stateful shader should be active at a time.**
+**Agent Warning:** The `dataTextureA` -> `dataTextureC` copy happens after *each chained slot's* dispatch, and is **usage-gated**: the renderer statically analyzes each shader's WGSL (`analyzeShaderBindings()` in `src/renderer/ShaderCompilation.ts`) and only copies A→C / B→C when that slot's shaders actually write them (skipping both when no enabled shader reads `dataTextureC`). If a shader writes **both** A and B, the B copy lands last and wins. Multiple stateful shaders in a stack still share the single A/C pair and will overwrite each other's state — **only one stateful shader should be active at a time.**
 
 ### C. Remote Synchronization (Race Conditions)
 **Why it's complex:** The Main App is the "Source of Truth". The Remote App is a "Dumb Terminal".


### PR DESCRIPTION
MULTIPASS_SIM_CONTRACT.md and DEVELOPER_CONTEXT.md described the old unconditional dataTextureA->C then B->C copy pair (with B always clobbering A). Updated both to document the usage-gated behavior and the history-ring gating, with pointers to analyzeShaderBindings().

Also corrected two pre-existing inaccuracies in the multipass contract: passes cannot sample dataTextureA/B (they are bound write-only), and dataTextureC only refreshes after a slot's whole chain, so cross-pass state travels with one frame of latency - the previous text told sim authors pass N+1 could read pass N's same-frame writes, which was never true of the TS renderer.


Claude-Session: https://claude.ai/code/session_01QCTVUKCUYr3GX5k5j1drsD