### PR TITLE
Relay hop-2: polar kaleidoscope symmetry fold

### DIFF
--- a/agents/swarm-tasks/prompts/relay-hop-2-symmetry.md
+++ b/agents/swarm-tasks/prompts/relay-hop-2-symmetry.md
@@ -1,0 +1,62 @@
+# Relay Hop 2 — Symmetry Fold (`gen-relay-psychedelia`)
+
+## Metadata
+- **Shader ID**: gen-relay-psychedelia
+- **Hop**: 2
+- **CHUNK**: `symmetry-fold`
+- **Agent Role**: Symmetry / Kaleidoscope Specialist
+- **Status**: completed (cursor-hop-2 2026-07-19)
+- **Protocol**: [`agents/RELAY_PROTOCOL.md`](../../RELAY_PROTOCOL.md)
+
+## Immutable Rules
+1. Edit **only** `applySymmetry` inside the `CHUNK: symmetry-fold` block.
+2. Do NOT modify bindings, `Uniforms`, `main()`, utilities, or other CHUNKs.
+3. Function signature stays: `fn applySymmetry(p: vec2<f32>) -> vec2<f32>`
+4. **No RGB** — return folded `vec2<f32>` coordinates only.
+5. Return bounded coordinates — polar fold preserves radius; avoid post-fold scaling blowups.
+6. Run gate before marking complete:
+   ```bash
+   python3 scripts/wgsl_precommit_gate.py --files public/shaders/gen-relay-psychedelia.wgsl
+   ```
+
+## Task
+
+Apply a **polar kaleidoscope fold** on warped UV before `sampleField`:
+
+```
+p → slow time rotation → optional mouse-center offset → N-fold polar mirror → return
+```
+
+Goals:
+- Fixed **6-fold** mandala symmetry (hexagonal kaleidoscope)
+- Slow time spin so the fold pattern breathes (`u.config.x`)
+- Optional mouse bias: shift fold origin toward `(u.zoom_config.yz - 0.5) * 2` when `u.zoom_config.w > 0.5`
+- Visible improvement over spine identity at default params
+- Do **not** steal `zoom_params` — those belong to warp / palette / feedback hops
+
+## Reference pattern (from `mouse-kaleidoscope-tunnel.wgsl`)
+
+```wgsl
+fn kaleidoscope(uv: vec2<f32>, segments: f32) -> vec2<f32> {
+  let angle = atan2(uv.y, uv.x);
+  let radius = length(uv);
+  let segmentAngle = TAU / segments;
+  let mirroredAngle = abs(fract(angle / segmentAngle + 0.5) - 0.5) * segmentAngle;
+  return vec2<f32>(cos(mirroredAngle), sin(mirroredAngle)) * radius;
+}
+```
+
+## Current CHUNK (replace body only)
+
+```wgsl
+fn applySymmetry(p: vec2<f32>) -> vec2<f32> {
+    // Spine: identity. Hop 2: polar/kaleidoscope fold before field sampling.
+    return p;
+}
+```
+
+## On completion
+
+1. Add comment: `// OWNER: <agent> <date>`
+2. Set `relay-queue.json` hop 2 `status` → `completed`, hop 3 → `pending`
+3. Do not touch hop 3+ chunks

--- a/agents/swarm-tasks/relay-queue.json
+++ b/agents/swarm-tasks/relay-queue.json
@@ -26,11 +26,12 @@
     {
       "hop": 2,
       "name": "symmetry-fold",
-      "owner": "unassigned",
+      "owner": "cursor-hop-2",
       "chunk": "symmetry-fold",
       "prompt": "agents/swarm-tasks/prompts/relay-hop-2-symmetry.md",
-      "status": "pending",
-      "target": "Polar kaleidoscope fold on UV before field sample. N-fold via zoom_params or fixed 6-fold."
+      "status": "completed",
+      "target": "Polar kaleidoscope fold on UV before field sample. N-fold via zoom_params or fixed 6-fold.",
+      "notes": "6-fold polar kaleidoscope; slow time spin; mouse-centers fold origin when held. No zoom_params stolen."
     },
     {
       "hop": 3,
@@ -38,7 +39,7 @@
       "owner": "unassigned",
       "chunk": "palette",
       "prompt": "agents/swarm-tasks/prompts/relay-hop-3-palette.md",
-      "status": "blocked",
+      "status": "pending",
       "target": "IQ cosine palette or enhanced psychedelicPalette. Only chunk that assigns RGB."
     },
     {

--- a/public/shaders/gen-relay-psychedelia.wgsl
+++ b/public/shaders/gen-relay-psychedelia.wgsl
@@ -153,8 +153,28 @@ fn applyDomainWarp(p: vec2<f32>, time: f32, strength: f32) -> vec2<f32> {
 // ═══ CHUNK: symmetry-fold (OWNER: hop-2) ═════════════════════════════════════
 
 fn applySymmetry(p: vec2<f32>) -> vec2<f32> {
-    // Spine: identity. Hop 2: polar/kaleidoscope fold before field sampling.
-    return p;
+    // OWNER: cursor-hop-2 2026-07-19
+    // Polar kaleidoscope fold: fixed 6-fold mandala, slow time spin, mouse-centers when held.
+    var q = p;
+
+    // Slow pre-rotation so the fold breathes instead of locking static.
+    let spin = u.config.x * 0.04;
+    let cs = cos(spin);
+    let sn = sin(spin);
+    q = vec2<f32>(cs * q.x - sn * q.y, sn * q.x + cs * q.y);
+
+    // Pull fold origin toward cursor while mouse is held (no zoom_params steal).
+    if (u.zoom_config.w > 0.5) {
+        let mouse = (u.zoom_config.yz - vec2<f32>(0.5)) * 2.0;
+        q -= mouse * 0.35;
+    }
+
+    let segments: f32 = 6.0;
+    let angle = atan2(q.y, q.x);
+    let radius = length(q);
+    let segmentAngle = TAU / segments;
+    let mirroredAngle = abs(fract(angle / segmentAngle + 0.5) - 0.5) * segmentAngle;
+    return vec2<f32>(cos(mirroredAngle), sin(mirroredAngle)) * radius;
 }
 
 // ═══ CHUNK: palette (OWNER: hop-3) — sole RGB assignment site ══════════════


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **relay hop 2** (`symmetry-fold`) for `gen-relay-psychedelia`:

- **`applySymmetry`**: fixed 6-fold polar kaleidoscope mirror on warped UV before field sampling
- Slow time rotation so the mandala breathes instead of locking static
- Mouse-held bias shifts fold origin toward cursor (uses `zoom_config`, does not steal `zoom_params`)
- Adds missing `relay-hop-2-symmetry.md` prompt file
- Updates `relay-queue.json`: hop 2 → `completed`, hop 3 (palette) → `pending`

## Validation

```bash
python3 scripts/wgsl_precommit_gate.py --files public/shaders/gen-relay-psychedelia.wgsl
```

Gate passes (bindgroup compatible; naga skipped in VM).

## Protocol compliance

- Only `applySymmetry` modified in WGSL
- Returns `vec2<f32>` — no RGB introduced
- Pipeline order unchanged: `aspectUv → domainWarp → symmetry → sampleField → palette → feedback → composite`

## Next hop

Hop 3 (`palette`) — IQ cosine palette or enhanced `psychedelicPalette` in `sampleField` / `applyPalette` only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6413446d-f198-40cb-993d-8972173455cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6413446d-f198-40cb-993d-8972173455cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a six-fold kaleidoscope symmetry effect to the psychedelic shader.
  * Introduced time-based motion and optional cursor-centered bias for more dynamic visuals.

* **Chores**
  * Advanced the relay workflow by marking the symmetry stage complete and the palette stage ready to begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->