### PR TITLE
Relay hop 1: recursive domain warp for gen-relay-psychedelia

### DIFF
--- a/agents/swarm-tasks/relay-queue.json
+++ b/agents/swarm-tasks/relay-queue.json
@@ -16,11 +16,12 @@
     {
       "hop": 1,
       "name": "domain-warp",
-      "owner": "unassigned",
+      "owner": "claude-hop-1",
       "chunk": "domain-warp",
       "prompt": "agents/swarm-tasks/prompts/relay-hop-1-domain-warp.md",
-      "status": "pending",
-      "target": "Recursive domain warp: fbm(p + fbm(p + fbm(p))). Stay within 6 octaves/call."
+      "status": "completed",
+      "target": "Recursive domain warp: fbm(p + fbm(p + fbm(p))). Stay within 6 octaves/call.",
+      "notes": "Three chained fbm levels (q->r->s) + organicDrift pre-warp; mouse bias on zoom_config.w. Gate: naga OK, bindgroup compatible."
     },
     {
       "hop": 2,
@@ -28,7 +29,7 @@
       "owner": "unassigned",
       "chunk": "symmetry-fold",
       "prompt": "agents/swarm-tasks/prompts/relay-hop-2-symmetry.md",
-      "status": "blocked",
+      "status": "pending",
       "target": "Polar kaleidoscope fold on UV before field sample. N-fold via zoom_params or fixed 6-fold."
     },
     {

--- a/public/shaders/gen-relay-psychedelia.wgsl
+++ b/public/shaders/gen-relay-psychedelia.wgsl
@@ -118,11 +118,36 @@ fn motionModulate(time: f32, bass: f32, mids: f32) -> MotionState {
 // ═══ CHUNK: domain-warp (OWNER: hop-1) ═══════════════════════════════════════
 
 fn applyDomainWarp(p: vec2<f32>, time: f32, strength: f32) -> vec2<f32> {
-    // Spine: single-level warp. Hop 1: recursive fbm(p + fbm(p + fbm(p))).
-    let drift = organicDrift(p, time, 6.0) * strength;
-    let q = p + drift;
-    let field = fbm(q * 1.8 + vec2<f32>(time * 0.04, -time * 0.03), 3);
-    return q + vec2<f32>(field - 0.5, fbm(q * 2.1 - time * 0.02, 2) - 0.5) * strength * 0.35;
+    // OWNER: claude-hop-1 2026-07-19
+    // Recursive IQ-style domain warp: three chained fbm displacement levels
+    // (q -> r -> s), organicDrift kept as a slow pre-warp layer.
+    var pp = p + organicDrift(p, time, 6.0) * strength * 0.5;
+
+    // Optional mouse bias: pull the warp domain toward the cursor while held.
+    if (u.zoom_config.w > 0.5) {
+        let mouse = (u.zoom_config.yz - vec2<f32>(0.5)) * 2.0;
+        pp += (mouse - pp) * 0.18 * strength;
+    }
+
+    let flow = vec2<f32>(time * 0.05, -time * 0.04);
+
+    let q = vec2<f32>(
+        fbm(pp * 1.6 + flow, 4),
+        fbm(pp * 1.6 + vec2<f32>(5.2, 1.3) - flow, 4)
+    ) - vec2<f32>(0.5);
+
+    let r = vec2<f32>(
+        fbm(pp * 1.9 + q * 2.3 + vec2<f32>(1.7, 9.2) + flow * 1.4, 4),
+        fbm(pp * 1.9 + q * 2.3 + vec2<f32>(8.3, 2.8) - flow * 1.1, 4)
+    ) - vec2<f32>(0.5);
+
+    let s = vec2<f32>(
+        fbm(pp * 1.4 + r * 2.7 + vec2<f32>(6.9, 4.1) + flow * 0.7, 3),
+        fbm(pp * 1.4 + r * 2.7 + vec2<f32>(3.4, 7.7) - flow * 0.9, 3)
+    ) - vec2<f32>(0.5);
+
+    // Bounded: |q|,|r|,|s| <~ 0.5 each, so total offset <~ 2.1 * strength.
+    return pp + strength * (q * 0.7 + r * 1.2 + s * 1.6);
 }
 
 // ═══ CHUNK: symmetry-fold (OWNER: hop-2) ═════════════════════════════════════

--- a/reports/wgsl_precommit_report.json
+++ b/reports/wgsl_precommit_report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-07-19T08:32:29.508196",
+  "timestamp": "2026-07-19T06:37:21.302291",
   "naga_bin": "/root/.cargo/bin/naga",
   "naga_available": true,
   "total": 1,


### PR DESCRIPTION
## Summary
Runs hop 1 of the `gen-relay-psychedelia` relay (`agents/swarm-tasks/prompts/relay-hop-1-domain-warp.md`), editing only the `CHUNK: domain-warp` block per `agents/RELAY_PROTOCOL.md`.

- **`applyDomainWarp`** upgraded from the spine's single-level warp to a three-level Inigo Quilez-style recursive fbm chain (`q → r → s`), with `organicDrift` kept as a slow pre-warp layer.
- **Mouse bias**: while the pointer is held (`u.zoom_config.w > 0.5`), the warp domain is pulled toward the cursor, scaled by `strength`.
- **Bounded output**: each fbm level is centered (−0.5) so total offset stays within ~2.1 × strength; `strength` (Warp Depth) is respected, not bypassed.
- **Octave budget**: max 4 fbm octaves per call site (limit is 6).
- **Queue**: hop 1 → `completed` (owner `claude-hop-1`), hop 2 (symmetry-fold) → `pending`.

## Validation
```
python3 scripts/wgsl_precommit_gate.py --files public/shaders/gen-relay-psychedelia.wgsl
✅ naga OK, bindgroup compatible
```
`node scripts/generate_shader_lists.js` re-run (no catalog changes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7TwoqxoD8sXE462HAb5z7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7TwoqxoD8sXE462HAb5z7)_