### PR TITLE
feat: implement Prismatic Cyber-Aether Void-Kitsune generative shader

### DIFF
--- a/.shader_sync_manifest.json
+++ b/.shader_sync_manifest.json
@@ -28,8 +28,8 @@
     "synced_at": 1783584367.1892974
   },
   "pixel-depth-sort": {
-    "hash": "d83927bcef2d74b44fd8b50cd4452a50",
-    "synced_at": 1784275279.664035
+    "hash": "0708a6e17e382778aefecb4ce608c8a5",
+    "synced_at": 1784620130.2383404
   },
   "temporal-feedback-zoom-tracer": {
     "hash": "4cb0a7e010ad45ad73a4f8f3490ed365",
@@ -40,8 +40,8 @@
     "synced_at": 1783584367.2281792
   },
   "luma-pixel-sort": {
-    "hash": "5c33a6abecbd97d0860366c4caaa8998",
-    "synced_at": 1784275279.569316
+    "hash": "b72e04b3861f69ed03de1b7f75140906",
+    "synced_at": 1784620130.231371
   },
   "pp-tone-map": {
     "hash": "8d3f1c5d10ba21fb7b07a0d557f9b546",
@@ -1632,8 +1632,8 @@
     "synced_at": 1783584630.2484353
   },
   "chromatographic-separation": {
-    "hash": "4fa7cf6729db1080757ca66e1a2face4",
-    "synced_at": 1783584630.3563197
+    "hash": "d56d66ae1b371e7a544f9bcda8096e9b",
+    "synced_at": 1784620130.5171804
   },
   "astral-kaleidoscope": {
     "hash": "11ebbab3fe2e201f241c8df3ef4b7818",
@@ -2024,8 +2024,8 @@
     "synced_at": 1783584647.6492217
   },
   "cross-mouse-spec-dispersion-lens": {
-    "hash": "c54fe5169c6d349493b652ed565d959a",
-    "synced_at": 1783584647.759976
+    "hash": "9798c2ddaef61cd16f89cebca41043e7",
+    "synced_at": 1784620130.5527275
   },
   "luma-magnetism": {
     "hash": "6bf71a49c4bd440ee2710bc739d514b0",
@@ -2176,8 +2176,8 @@
     "synced_at": 1783584651.7944896
   },
   "prismatic-3d-compositor": {
-    "hash": "6dcc3b9cf30581f7d662778ea1113ce8",
-    "synced_at": 1783584651.8139908
+    "hash": "b2a3511dd8c94ef659c06741a15c3d52",
+    "synced_at": 1784620130.6853778
   },
   "directional-glitch": {
     "hash": "7d2196b5ed4b0e5f9a019ef8e2df784c",
@@ -2208,8 +2208,8 @@
     "synced_at": 1783584652.6527886
   },
   "flux-core": {
-    "hash": "407d78bf7dae90a4a0b88215f3b0c5e6",
-    "synced_at": 1783584652.7515411
+    "hash": "3bbc44b1a395d4b331c720ae155e479a",
+    "synced_at": 1784620130.6855245
   },
   "kinetic-dispersion": {
     "hash": "7b1c6bb752a275cdb5785cbe1c490e1f",
@@ -2256,8 +2256,8 @@
     "synced_at": 1783584654.0706673
   },
   "voronoi-light": {
-    "hash": "a330dfb504f7db2388e1f1716eeca536",
-    "synced_at": 1783584654.2950284
+    "hash": "d7d3094e37cb787a756f5ff0a6c5d435",
+    "synced_at": 1784620130.6908116
   },
   "sonar-pulse": {
     "hash": "2bd1ce01f226425553b9eea42155a238",
@@ -2364,8 +2364,8 @@
     "synced_at": 1783584692.568842
   },
   "quantum-superposition": {
-    "hash": "30d67296373c415e85c1d12746f62f28",
-    "synced_at": 1783584692.780351
+    "hash": "13d5d73f6513cfd3633832124e6cae08",
+    "synced_at": 1784620130.9331884
   },
   "glass-bead-curtain": {
     "hash": "c6de81ef6023d6827301330531fb682a",
@@ -2420,16 +2420,16 @@
     "synced_at": 1783584694.4963646
   },
   "rgb-ripple-waves": {
-    "hash": "1ac121e2c9e066cbdc13365dd1f4f1db",
-    "synced_at": 1783584694.654169
+    "hash": "86cd2757fe9a818f54fe4cc99e6965a1",
+    "synced_at": 1784620130.9743724
   },
   "data-slicer-interactive": {
-    "hash": "e6cce38106cce9e42bdc63519242406b",
-    "synced_at": 1784275372.0381677
+    "hash": "9a894083ac4d6ba9e68fca0842b3e2a2",
+    "synced_at": 1784620131.2651849
   },
   "rainbow-vector-field": {
-    "hash": "fe6183227075bf926c31bb25600c4772",
-    "synced_at": 1783584694.9000747
+    "hash": "480739a3391b9c6b368c1dae47ba5898",
+    "synced_at": 1784620131.1522248
   },
   "vhs-tracking-mouse": {
     "hash": "19b3d65b53efefb250abd931cd33487a",
@@ -2504,8 +2504,8 @@
     "synced_at": 1784275400.6521513
   },
   "slinky-distort": {
-    "hash": "8b88bf7d3b7c7da389682a0899968aa4",
-    "synced_at": 1783584697.9333794
+    "hash": "c4c77952f847f1495cb25f16384e7ebe",
+    "synced_at": 1784620131.1563585
   },
   "mirror-drag": {
     "hash": "d80ed4334ac0754abf0cad11536d8115",
@@ -2692,8 +2692,8 @@
     "synced_at": 1784275404.7434947
   },
   "strip-scan-glitch": {
-    "hash": "1b74cda540b6c44be886fce5e15dea96",
-    "synced_at": 1783584704.9732306
+    "hash": "c45a661a3e4f415e6d3768de1fe8c514",
+    "synced_at": 1784620131.3579764
   },
   "codebreaker-reveal": {
     "hash": "a64af4720fe678489912d188236c1632",
@@ -2768,8 +2768,8 @@
     "synced_at": 1783584707.0968792
   },
   "interactive-magnetic-ripple": {
-    "hash": "b1e6ba444b068b875d3c592a743f3c12",
-    "synced_at": 1784275398.6702619
+    "hash": "cadca0aa2a65c46921032b450f2ce02e",
+    "synced_at": 1784620131.5182302
   },
   "mouse-synesthetic-sound-paint": {
     "hash": "82e05f671a5b05ba4ece9b421f3c02c7",
@@ -2820,8 +2820,8 @@
     "synced_at": 1783584708.4118733
   },
   "venetian-blinds": {
-    "hash": "59eae4eab24147697f0d8ee80e608057",
-    "synced_at": 1783584708.5175683
+    "hash": "70325deda8fd7d05b2a08e0085122b81",
+    "synced_at": 1784620131.5813227
   },
   "magnetic-pixels": {
     "hash": "b246f7730051b4ee4678a7d4ad3d4671",
@@ -2880,8 +2880,8 @@
     "synced_at": 1783584711.7091472
   },
   "pixel-stretch-cross": {
-    "hash": "2b9f26b450058b3319495f586d217194",
-    "synced_at": 1784275386.2913978
+    "hash": "fd1efb138018e64159a050e42c650e02",
+    "synced_at": 1784620131.7149477
   },
   "cyber-organic": {
     "hash": "6f1868aedb0fd232186da87788436c5a",
@@ -3316,8 +3316,8 @@
     "synced_at": 1783584747.7731788
   },
   "cross-conv-mouse-bilateral": {
-    "hash": "5dea225970459d0e32a698b0b291a897",
-    "synced_at": 1783584748.1985502
+    "hash": "e5859722a5294bdcdd5658991ec18319",
+    "synced_at": 1784620131.9305747
   },
   "heat-haze-mirage": {
     "hash": "eb37ec4a7f1d04c94975aae96fdeae58",
@@ -3660,8 +3660,8 @@
     "synced_at": 1783471049.059257
   },
   "cross-spec-alpha-spectral-bloom": {
-    "hash": "d712f7ddec7a8109fa185f540517daa1",
-    "synced_at": 1783471049.4720178
+    "hash": "d33ba6f30c258195475c7721146d9025",
+    "synced_at": 1784620131.9866722
   },
   "interactive-fresnel": {
     "hash": "26a04573e43a9397d2dd78876f928bf9",
@@ -3680,8 +3680,8 @@
     "synced_at": 1783471051.1204824
   },
   "elastic-chromatic": {
-    "hash": "fc3271dd93631dac50a6fa338eb4d3d0",
-    "synced_at": 1784275393.9035242
+    "hash": "75cadcb4e09bff4ef86ff34aa3f2b0c0",
+    "synced_at": 1784620132.2158983
   },
   "alpha-spectral-decompose": {
     "hash": "f7eaa1b26ee73257f6180cd2dfe99e38",
@@ -3720,8 +3720,8 @@
     "synced_at": 1783471055.2644267
   },
   "temporal-rgb-smear": {
-    "hash": "ac5af738b19d161cf59be0ea34220714",
-    "synced_at": 1784275410.3869374
+    "hash": "e57d905d9f84940d113b3bc70c76be66",
+    "synced_at": 1784620132.2491367
   },
   "interactive-pcb-traces": {
     "hash": "c0246d61e84c0f76ede2f022424fcf5b",
@@ -3796,16 +3796,16 @@
     "synced_at": 1783471063.0589855
   },
   "liquid-glitch": {
-    "hash": "a9bc840d9aae0c6992d8da7aacc993c2",
-    "synced_at": 1783471063.4704869
+    "hash": "e351ba345fe3261f63c4648dc14315d0",
+    "synced_at": 1784620132.1882386
   },
   "liquid-optimized-pass1": {
     "hash": "04ac7d0b25fa1102132d5bd3b8bd6a98",
     "synced_at": 1783471063.8804412
   },
   "liquid-jelly": {
-    "hash": "45c29d5f7a3af4dc5978e1fbbc0def76",
-    "synced_at": 1783471064.2933073
+    "hash": "53541a118f9c5a59fec54c9e418ec03b",
+    "synced_at": 1784620132.3493297
   },
   "viscous-drag": {
     "hash": "d816ae8c690e61ddcb0c1bed34349d9f",
@@ -3832,20 +3832,20 @@
     "synced_at": 1783471066.767683
   },
   "liquid-perspective": {
-    "hash": "ffb2e8f272e15017cc2e74ea6be2b913",
-    "synced_at": 1783471067.1807172
+    "hash": "505f3493e6aec6d32b936b54d9c34f21",
+    "synced_at": 1784620132.3919427
   },
   "liquid-displacement": {
     "hash": "48486f32dffd469e91b96f9231a48fa7",
     "synced_at": 1783471067.594163
   },
   "liquid-viscous-grokcf1": {
-    "hash": "87668ad25d2a9e4ff83208fd9c5801cd",
-    "synced_at": 1783471068.004984
+    "hash": "4b8a8f12a104dc6c0ba9c618533cf892",
+    "synced_at": 1784620132.6057968
   },
   "liquid-rainbow": {
-    "hash": "13e618e0c05133bdef9a78da2e1ec619",
-    "synced_at": 1783471068.4176137
+    "hash": "96e2f0cb63fd0ea23cc4db710597ae7b",
+    "synced_at": 1784620132.6424327
   },
   "ink-marbling": {
     "hash": "30ac51c0663fd44fcefbadb3b84ce556",
@@ -3872,8 +3872,8 @@
     "synced_at": 1783471070.8627224
   },
   "liquid-rgb": {
-    "hash": "0cdbf5248fdd77eb250f71b145c68a5f",
-    "synced_at": 1783471071.2941651
+    "hash": "5c3d82c06481f370b41ef10e164af354",
+    "synced_at": 1784620132.667382
   },
   "liquid-tensor-vortex": {
     "hash": "79a904569afd183eed461ad13eec5494",
@@ -3888,12 +3888,12 @@
     "synced_at": 1783471072.576783
   },
   "liquid-fast": {
-    "hash": "918593e30a2dc2d468bd8a3825b377e5",
-    "synced_at": 1783471073.0115573
+    "hash": "c33c0fc204a117893d409b78741b76e2",
+    "synced_at": 1784620198.1767685
   },
   "liquid-viscous-simple": {
-    "hash": "a486edde0ceff75c72b1a09c0c75ca85",
-    "synced_at": 1783471073.4452772
+    "hash": "514fa7efe324795dc6d5a6f81bef25d8",
+    "synced_at": 1784620194.924359
   },
   "glass-wipes": {
     "hash": "5af84f2bb4e5588cc3d45fb6b3f891bd",
@@ -3984,8 +3984,8 @@
     "synced_at": 1783471082.5600207
   },
   "bitonic-sort": {
-    "hash": "bae10a4da10ce2fd574fcdaa61d5bcc5",
-    "synced_at": 1784275397.7925704
+    "hash": "6132c1764a145e8d3124054195fa9965",
+    "synced_at": 1784620195.1615734
   },
   "split-flap-display": {
     "hash": "e479cb0aca264444ab5d27fe9b126ede",
@@ -4092,8 +4092,8 @@
     "synced_at": 1783471093.6180682
   },
   "lens-flare-brush": {
-    "hash": "a10c5a5f22028d7245a43c30aba5db80",
-    "synced_at": 1783471094.0267482
+    "hash": "452380904989ae14968f58fdb4ae1697",
+    "synced_at": 1784620185.1597645
   },
   "underwater_caustics": {
     "hash": "8c8eebe511f79b0f134273036d3b2b4a",
@@ -4112,8 +4112,8 @@
     "synced_at": 1783471095.6808224
   },
   "divine-light": {
-    "hash": "458b6ab57c2690ce66eafb41209c62ec",
-    "synced_at": 1783471096.0940845
+    "hash": "27b3fcec12fdd9ecc1e29810720088c0",
+    "synced_at": 1784620185.1304014
   },
   "neon-pulse-edge": {
     "hash": "79121c663b15eb14025984a07b75827e",
@@ -4276,8 +4276,8 @@
     "synced_at": 1783471112.644696
   },
   "hyb-hex-voronoi-distort": {
-    "hash": "17151bc481483cd6a4204ecd85c092dd",
-    "synced_at": 1783471113.0526948
+    "hash": "0666e0548acaa0e6bc1971b955c04341",
+    "synced_at": 1784620185.5516474
   },
   "hybrid-magnetic-field": {
     "hash": "480a40140e523ed963c557da9792906a",
@@ -4340,8 +4340,8 @@
     "synced_at": 1783471119.1901546
   },
   "parallax-shift": {
-    "hash": "25a045cc5c3c34a00bbfcea4bf72c6a2",
-    "synced_at": 1783471119.59876
+    "hash": "5e3fbda3e504087a4d73531fc5dd0d7c",
+    "synced_at": 1784620221.3686266
   },
   "gen-chromatic-vortex": {
     "hash": "ae8148bdd1f87623537064337a26785f",
@@ -4844,8 +4844,8 @@
     "synced_at": 1783842800.2585526
   },
   "interactive-rgb-split-explosion": {
-    "hash": "e946d4d0c8d74e2c3dfaba8dd8120210",
-    "synced_at": 1783842800.6762338
+    "hash": "719082f030895376ad129744fb849df9",
+    "synced_at": 1784620131.679097
   },
   "ethereal-swirl-coupled": {
     "hash": "c7bfb1e96d72effb276b42a74c12b936",
@@ -4868,8 +4868,8 @@
     "synced_at": 1783842814.170933
   },
   "chroma-depth-tunnel-prismatic": {
-    "hash": "2c20859773aef919a0af494a1cae0191",
-    "synced_at": 1783842814.5950363
+    "hash": "e8eb05d09c180bc04b3cffab0cfb2af0",
+    "synced_at": 1784620131.774538
   },
   "spectral-bleed-confine": {
     "hash": "9992466c0d459acd6b7426d2ebb4dbb3",
@@ -5028,8 +5028,8 @@
     "synced_at": 1784448572.6988556
   },
   "gen-luminescent-chrono-prism-astro-stag": {
-    "hash": "96cc7258bd8462d15773cb0d54cc3175",
-    "synced_at": 1784275276.8752236
+    "hash": "77ca110fa9ba7725aa6dbb41112b03c6",
+    "synced_at": 1784620130.0962603
   },
   "gen-fireworks-dahlia-burst": {
     "hash": "c80064a9188e2d2f415e0a2f899a9b59",
@@ -5072,7 +5072,11 @@
     "synced_at": 1784448699.1209042
   },
   "gen-bioluminescent-chrono-plasma-astro-owl": {
-    "hash": "c519e1b780fe0b3c32bad60a9af11ed0",
-    "synced_at": 1784545735.171545
+    "hash": "206fef75be7f32cc69997e0853855adc",
+    "synced_at": 1784620130.1295793
+  },
+  "gen-prismatic-cyber-aether-void-kitsune": {
+    "hash": "76c8eccec23a60009deefe38e29b59ad",
+    "synced_at": 1784620130.2266104
   }
 }

--- a/public/shader-lists/advanced-hybrid.json
+++ b/public/shader-lists/advanced-hybrid.json
@@ -2,7 +2,7 @@
   {
     "id": "aero-chromatics-prismatic",
     "name": "Aero Chromatics Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aero-chromatics-prismatic.wgsl",
+    "url": "shaders/aero-chromatics-prismatic.wgsl",
     "description": "Wind-driven chromatic smoke trails enhanced with physical prismatic dispersion via Cauchy's equation. Each wavelength refracts at a different angle through a virtual lens, creating rainbow edge effects on advected smoke.",
     "tags": [
       "prismatic",
@@ -58,7 +58,7 @@
   {
     "id": "aerogel-smoke-hdr",
     "name": "Aerogel Smoke HDR",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aerogel-smoke-hdr.wgsl",
+    "url": "shaders/aerogel-smoke-hdr.wgsl",
     "description": "Ethereal aerogel volumetric smoke with HDR bloom enhancement. Silica nanoparticle scattering combines with an HDR bloom kernel that amplifies overbright regions, creating luminous glow around dense scattering zones.",
     "tags": [
       "volumetric",
@@ -114,7 +114,7 @@
   {
     "id": "alucinate-hdr",
     "name": "Alucinate HDR",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alucinate-hdr.wgsl",
+    "url": "shaders/alucinate-hdr.wgsl",
     "category": "advanced-hybrid",
     "description": "When Alucinate (AI VJ) mode is active, this serves as a visual 'conductor's baton' — elegant, minimal music-reactive glyphs and a living spectrogram that represent the current vibe stack. The psychedelic warp + HDR bloom provides a rich atmospheric underlayer. Mouse acts as the conductor's hand.",
     "features": [
@@ -181,7 +181,7 @@
   {
     "id": "ambient-liquid-coupled",
     "name": "Ambient Liquid Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ambient-liquid-coupled.wgsl",
+    "url": "shaders/ambient-liquid-coupled.wgsl",
     "category": "advanced-hybrid",
     "description": "Two viscous liquid layers coupled through a living membrane. Mouse presses like a finger into the surface, creating tears that slowly heal. Bass increases surface tension, making deformations more dramatic and persistent.",
     "features": [
@@ -245,7 +245,7 @@
   {
     "id": "anamorphic-flare-iridescence",
     "name": "Anamorphic Flare Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/anamorphic-flare-iridescence.wgsl",
+    "url": "shaders/anamorphic-flare-iridescence.wgsl",
     "description": "Anamorphic Flare Iridescence",
     "tags": [
       "lens-flare",
@@ -304,7 +304,7 @@
   {
     "id": "anisotropic-kuwahara-nlm",
     "name": "Anisotropic Kuwahara + NLM",
-    "url": "https://test.1ink.us/image_video_effects/shaders/anisotropic-kuwahara-nlm.wgsl",
+    "url": "shaders/anisotropic-kuwahara-nlm.wgsl",
     "description": "Painterly anisotropic Kuwahara filter enhanced with Non-Local Means patch-similarity denoising. Structure tensor guides brush stroke direction while NLM preserves edges and creates an importance map.",
     "tags": [
       "painterly",
@@ -361,7 +361,7 @@
   {
     "id": "ascii-flow-structure",
     "name": "ASCII Flow + Structure Tensor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ascii-flow-structure.wgsl",
+    "url": "shaders/ascii-flow-structure.wgsl",
     "description": "ASCII glyph rendering driven by structure tensor flow field. Glyphs align with image edges and orientations instead of random noise. Line Integral Convolution modulates brightness.",
     "tags": [
       "ascii",
@@ -417,7 +417,7 @@
   {
     "id": "astral-kaleidoscope-julia",
     "name": "Astral Kaleidoscope Julia",
-    "url": "https://test.1ink.us/image_video_effects/shaders/astral-kaleidoscope-julia.wgsl",
+    "url": "shaders/astral-kaleidoscope-julia.wgsl",
     "description": "Astral Kaleidoscope Julia",
     "tags": [
       "kaleidoscope",
@@ -474,7 +474,7 @@
   {
     "id": "astral-kaleidoscope-morph",
     "name": "Astral Kaleidoscope + Morphological",
-    "url": "https://test.1ink.us/image_video_effects/shaders/astral-kaleidoscope-morph.wgsl",
+    "url": "shaders/astral-kaleidoscope-morph.wgsl",
     "description": "Psychedelic kaleidoscope with chromatic separation enhanced by morphological erosion/dilation operations. Morphological gradient creates glowing halos around segments, top-hat transform isolates bright sparkles.",
     "tags": [
       "kaleidoscope",
@@ -532,7 +532,7 @@
   {
     "id": "atmos-fog-volumetric",
     "name": "Atmospheric Fog Volumetric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/atmos-fog-volumetric.wgsl",
+    "url": "shaders/atmos-fog-volumetric.wgsl",
     "description": "Enhanced volumetric fog combining physical transmittance with interactive depth-layered alpha. Mouse clears fog locally, ripples create swirling disturbances, and height-based density mixes with Beer's Law for atmospheric realism.",
     "tags": [
       "volumetric",
@@ -589,7 +589,7 @@
   {
     "id": "audio-voronoi-displacement",
     "name": "Audio Voronoi Displacement",
-    "url": "https://test.1ink.us/image_video_effects/shaders/audio-voronoi-displacement.wgsl",
+    "url": "shaders/audio-voronoi-displacement.wgsl",
     "description": "Audio-reactive Voronoi cells that displace the image. Image fractured into cells that pulse with music.",
     "features": [
       "mouse-driven",
@@ -663,7 +663,7 @@
   {
     "id": "audio-voronoi-gabor",
     "name": "Audio Voronoi Gabor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/audio-voronoi-gabor.wgsl",
+    "url": "shaders/audio-voronoi-gabor.wgsl",
     "description": "Audio-reactive Voronoi displacement modulated by Gabor texture analysis. Gabor filter banks detect local texture orientation and strength, rotating and scaling cell displacement. Edges and textured regions displace differently than smooth areas.",
     "features": [
       "audio-reactive",
@@ -739,7 +739,7 @@
   {
     "id": "aurora-borealis-iridescence",
     "name": "Aurora Borealis Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-borealis-iridescence.wgsl",
+    "url": "shaders/aurora-borealis-iridescence.wgsl",
     "description": "Northern lights with flowing ribbon curves enhanced by thin-film iridescence. Each aurora ribbon shimmers with soap-bubble and oil-slick interference colors driven by ribbon intensity and animated turbulence.",
     "tags": [
       "aurora",
@@ -796,7 +796,7 @@
   {
     "id": "aurora-rift-2-iridescence",
     "name": "Aurora Rift 2 Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-2-iridescence.wgsl",
+    "url": "shaders/aurora-rift-2-iridescence.wgsl",
     "description": "Iridescent aurora curtains combining volumetric aurora simulation with thin-film interference. Each aurora layer gets soap-bubble/oil-slick coloring from optical path difference. Optical depth modulates film thickness; viewing angle drives color shift. Beer's Law transmittance composites physically.",
     "features": [
       "thin-film-interference",
@@ -871,7 +871,7 @@
   {
     "id": "aurora-rift-iridescence",
     "name": "Aurora Rift Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-iridescence.wgsl",
+    "url": "shaders/aurora-rift-iridescence.wgsl",
     "description": "Atmospheric curl-flow aurora blended with thin-film interference. Pattern density drives soap-bubble and oil-slick film thickness, producing flowing iridescence that rides the aurora's organic motion.",
     "tags": [
       "iridescence",
@@ -929,7 +929,7 @@
   {
     "id": "bio-lenia-rgba",
     "name": "Bio Lenia RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bio-lenia-rgba.wgsl",
+    "url": "shaders/bio-lenia-rgba.wgsl",
     "description": "Four-species continuous cellular automata with Lenia-style smooth growth functions applied to each RGBA channel. Combines reaction-diffusion chemistry with biological emergence patterns. Cross-inhibition between species pairs creates complex multi-color morphologies.",
     "tags": [
       "lenia",
@@ -986,7 +986,7 @@
   {
     "id": "bio-touch-em",
     "name": "Bio Touch EM",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bio-touch-em.wgsl",
+    "url": "shaders/bio-touch-em.wgsl",
     "description": "Bio-luminescent cellular structures distorted by electromagnetic field lines. Magnetic field rotates cell glow colors. Click ripples spawn orbiting secondary charges.",
     "features": [
       "mouse-driven",
@@ -1035,7 +1035,7 @@
   {
     "id": "bioluminescent-blackbody",
     "name": "Bioluminescent Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bioluminescent-blackbody.wgsl",
+    "url": "shaders/bioluminescent-blackbody.wgsl",
     "description": "Living organic growth patterns with physically-correct thermal coloring. Growth energy maps to blackbody temperature — cooler regions glow deep red, active growth burns orange-yellow, and intense hotspots reach white-hot temperatures.",
     "tags": [
       "bioluminescent",
@@ -1092,7 +1092,7 @@
   {
     "id": "bismuth-crystal-growth",
     "name": "Bismuth Crystal Growth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bismuth-crystal-growth.wgsl",
+    "url": "shaders/bismuth-crystal-growth.wgsl",
     "description": "Bismuth Crystal Growth",
     "tags": [
       "phase-field-crystal",
@@ -1147,7 +1147,7 @@
   {
     "id": "black-hole-iridescence",
     "name": "Black Hole Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/black-hole-iridescence.wgsl",
+    "url": "shaders/black-hole-iridescence.wgsl",
     "description": "Gravitational lensing black hole with iridescent accretion disk. The warped background and glowing disk receive thin-film interference coloring based on viewing angle, producing soap-bubble chromatic effects around the event horizon.",
     "tags": [
       "black-hole",
@@ -1203,7 +1203,7 @@
   {
     "id": "block-distort-em",
     "name": "Block Distort EM",
-    "url": "https://test.1ink.us/image_video_effects/shaders/block-distort-em.wgsl",
+    "url": "shaders/block-distort-em.wgsl",
     "description": "Grid blocks pushed by mouse proximity, distorted by electromagnetic field lines. Electric field displaces UVs, magnetic field rotates hue. Click ripples spawn orbiting secondary charges.",
     "features": [
       "mouse-driven",
@@ -1252,7 +1252,7 @@
   {
     "id": "blueprint-reveal-guided",
     "name": "Blueprint Reveal + Guided Filter",
-    "url": "https://test.1ink.us/image_video_effects/shaders/blueprint-reveal-guided.wgsl",
+    "url": "shaders/blueprint-reveal-guided.wgsl",
     "description": "Blueprint effect with depth-guided edge-aware filtering. The guided filter smooths the image using depth as guide before Sobel edge detection, creating blueprint lines that respect true object boundaries.",
     "tags": [
       "blueprint",
@@ -1307,7 +1307,7 @@
   {
     "id": "boids-rgba-ecosystem",
     "name": "Boids RGBA Ecosystem",
-    "url": "https://test.1ink.us/image_video_effects/shaders/boids-rgba-ecosystem.wgsl",
+    "url": "shaders/boids-rgba-ecosystem.wgsl",
     "description": "Boids-inspired flow-field flocking combined with continuous multi-species ecosystem simulation. RGBA channels store species densities that advect, flock, and compete. Species 1 (flockers) and Species 2 (predators) consume resources, produce toxins, and exhibit emergent flocking behavior through neighborhood vector fields.",
     "tags": [
       "boids",
@@ -1364,7 +1364,7 @@
   {
     "id": "breathing-kaleidoscope-morph",
     "name": "Breathing Kaleidoscope Morph",
-    "url": "https://test.1ink.us/image_video_effects/shaders/breathing-kaleidoscope-morph.wgsl",
+    "url": "shaders/breathing-kaleidoscope-morph.wgsl",
     "description": "Breathing Kaleidoscope Morph",
     "tags": [
       "kaleidoscope",
@@ -1423,7 +1423,7 @@
   {
     "id": "bubble-lens-coupled",
     "name": "Bubble Lens Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bubble-lens-coupled.wgsl",
+    "url": "shaders/bubble-lens-coupled.wgsl",
     "description": "Magnifying bubble lens warped by fluid dynamics. Mouse movement drags viscous fluid that distorts the lens boundary and creates vortices inside. Click ripples create fluid bursts.",
     "features": [
       "mouse-driven",
@@ -1472,7 +1472,7 @@
   {
     "id": "byte-mosh-explosion",
     "name": "Byte Mosh Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/byte-mosh-explosion.wgsl",
+    "url": "shaders/byte-mosh-explosion.wgsl",
     "description": "Bitwise pixel corruption meets chromatic prism explosion. XOR, AND, shift and rotate operations are applied to spectrally displaced channels radiating from mouse and ripple shockwaves.",
     "features": [
       "advanced-hybrid",
@@ -1543,7 +1543,7 @@
   {
     "id": "cellular-automata-3d",
     "name": "Cellular Automata 3D",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cellular-automata-3d.wgsl",
+    "url": "shaders/cellular-automata-3d.wgsl",
     "description": "3D Game of Life rendered with volume raymarching. Glowing 3D structures that evolve frame-by-frame.",
     "features": [
       "advanced-hybrid",
@@ -1615,7 +1615,7 @@
   {
     "id": "charcoal-rub-diffusion",
     "name": "Charcoal Rub + Anisotropic Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/charcoal-rub-diffusion.wgsl",
+    "url": "shaders/charcoal-rub-diffusion.wgsl",
     "description": "Physical charcoal media simulation with Perona-Malik anisotropic diffusion preprocessing. Diffusion creates smooth tonal regions before charcoal conversion, with diffusion coefficient modulating charcoal density.",
     "tags": [
       "charcoal",
@@ -1671,7 +1671,7 @@
   {
     "id": "chroma-depth-tunnel-prismatic",
     "name": "Chroma Depth Tunnel Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-depth-tunnel-prismatic.wgsl",
+    "url": "shaders/chroma-depth-tunnel-prismatic.wgsl",
     "description": "Chroma Depth Tunnel Prismatic",
     "tags": [
       "chroma-depth-tunnel",
@@ -1729,7 +1729,7 @@
   {
     "id": "chroma-kinetic-blackbody",
     "name": "Chroma Kinetic Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-kinetic-blackbody.wgsl",
+    "url": "shaders/chroma-kinetic-blackbody.wgsl",
     "description": "Chroma Kinetic Blackbody",
     "tags": [
       "chroma-kinetic",
@@ -1784,7 +1784,7 @@
   {
     "id": "chroma-lens-iridescence",
     "name": "Chroma Lens Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-lens-iridescence.wgsl",
+    "url": "shaders/chroma-lens-iridescence.wgsl",
     "description": "Chroma Lens Iridescence",
     "tags": [
       "chroma-lens",
@@ -1841,7 +1841,7 @@
   {
     "id": "chroma-threads-gabor",
     "name": "Chroma Threads Gabor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-threads-gabor.wgsl",
+    "url": "shaders/chroma-threads-gabor.wgsl",
     "description": "Catalog entry for Chroma Threads Gabor.",
     "tags": [
       "chroma-threads",
@@ -1896,7 +1896,7 @@
   {
     "id": "chroma-vortex-coupled",
     "name": "Chroma Vortex Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-vortex-coupled.wgsl",
+    "url": "shaders/chroma-vortex-coupled.wgsl",
     "description": "Chroma Vortex Coupled",
     "tags": [
       "chroma-vortex",
@@ -1953,7 +1953,7 @@
   {
     "id": "chromatic-crawler-structure",
     "name": "Chromatic Crawler Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-crawler-structure.wgsl",
+    "url": "shaders/chromatic-crawler-structure.wgsl",
     "description": "Chromatic Crawler Structure",
     "tags": [
       "chromatic-crawler",
@@ -2008,7 +2008,7 @@
   {
     "id": "chromatic-focus-coupled",
     "name": "Chromatic Focus Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-focus-coupled.wgsl",
+    "url": "shaders/chromatic-focus-coupled.wgsl",
     "description": "Chromatic aberration DOF with fluid-coupled distortion. Mouse movement stirs a viscous fluid that twists and blurs chromatic channels. Click ripples inject fluid bursts.",
     "features": [
       "mouse-driven",
@@ -2057,7 +2057,7 @@
   {
     "id": "chromatic-focus-guided",
     "name": "Chromatic Focus Guided",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-focus-guided.wgsl",
+    "url": "shaders/chromatic-focus-guided.wgsl",
     "description": "Chromatic Focus Guided",
     "tags": [
       "chromatic-focus",
@@ -2112,7 +2112,7 @@
   {
     "id": "chromatic-folds-bilateral",
     "name": "Chromatic Folds Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-folds-bilateral.wgsl",
+    "url": "shaders/chromatic-folds-bilateral.wgsl",
     "description": "Chromatic Folds Bilateral",
     "tags": [
       "chromatic-folds",
@@ -2167,7 +2167,7 @@
   {
     "id": "chromatic-reaction-diffusion",
     "name": "Chromatic Reaction-Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-reaction-diffusion.wgsl",
+    "url": "shaders/chromatic-reaction-diffusion.wgsl",
     "description": "Multi-channel Gray-Scott reaction-diffusion with chromatic separation. Each RGB channel has separate feed/kill rates.",
     "features": [
       "advanced-hybrid",
@@ -2237,7 +2237,7 @@
   {
     "id": "chronos-brush-explosion",
     "name": "Chronos Brush Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chronos-brush-explosion.wgsl",
+    "url": "shaders/chronos-brush-explosion.wgsl",
     "description": "Chronos Brush Explosion",
     "tags": [
       "time-freeze",
@@ -2294,7 +2294,7 @@
   {
     "id": "circuit-breaker-explosion",
     "name": "Circuit Breaker Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/circuit-breaker-explosion.wgsl",
+    "url": "shaders/circuit-breaker-explosion.wgsl",
     "description": "Circuit board edges chromatically separated near the mouse prism. Overload flashes become spectral rainbows. Click ripples launch chromatic shockwaves through the circuit pattern.",
     "features": [
       "mouse-driven",
@@ -2343,7 +2343,7 @@
   {
     "id": "cmyk-halftone-explosion",
     "name": "CMYK Halftone Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cmyk-halftone-explosion.wgsl",
+    "url": "shaders/cmyk-halftone-explosion.wgsl",
     "description": "CMYK halftone dots spectrally separated near the mouse via prism displacement. Click ripples launch chromatic shockwaves through the halftone pattern.",
     "features": [
       "mouse-driven",
@@ -2392,7 +2392,7 @@
   {
     "id": "cosmic-jellyfish-coupled",
     "name": "Cosmic Jellyfish Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cosmic-jellyfish-coupled.wgsl",
+    "url": "shaders/cosmic-jellyfish-coupled.wgsl",
     "description": "Cosmic Jellyfish Coupled",
     "tags": [
       "raymarching",
@@ -2449,7 +2449,7 @@
   {
     "id": "cosmic-web-structure",
     "name": "Cosmic Web Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cosmic-web-structure.wgsl",
+    "url": "shaders/cosmic-web-structure.wgsl",
     "description": "Catalog entry for Cosmic Web Structure.",
     "tags": [
       "voronoi-filaments",
@@ -2504,7 +2504,7 @@
   {
     "id": "crt-tv-stipple",
     "name": "CRT TV Stipple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crt-tv-stipple.wgsl",
+    "url": "shaders/crt-tv-stipple.wgsl",
     "description": "Authentic CRT TV simulation with blue-noise stippled phosphor dots. Combines barrel distortion, chromatic aberration, scanlines, and phosphor decay with perceptually optimal blue-noise dot placement for each RGB subpixel triad.",
     "features": [
       "advanced-hybrid",
@@ -2578,7 +2578,7 @@
   {
     "id": "crystal-illuminator-iridescence",
     "name": "Crystal Illuminator Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystal-illuminator-iridescence.wgsl",
+    "url": "shaders/crystal-illuminator-iridescence.wgsl",
     "description": "Crystal Illuminator Iridescence",
     "tags": [
       "voronoi-facets",
@@ -2633,7 +2633,7 @@
   {
     "id": "cursor-aura-explosion",
     "name": "Cursor Aura Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cursor-aura-explosion.wgsl",
+    "url": "shaders/cursor-aura-explosion.wgsl",
     "description": "Cursor Aura Explosion",
     "tags": [
       "mouse-driven",
@@ -2690,7 +2690,7 @@
   {
     "id": "cyber-lattice-bilateral",
     "name": "Cyber Lattice Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-lattice-bilateral.wgsl",
+    "url": "shaders/cyber-lattice-bilateral.wgsl",
     "description": "Cyber Lattice Bilateral",
     "tags": [
       "mouse-driven",
@@ -2747,7 +2747,7 @@
   {
     "id": "cyber-organic-ecosystem",
     "name": "Cyber Organic Ecosystem",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-organic-ecosystem.wgsl",
+    "url": "shaders/cyber-organic-ecosystem.wgsl",
     "description": "Cyber Organic Ecosystem",
     "tags": [
       "mouse-driven",
@@ -2804,7 +2804,7 @@
   {
     "id": "cyber-rain-em",
     "name": "Cyber Rain Em",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-rain-em.wgsl",
+    "url": "shaders/cyber-rain-em.wgsl",
     "description": "Catalog entry for Cyber Rain Em.",
     "tags": [
       "mouse-driven",
@@ -2861,7 +2861,7 @@
   {
     "id": "cyber-ripples-coupled",
     "name": "Cyber Ripples Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-ripples-coupled.wgsl",
+    "url": "shaders/cyber-ripples-coupled.wgsl",
     "description": "Cyber Ripples Coupled",
     "tags": [
       "mouse-driven",
@@ -2918,7 +2918,7 @@
   {
     "id": "cyber-scan-gabor",
     "name": "Cyber Scan Gabor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-scan-gabor.wgsl",
+    "url": "shaders/cyber-scan-gabor.wgsl",
     "description": "Catalog entry for Cyber Scan Gabor.",
     "tags": [
       "cyber-scan",
@@ -2975,7 +2975,7 @@
   {
     "id": "cyber-trace-structure",
     "name": "Cyber Trace Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-trace-structure.wgsl",
+    "url": "shaders/cyber-trace-structure.wgsl",
     "description": "Cyber Trace Structure",
     "tags": [
       "mouse-driven",
@@ -3032,7 +3032,7 @@
   {
     "id": "data-scanner-gabor",
     "name": "Data Scanner Gabor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-scanner-gabor.wgsl",
+    "url": "shaders/data-scanner-gabor.wgsl",
     "description": "Catalog entry for Data Scanner Gabor.",
     "tags": [
       "mouse-driven",
@@ -3087,7 +3087,7 @@
   {
     "id": "data-stream-corruption-hdr",
     "name": "Data Stream Corruption Hdr",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-stream-corruption-hdr.wgsl",
+    "url": "shaders/data-stream-corruption-hdr.wgsl",
     "description": "Data Stream Corruption Hdr",
     "tags": [
       "mouse-driven",
@@ -3144,7 +3144,7 @@
   {
     "id": "data-stream-spectral",
     "name": "Data Stream Spectral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-stream-spectral.wgsl",
+    "url": "shaders/data-stream-spectral.wgsl",
     "description": "Catalog entry for Data Stream Spectral.",
     "tags": [
       "mouse-driven",
@@ -3199,7 +3199,7 @@
   {
     "id": "data-stream-structure",
     "name": "Data Stream Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-stream-structure.wgsl",
+    "url": "shaders/data-stream-structure.wgsl",
     "description": "Data Stream Structure",
     "tags": [
       "mouse-driven",
@@ -3256,7 +3256,7 @@
   {
     "id": "datamosh-brush-diffusion",
     "name": "Datamosh Brush Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/datamosh-brush-diffusion.wgsl",
+    "url": "shaders/datamosh-brush-diffusion.wgsl",
     "description": "Interactive datamoshing brush with anisotropic diffusion. Paint to freeze or corrupt pixels while Perona-Malik diffusion smooths along edges, creating oil-painted MPEG artifact trails with temporal persistence.",
     "features": [
       "advanced-hybrid",
@@ -3327,7 +3327,7 @@
   {
     "id": "deep-workgroup-multi-effect-blend",
     "name": "Deep-Workgroup Multi-Effect Blend",
-    "url": "https://test.1ink.us/image_video_effects/shaders/deep-workgroup-multi-effect-blend.wgsl",
+    "url": "shaders/deep-workgroup-multi-effect-blend.wgsl",
     "description": "Uses a 16×16×4 workgroup (1024 invocations) to run four effects simultaneously in Z-lanes — edge detection, bloom, hue-shift, and phosphor glow — then blends them via workgroup shared memory. Requires a GPU with maxComputeInvocationsPerWorkgroup ≥ 1024 (Apple M1+, NVIDIA RTX, AMD RDNA2+).",
     "tags": [
       "deep-workgroup",
@@ -3381,7 +3381,7 @@
   {
     "id": "digital-decay-rgba",
     "name": "Digital Decay RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-decay-rgba.wgsl",
+    "url": "shaders/digital-decay-rgba.wgsl",
     "description": "Digital block corruption feeds into a 4-species reaction-diffusion system. Corrupted pixels become chemical seeds that evolve into organic decay patterns, merging glitch aesthetics with emergent biological forms.",
     "features": [
       "advanced-hybrid",
@@ -3452,7 +3452,7 @@
   {
     "id": "digital-glitch-explosion",
     "name": "Digital Glitch Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-glitch-explosion.wgsl",
+    "url": "shaders/digital-glitch-explosion.wgsl",
     "description": "Digital Glitch Explosion",
     "tags": [
       "mouse-driven",
@@ -3509,7 +3509,7 @@
   {
     "id": "digital-lens-prismatic",
     "name": "Digital Lens Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-lens-prismatic.wgsl",
+    "url": "shaders/digital-lens-prismatic.wgsl",
     "description": "Digital Lens Prismatic",
     "tags": [
       "mouse-driven",
@@ -3566,7 +3566,7 @@
   {
     "id": "digital-moss-rgba",
     "name": "Digital Moss Rgba",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-moss-rgba.wgsl",
+    "url": "shaders/digital-moss-rgba.wgsl",
     "description": "Catalog entry for Digital Moss Rgba.",
     "tags": [
       "mouse-driven",
@@ -3623,7 +3623,7 @@
   {
     "id": "digital-reveal-guided",
     "name": "Digital Reveal Guided",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-reveal-guided.wgsl",
+    "url": "shaders/digital-reveal-guided.wgsl",
     "description": "Digital Reveal Guided",
     "tags": [
       "mouse-driven",
@@ -3680,7 +3680,7 @@
   {
     "id": "dimension-slicer-guided",
     "name": "Dimension Slicer Guided",
-    "url": "https://test.1ink.us/image_video_effects/shaders/dimension-slicer-guided.wgsl",
+    "url": "shaders/dimension-slicer-guided.wgsl",
     "description": "Dimension Slicer Guided",
     "tags": [
       "dimensional-slice",
@@ -3739,7 +3739,7 @@
   {
     "id": "distortion-gravitational-prismatic",
     "name": "Distortion Gravitational Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/distortion-gravitational-prismatic.wgsl",
+    "url": "shaders/distortion-gravitational-prismatic.wgsl",
     "description": "Distortion Gravitational Prismatic",
     "tags": [
       "gravitational-lensing",
@@ -3794,7 +3794,7 @@
   {
     "id": "divine-light-iridescence",
     "name": "Divine Light Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/divine-light-iridescence.wgsl",
+    "url": "shaders/divine-light-iridescence.wgsl",
     "description": "Divine Light Iridescence",
     "tags": [
       "god-rays",
@@ -3851,7 +3851,7 @@
   {
     "id": "double-exposure-hdr",
     "name": "Double Exposure HDR",
-    "url": "https://test.1ink.us/image_video_effects/shaders/double-exposure-hdr.wgsl",
+    "url": "shaders/double-exposure-hdr.wgsl",
     "description": "Ghostly double exposure blending combined with HDR bloom chain. The image overlays a zoomed/rotated version of itself, then luminous halos form around bright overlap regions with ACES tone mapping. Mouse sets the pivot point.",
     "features": [
       "mouse-driven",
@@ -3902,7 +3902,7 @@
   {
     "id": "dynamic-lens-flares-prismatic",
     "name": "Dynamic Lens Flares Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/dynamic-lens-flares-prismatic.wgsl",
+    "url": "shaders/dynamic-lens-flares-prismatic.wgsl",
     "description": "Dynamic Lens Flares Prismatic",
     "tags": [
       "lens-flares",
@@ -3959,7 +3959,7 @@
   {
     "id": "edge-glow-mouse-em",
     "name": "Edge Glow Mouse Em",
-    "url": "https://test.1ink.us/image_video_effects/shaders/edge-glow-mouse-em.wgsl",
+    "url": "shaders/edge-glow-mouse-em.wgsl",
     "description": "Catalog entry for Edge Glow Mouse Em.",
     "tags": [
       "edge-detection",
@@ -4016,7 +4016,7 @@
   {
     "id": "elastic-chromatic-explosion",
     "name": "Elastic Chromatic Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/elastic-chromatic-explosion.wgsl",
+    "url": "shaders/elastic-chromatic-explosion.wgsl",
     "description": "Elastic Chromatic Explosion",
     "tags": [
       "chromatic-lag",
@@ -4073,7 +4073,7 @@
   {
     "id": "encaustic-wax-blackbody",
     "name": "Encaustic Wax Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/encaustic-wax-blackbody.wgsl",
+    "url": "shaders/encaustic-wax-blackbody.wgsl",
     "description": "Physical encaustic wax simulation combined with blackbody thermal radiation coloring. Thick wax pools glow like cooling magma with physically-correct color temperature, while thin glaze remains translucent amber. Mouse melts wax creating localized thermal hotspots.",
     "features": [
       "mouse-driven",
@@ -4125,7 +4125,7 @@
   {
     "id": "energy-shield-blackbody",
     "name": "Energy Shield Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/energy-shield-blackbody.wgsl",
+    "url": "shaders/energy-shield-blackbody.wgsl",
     "description": "Energy Shield Blackbody",
     "tags": [
       "hex-grid",
@@ -4182,7 +4182,7 @@
   {
     "id": "engraving-stipple-blue-noise",
     "name": "Engraving Stipple Blue Noise",
-    "url": "https://test.1ink.us/image_video_effects/shaders/engraving-stipple-blue-noise.wgsl",
+    "url": "shaders/engraving-stipple-blue-noise.wgsl",
     "description": "Traditional copper-plate engraving stipple fused with blue-noise dithered pointillism. Golden-ratio low-discrepancy sequences create perceptually optimal dot distributions. Mouse acts as raking light revealing engraved depth.",
     "features": [
       "mouse-driven",
@@ -4233,7 +4233,7 @@
   {
     "id": "ethereal-swirl-coupled",
     "name": "Ethereal Swirl Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ethereal-swirl-coupled.wgsl",
+    "url": "shaders/ethereal-swirl-coupled.wgsl",
     "description": "Ethereal Swirl Coupled",
     "tags": [
       "fluid-coupling",
@@ -4292,7 +4292,7 @@
   {
     "id": "fabric-step-gabor",
     "name": "Fabric Step Gabor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fabric-step-gabor.wgsl",
+    "url": "shaders/fabric-step-gabor.wgsl",
     "description": "Mass-spring cloth simulation deforms the image into flowing folds, then Gabor filter banks detect oriented texture patterns across the fabric. Strain creates visual texture mapped to psychedelic orientation colors. Mouse pulls and tears the textile.",
     "features": [
       "mouse-driven",
@@ -4345,7 +4345,7 @@
   {
     "id": "ferrofluid-em",
     "name": "Ferrofluid Em",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ferrofluid-em.wgsl",
+    "url": "shaders/ferrofluid-em.wgsl",
     "description": "Catalog entry for Ferrofluid Em.",
     "tags": [
       "ferrofluid-distortion",
@@ -4400,7 +4400,7 @@
   {
     "id": "fire-smoke-volumetric-fog",
     "name": "Fire Smoke Volumetric Fog",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fire-smoke-volumetric-fog.wgsl",
+    "url": "shaders/fire-smoke-volumetric-fog.wgsl",
     "description": "Fire Smoke Volumetric Fog",
     "tags": [
       "fire",
@@ -4461,7 +4461,7 @@
   {
     "id": "fluid-grid-rgba-fluid",
     "name": "Fluid Grid Rgba Fluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fluid-grid-rgba-fluid.wgsl",
+    "url": "shaders/fluid-grid-rgba-fluid.wgsl",
     "description": "Fluid Grid Rgba Fluid",
     "tags": [
       "fluid-simulation",
@@ -4518,7 +4518,7 @@
   {
     "id": "fractal-boids-field-coupled",
     "name": "Fractal Boids Field + Fluid Coupling",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-boids-field-coupled.wgsl",
+    "url": "shaders/fractal-boids-field-coupled.wgsl",
     "description": "Flocking behavior on a fractal vector field with viscous mouse fluid coupling. Mouse wakes push boids; click ripples spawn shockwaves through the flock.",
     "features": [
       "advanced-hybrid",
@@ -4598,7 +4598,7 @@
   {
     "id": "fractal-boids-field",
     "name": "Fractal Boids Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-boids-field.wgsl",
+    "url": "shaders/fractal-boids-field.wgsl",
     "description": "Flocking behavior on a fractal vector field. Swarms of particles flowing through organic fractal currents.",
     "features": [
       "advanced-hybrid",
@@ -4669,7 +4669,7 @@
   {
     "id": "fractal-glass-distort-bilateral",
     "name": "Fractal Glass Distort Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-glass-distort-bilateral.wgsl",
+    "url": "shaders/fractal-glass-distort-bilateral.wgsl",
     "description": "Fractal Glass Distort Bilateral",
     "tags": [
       "fractal-glass-distortion",
@@ -4724,7 +4724,7 @@
   {
     "id": "fractal-noise-dissolve-nlm",
     "name": "Fractal Noise Dissolve Nlm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-noise-dissolve-nlm.wgsl",
+    "url": "shaders/fractal-noise-dissolve-nlm.wgsl",
     "description": "Fractal Noise Dissolve Nlm",
     "tags": [
       "fractal-dissolve",
@@ -4779,7 +4779,7 @@
   {
     "id": "frost-reveal-crystal",
     "name": "Frost Reveal Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/frost-reveal-crystal.wgsl",
+    "url": "shaders/frost-reveal-crystal.wgsl",
     "description": "Catalog entry for Frost Reveal Crystal.",
     "tags": [
       "frost-reveal",
@@ -4836,7 +4836,7 @@
   {
     "id": "frosted-glass-lens-iridescence",
     "name": "Frosted Glass Lens Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/frosted-glass-lens-iridescence.wgsl",
+    "url": "shaders/frosted-glass-lens-iridescence.wgsl",
     "description": "Frosted Glass Lens Iridescence",
     "tags": [
       "frosted-glass",
@@ -4893,7 +4893,7 @@
   {
     "id": "gamma-ray-burst-blackbody",
     "name": "Gamma Ray Burst Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gamma-ray-burst-blackbody.wgsl",
+    "url": "shaders/gamma-ray-burst-blackbody.wgsl",
     "description": "Gamma Ray Burst Blackbody",
     "tags": [
       "radial-blur",
@@ -4952,7 +4952,7 @@
   {
     "id": "gemstone-fractures-crystal",
     "name": "Gemstone Fractures Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gemstone-fractures-crystal.wgsl",
+    "url": "shaders/gemstone-fractures-crystal.wgsl",
     "description": "Gemstone Fractures Crystal",
     "tags": [
       "voronoi-shards",
@@ -5009,7 +5009,7 @@
   {
     "id": "gen-abyssal-leviathan-iridescence",
     "name": "Gen Abyssal Leviathan Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-abyssal-leviathan-iridescence.wgsl",
+    "url": "shaders/gen-abyssal-leviathan-iridescence.wgsl",
     "description": "Gen Abyssal Leviathan Iridescence",
     "tags": [
       "raymarching",
@@ -5066,7 +5066,7 @@
   {
     "id": "gen-art-deco-sky-prismatic",
     "name": "Gen Art Deco Sky Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-art-deco-sky-prismatic.wgsl",
+    "url": "shaders/gen-art-deco-sky-prismatic.wgsl",
     "description": "Gen Art Deco Sky Prismatic",
     "tags": [
       "raymarching",
@@ -5123,7 +5123,7 @@
   {
     "id": "gen-astro-orrery-blackbody",
     "name": "Astro Orrery Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-astro-orrery-blackbody.wgsl",
+    "url": "shaders/gen-astro-orrery-blackbody.wgsl",
     "description": "A kinetic astronomical orrery where each ring's thermal energy determines its blackbody color. Rotating rings glow with physically accurate star temperatures from cool red dwarfs to blazing blue giants.",
     "tags": [
       "astronomical",
@@ -5178,7 +5178,7 @@
   {
     "id": "gen-audio-spirograph-julia",
     "name": "Audio Spirograph Julia",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-audio-spirograph-julia.wgsl",
+    "url": "shaders/gen-audio-spirograph-julia.wgsl",
     "description": "Audio-reactive spirograph curves that unfold into mouse-driven Julia set fractals. Each harmonic ring breathes with audio while the Julia constant morphs via mouse position.",
     "tags": [
       "audio-reactive",
@@ -5232,7 +5232,7 @@
   {
     "id": "gen-biomechanical-hive-julia",
     "name": "Biomechanical Hive Julia",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-biomechanical-hive-julia.wgsl",
+    "url": "shaders/gen-biomechanical-hive-julia.wgsl",
     "description": "A biomechanical hive where each cell contains a living quaternion Julia fractal core. The chitinous exoskeleton surrounds morphing 4D fractal organisms that pulse with bioluminescence.",
     "tags": [
       "biomechanical",
@@ -5286,7 +5286,7 @@
   {
     "id": "gen-bismuth-citadel-crystal",
     "name": "Gen Bismuth Citadel Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bismuth-citadel-crystal.wgsl",
+    "url": "shaders/gen-bismuth-citadel-crystal.wgsl",
     "description": "Gen Bismuth Citadel Crystal",
     "tags": [
       "raymarching",
@@ -5345,7 +5345,7 @@
   {
     "id": "gen-neural-fractal-hdr",
     "name": "Gen Neural Fractal Hdr",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neural-fractal-hdr.wgsl",
+    "url": "shaders/gen-neural-fractal-hdr.wgsl",
     "description": "Gen Neural Fractal Hdr",
     "tags": [
       "generative",
@@ -5402,7 +5402,7 @@
   {
     "id": "gen-quasicrystal-iridescence",
     "name": "Gen Quasicrystal Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quasicrystal-iridescence.wgsl",
+    "url": "shaders/gen-quasicrystal-iridescence.wgsl",
     "description": "Gen Quasicrystal Iridescence",
     "tags": [
       "generative",
@@ -5459,7 +5459,7 @@
   {
     "id": "gen-raptor-mini-flow",
     "name": "Raptor Mini Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-raptor-mini-flow.wgsl",
+    "url": "shaders/gen-raptor-mini-flow.wgsl",
     "description": "Predatory raptor agents navigate structure-tensor flow fields, hunting along image edges and orientations. Their trails follow dominant eigenvectors while audio rage pulses through the swarm.",
     "tags": [
       "predator",
@@ -5513,7 +5513,7 @@
   {
     "id": "gen-singularity-forge-blackbody",
     "name": "Gen Singularity Forge Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-singularity-forge-blackbody.wgsl",
+    "url": "shaders/gen-singularity-forge-blackbody.wgsl",
     "description": "Gen Singularity Forge Blackbody",
     "tags": [
       "generative",
@@ -5570,7 +5570,7 @@
   {
     "id": "gen-string-theory-structure",
     "name": "Gen String Theory Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-string-theory-structure.wgsl",
+    "url": "shaders/gen-string-theory-structure.wgsl",
     "description": "Gen String Theory Structure",
     "tags": [
       "generative",
@@ -5627,7 +5627,7 @@
   {
     "id": "gen-xeno-botanical-ecosystem",
     "name": "Xeno Botanical Ecosystem",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-xeno-botanical-ecosystem.wgsl",
+    "url": "shaders/gen-xeno-botanical-ecosystem.wgsl",
     "description": "Botanical flora patterns host a living RGBA ecosystem simulation. Species colonize branch structures, competing for photosynthetic resources while toxins accumulate in dense growth regions.",
     "tags": [
       "botanical",
@@ -5682,7 +5682,7 @@
   {
     "id": "glass-bead-curtain-iridescence",
     "name": "Glass Bead Curtain Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-bead-curtain-iridescence.wgsl",
+    "url": "shaders/glass-bead-curtain-iridescence.wgsl",
     "description": "A curtain of refractive glass beads where each bead surface exhibits thin-film iridescence (soap-bubble colors). Combines physical Beer-Lambert transmission with spectral interference.",
     "tags": [
       "glass",
@@ -5738,7 +5738,7 @@
   {
     "id": "glass-refraction-prismatic",
     "name": "Glass Refraction Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-refraction-prismatic.wgsl",
+    "url": "shaders/glass-refraction-prismatic.wgsl",
     "description": "Raymarched glass blobs with 4-band spectral dispersion using Cauchy's equation and CIE color matching. Each wavelength refracts at a different angle through animated SDF glass surfaces.",
     "features": [
       "advanced-hybrid",
@@ -5811,7 +5811,7 @@
   {
     "id": "glass-shatter-morph",
     "name": "Glass Shatter Morph",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-shatter-morph.wgsl",
+    "url": "shaders/glass-shatter-morph.wgsl",
     "description": "Interactive shattered glass where Voronoi shards are sculpted by morphological erosion/dilation on edges. Combines physical glass transmission with mathematical morphology for cracked-edge detail.",
     "tags": [
       "glass",
@@ -5869,7 +5869,7 @@
   {
     "id": "glass-wall-prismatic",
     "name": "Glass Wall Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-wall-prismatic.wgsl",
+    "url": "shaders/glass-wall-prismatic.wgsl",
     "description": "A grid of glass tiles where each tile acts as a prismatic lens with 4-band spectral dispersion via Cauchy's equation. Mouse interaction tilts tiles, refracting light into rainbow spectra.",
     "tags": [
       "glass",
@@ -5925,7 +5925,7 @@
   {
     "id": "glass-wipes-coupled",
     "name": "Glass Wipes Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-wipes-coupled.wgsl",
+    "url": "shaders/glass-wipes-coupled.wgsl",
     "description": "Rain on glass combined with viscous fluid coupling physics. Rain drops feed a fluid simulation that creates realistic water streaks, while the mouse wiper clears fluid with vortex dynamics.",
     "tags": [
       "glass",
@@ -5980,7 +5980,7 @@
   {
     "id": "gravitational-lensing-nlm",
     "name": "Gravitational Lensing NLM",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gravitational-lensing-nlm.wgsl",
+    "url": "shaders/gravitational-lensing-nlm.wgsl",
     "description": "Black hole gravitational lensing with non-local means artistic overdrive. Patch-similarity filtering smooths background starfields while preserving unique features like the event horizon and Einstein ring.",
     "features": [
       "advanced-hybrid",
@@ -6094,7 +6094,7 @@
   {
     "id": "gravitational-lensing",
     "name": "Gravitational Lensing",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gravitational-lensing.wgsl",
+    "url": "shaders/gravitational-lensing.wgsl",
     "description": "General relativistic light bending around black hole. Einstein ring with glowing accretion disk.",
     "features": [
       "mouse-driven",
@@ -6167,7 +6167,7 @@
   {
     "id": "gravity-well-em",
     "name": "Gravity Well Em",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gravity-well-em.wgsl",
+    "url": "shaders/gravity-well-em.wgsl",
     "description": "Catalog entry for Gravity Well Em.",
     "tags": [
       "gravitational-lensing",
@@ -6222,7 +6222,7 @@
   {
     "id": "heat-haze-volumetric",
     "name": "Heat Haze Volumetric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/heat-haze-volumetric.wgsl",
+    "url": "shaders/heat-haze-volumetric.wgsl",
     "description": "Catalog entry for Heat Haze Volumetric.",
     "tags": [
       "heat-diffusion",
@@ -6279,7 +6279,7 @@
   {
     "id": "holographic-failure-iridescence",
     "name": "Holographic Failure Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-failure-iridescence.wgsl",
+    "url": "shaders/holographic-failure-iridescence.wgsl",
     "description": "Simulated hologram projection failure merged with thin-film interference iridescence. Flickering artifacts and block noise overlay soap-bubble spectral colors driven by depth, viewing angle, and time.",
     "features": [
       "advanced-hybrid",
@@ -6351,7 +6351,7 @@
   {
     "id": "holographic-interferometry-bilateral",
     "name": "Holographic Interferometry Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-interferometry-bilateral.wgsl",
+    "url": "shaders/holographic-interferometry-bilateral.wgsl",
     "description": "Simulated hologram with interference fringes and edge-preserving bilateral smoothing. Speckle noise is softly reduced while sharp interference fringe edges remain crisp.",
     "features": [
       "advanced-hybrid",
@@ -6456,7 +6456,7 @@
   {
     "id": "holographic-interferometry",
     "name": "Holographic Interferometry",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-interferometry.wgsl",
+    "url": "shaders/holographic-interferometry.wgsl",
     "description": "Simulated hologram with interference fringe patterns. Rainbow interference fringes with speckled laser light.",
     "features": [
       "advanced-hybrid",
@@ -6526,7 +6526,7 @@
   {
     "id": "honey-melt-blackbody",
     "name": "Honey Melt Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/honey-melt-blackbody.wgsl",
+    "url": "shaders/honey-melt-blackbody.wgsl",
     "description": "Catalog entry for Honey Melt Blackbody.",
     "tags": [
       "hex-grid",
@@ -6583,7 +6583,7 @@
   {
     "id": "hybrid-spectral-decomposed",
     "name": "Hybrid Spectral Decomposed",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-spectral-decomposed.wgsl",
+    "url": "shaders/hybrid-spectral-decomposed.wgsl",
     "description": "4-band spectral decomposition combined with audio-reactive pixel sorting. Image decomposed into low/mid-low/mid-high/high frequencies. Each band sorted independently with unique spectral color tints, then recomposed with per-band gains.",
     "features": [
       "advanced-hybrid",
@@ -6657,7 +6657,7 @@
   {
     "id": "hyper-space-jump-blackbody",
     "name": "Hyper Space Jump Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyper-space-jump-blackbody.wgsl",
+    "url": "shaders/hyper-space-jump-blackbody.wgsl",
     "description": "Hyper Space Jump Blackbody",
     "tags": [
       "radial-streaks",
@@ -6714,7 +6714,7 @@
   {
     "id": "hyper-tensor-fluid-coupled",
     "name": "Hyper Tensor Fluid + Mouse Coupling",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyper-tensor-fluid-coupled.wgsl",
+    "url": "shaders/hyper-tensor-fluid-coupled.wgsl",
     "description": "Tensor-field fluid dynamics with viscous mouse stirring. Mouse injects velocity and vorticity; click ripples spawn radial fluid bursts.",
     "features": [
       "advanced-hybrid",
@@ -6793,7 +6793,7 @@
   {
     "id": "hyper-tensor-fluid",
     "name": "Hyper Tensor Fluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyper-tensor-fluid.wgsl",
+    "url": "shaders/hyper-tensor-fluid.wgsl",
     "description": "Fluid flows according to image structure via tensor eigendecomposition. Combines tensor fields with Navier-Stokes dynamics.",
     "features": [
       "advanced-hybrid",
@@ -6865,7 +6865,7 @@
   {
     "id": "hyperbolic-dreamweaver-julia",
     "name": "Hyperbolic Dreamweaver Julia",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyperbolic-dreamweaver-julia.wgsl",
+    "url": "shaders/hyperbolic-dreamweaver-julia.wgsl",
     "description": "Hyperbolic Dreamweaver Julia",
     "tags": [
       "hyperbolic-geometry",
@@ -6922,7 +6922,7 @@
   {
     "id": "impasto-swirl-bilateral",
     "name": "Impasto Swirl Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/impasto-swirl-bilateral.wgsl",
+    "url": "shaders/impasto-swirl-bilateral.wgsl",
     "description": "Impasto Swirl Bilateral",
     "tags": [
       "bilateral-filter",
@@ -6979,7 +6979,7 @@
   {
     "id": "infinite-fractal-feedback-hdr",
     "name": "Infinite Fractal Feedback Hdr",
-    "url": "https://test.1ink.us/image_video_effects/shaders/infinite-fractal-feedback-hdr.wgsl",
+    "url": "shaders/infinite-fractal-feedback-hdr.wgsl",
     "description": "Infinite Fractal Feedback Hdr",
     "tags": [
       "fractal-feedback",
@@ -7036,7 +7036,7 @@
   {
     "id": "ink-bleed-fluid",
     "name": "Ink Bleed Fluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ink-bleed-fluid.wgsl",
+    "url": "shaders/ink-bleed-fluid.wgsl",
     "description": "Catalog entry for Ink Bleed Fluid.",
     "tags": [
       "fluid-simulation",
@@ -7093,7 +7093,7 @@
   {
     "id": "ink-dispersion-guided",
     "name": "Ink Dispersion Guided",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ink-dispersion-guided.wgsl",
+    "url": "shaders/ink-dispersion-guided.wgsl",
     "description": "Depth-guided edge-preserving filter combined with ink-style halftone rendering. The guided filter smooths based on depth boundaries, then the result is rendered as ink dots with paper texture.",
     "features": [
       "advanced-hybrid",
@@ -7166,7 +7166,7 @@
   {
     "id": "interactive-magnetic-ripple-em",
     "name": "Interactive Magnetic Ripple Em",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-magnetic-ripple-em.wgsl",
+    "url": "shaders/interactive-magnetic-ripple-em.wgsl",
     "description": "Interactive Magnetic Ripple Em",
     "tags": [
       "mouse-driven",
@@ -7223,7 +7223,7 @@
   {
     "id": "interactive-origami-coupled",
     "name": "Interactive Origami Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-origami-coupled.wgsl",
+    "url": "shaders/interactive-origami-coupled.wgsl",
     "description": "Interactive Origami Coupled",
     "tags": [
       "mouse-driven",
@@ -7278,7 +7278,7 @@
   {
     "id": "interactive-pixel-wind-structure",
     "name": "Interactive Pixel Wind Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-pixel-wind-structure.wgsl",
+    "url": "shaders/interactive-pixel-wind-structure.wgsl",
     "description": "Interactive Pixel Wind Structure",
     "tags": [
       "mouse-driven",
@@ -7335,7 +7335,7 @@
   {
     "id": "interactive-rgb-split-explosion",
     "name": "Interactive Rgb Split Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-rgb-split-explosion.wgsl",
+    "url": "shaders/interactive-rgb-split-explosion.wgsl",
     "description": "Interactive Rgb Split Explosion",
     "tags": [
       "mouse-driven",
@@ -7394,7 +7394,7 @@
   {
     "id": "kimi-flock-symphony-em",
     "name": "Kimi Flock Symphony Em",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi-flock-symphony-em.wgsl",
+    "url": "shaders/kimi-flock-symphony-em.wgsl",
     "description": "Kimi Flock Symphony Em",
     "tags": [
       "flocking-particles",
@@ -7447,7 +7447,7 @@
   {
     "id": "liquid-jelly-fluid",
     "name": "Liquid Jelly Fluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-jelly-fluid.wgsl",
+    "url": "shaders/liquid-jelly-fluid.wgsl",
     "description": "Catalog entry for Liquid Jelly Fluid.",
     "tags": [
       "liquid-jelly",
@@ -7504,7 +7504,7 @@
   {
     "id": "liquid-magnetic-ferro-em",
     "name": "Liquid Magnetic Ferro EM",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-magnetic-ferro-em.wgsl",
+    "url": "shaders/liquid-magnetic-ferro-em.wgsl",
     "description": "Ferrofluid simulation coupled with electromagnetic wave propagation. Rosensweig instability spikes are driven by both static magnetic dipoles and time-varying EM waves, with metallic iridescence colored by field direction.",
     "features": [
       "advanced-hybrid",
@@ -7577,7 +7577,7 @@
   {
     "id": "liquid-metal-prismatic",
     "name": "Liquid Metal Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-metal-prismatic.wgsl",
+    "url": "shaders/liquid-metal-prismatic.wgsl",
     "description": "Liquid metal ripple distortion combined with 4-band spectral prismatic dispersion. Curved metal surface acts as a dynamic liquid prism — ripples create varying curvature that refracts light into separated wavelength bands via Cauchy's equation.",
     "tags": [
       "prismatic",
@@ -7634,7 +7634,7 @@
   {
     "id": "liquid-oil-iridescence",
     "name": "Liquid Oil Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-oil-iridescence.wgsl",
+    "url": "shaders/liquid-oil-iridescence.wgsl",
     "description": "Liquid Oil Iridescence",
     "tags": [
       "liquid-oil",
@@ -7691,7 +7691,7 @@
   {
     "id": "liquid-smear-structure",
     "name": "Liquid Smear Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-smear-structure.wgsl",
+    "url": "shaders/liquid-smear-structure.wgsl",
     "description": "Liquid Smear Structure",
     "tags": [
       "liquid-smear",
@@ -7750,7 +7750,7 @@
   {
     "id": "melting-oil-blackbody",
     "name": "Melting Oil Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/melting-oil-blackbody.wgsl",
+    "url": "shaders/melting-oil-blackbody.wgsl",
     "description": "Melting Oil Blackbody",
     "tags": [
       "melting-oil",
@@ -7807,7 +7807,7 @@
   {
     "id": "multi-fractal-compositor-lens",
     "name": "Multi-Fractal Compositor + Gravitational Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/multi-fractal-compositor-lens.wgsl",
+    "url": "shaders/multi-fractal-compositor-lens.wgsl",
     "description": "Multi-layer fractal compositor with mouse-controlled gravitational lensing. Mouse mass bends UV coordinates; ripples create temporary mass concentrations with Einstein ring glow.",
     "features": [
       "advanced-hybrid",
@@ -7887,7 +7887,7 @@
   {
     "id": "multi-fractal-compositor",
     "name": "Multi-Fractal Compositor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/multi-fractal-compositor.wgsl",
+    "url": "shaders/multi-fractal-compositor.wgsl",
     "description": "Smoothly blend between multiple fractal types. Mandelbrot, Julia, Burning Ship, and Newton fractals.",
     "features": [
       "advanced-hybrid",
@@ -7961,7 +7961,7 @@
   {
     "id": "nano-assembler-crystal",
     "name": "Nano Assembler Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/nano-assembler-crystal.wgsl",
+    "url": "shaders/nano-assembler-crystal.wgsl",
     "description": "Grid-based nanobots assemble into crystalline structures using phase-field dynamics. RGBA stores assembly phase, temperature, crystal orientation, and impurity. Mouse disrupts assembly causing scatter; ripples trigger nucleation. Displays nanobot glow when disassembled and orientation-dependent crystal color when assembled.",
     "tags": [
       "nano-assembler",
@@ -8018,7 +8018,7 @@
   {
     "id": "neural-raymarcher-gabor",
     "name": "Neural Raymarcher Gabor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-raymarcher-gabor.wgsl",
+    "url": "shaders/neural-raymarcher-gabor.wgsl",
     "description": "Raymarched neural network visualization with Gabor oriented texture detection. Gabor responses highlight connection directions and layer boundaries with psychedelic color mapping.",
     "features": [
       "advanced-hybrid",
@@ -8125,7 +8125,7 @@
   {
     "id": "neural-raymarcher",
     "name": "Neural Raymarcher",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-raymarcher.wgsl",
+    "url": "shaders/neural-raymarcher.wgsl",
     "description": "Raymarched neural network with activation visualization. Glowing 3D structure with weights as connection thickness.",
     "features": [
       "advanced-hybrid",
@@ -8196,7 +8196,7 @@
   {
     "id": "painterly-oil-bilateral",
     "name": "Painterly Oil + Bilateral Dream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/painterly-oil-bilateral.wgsl",
+    "url": "shaders/painterly-oil-bilateral.wgsl",
     "description": "Oil painting simulation with anisotropic Kuwahara, color quantization, and impasto texture, post-processed with edge-preserving bilateral filter for a dreamy smoothness. Mouse focus aperture controls sharpness.",
     "tags": [
       "oil",
@@ -8253,7 +8253,7 @@
   {
     "id": "particle-dreams-hdr",
     "name": "Particle Dreams HDR",
-    "url": "https://test.1ink.us/image_video_effects/shaders/particle-dreams-hdr.wgsl",
+    "url": "shaders/particle-dreams-hdr.wgsl",
     "description": "Multi-layer depth particle accumulation with HDR bloom chain. 5 depth layers with flow noise and vortex distortion, combined with exposure-based radial bloom and ACES tone mapping.",
     "features": [
       "advanced-hybrid",
@@ -8326,7 +8326,7 @@
   {
     "id": "phantom-lag-history",
     "name": "Phantom Lag History",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phantom-lag-history.wgsl",
+    "url": "shaders/phantom-lag-history.wgsl",
     "description": "Catalog entry for Phantom Lag History.",
     "tags": [
       "temporal-echo",
@@ -8383,7 +8383,7 @@
   {
     "id": "photonic-caustics-iridescence",
     "name": "Photonic Caustics Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/photonic-caustics-iridescence.wgsl",
+    "url": "shaders/photonic-caustics-iridescence.wgsl",
     "description": "Backward photon-traced caustics combined with thin-film interference iridescence. Caustic intensity modulates film thickness, creating soap-bubble colors on light concentrations. Features chromatic dispersion, Fresnel reflections, and temporal accumulation.",
     "tags": [
       "caustics",
@@ -8441,7 +8441,7 @@
   {
     "id": "predator-prey-rgba",
     "name": "Predator-Prey RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/predator-prey-rgba.wgsl",
+    "url": "shaders/predator-prey-rgba.wgsl",
     "description": "Continuous-density predator-prey ecosystem simulation packed into RGBA32FLOAT. Plants photosynthesize using source image luminance, herbivores graze, carnivores hunt, and toxins accumulate from overpopulation. Species diffuse across the grid creating emergent spatial waves.",
     "tags": [
       "predator-prey",
@@ -8497,7 +8497,7 @@
   {
     "id": "quantum-foam-bilateral",
     "name": "Quantum Foam Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-foam-bilateral.wgsl",
+    "url": "shaders/quantum-foam-bilateral.wgsl",
     "description": "Quantum foam chromatic parallax diffusion with edge-preserving bilateral smoothing. Cell boundaries and emissive edges remain crisp while foam interiors are dreamily smoothed.",
     "features": [
       "advanced-hybrid",
@@ -8602,7 +8602,7 @@
   {
     "id": "retro-phosphor-hdr",
     "name": "Retro Phosphor HDR",
-    "url": "https://test.1ink.us/image_video_effects/shaders/retro-phosphor-hdr.wgsl",
+    "url": "shaders/retro-phosphor-hdr.wgsl",
     "description": "Authentic CRT phosphor simulation enhanced with HDR bloom chain. RGB triads, barrel distortion, scanlines, and temporal persistence combine with exposure-based bloom and ACES tone mapping for dramatic glowing phosphors.",
     "features": [
       "advanced-hybrid",
@@ -8673,7 +8673,7 @@
   {
     "id": "retro-phosphor-stipple",
     "name": "Retro Phosphor Stipple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/retro-phosphor-stipple.wgsl",
+    "url": "shaders/retro-phosphor-stipple.wgsl",
     "description": "CRT phosphor simulation with blue-noise stippled dot triads. Authentic barrel distortion, scanlines, and temporal persistence combined with perceptually optimal blue-noise dot placement for each RGB channel.",
     "features": [
       "advanced-hybrid",
@@ -8745,7 +8745,7 @@
   {
     "id": "sim-heat-haze-blackbody",
     "name": "Heat Haze Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-heat-haze-blackbody.wgsl",
+    "url": "shaders/sim-heat-haze-blackbody.wgsl",
     "description": "Temperature field convection simulation with physically-correct blackbody thermal glow. Hot ground and rising convection plumes radiate with Planck's law colors — cool air stays neutral while intense heat sources glow from red ember to blue-white.",
     "tags": [
       "blackbody",
@@ -8803,7 +8803,7 @@
   {
     "id": "sim-smoke-trails-thermal",
     "name": "Smoke Trails Thermal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-smoke-trails-thermal.wgsl",
+    "url": "shaders/sim-smoke-trails-thermal.wgsl",
     "description": "Volumetric smoke fluid simulation with physically-correct blackbody thermal coloring. Smoke temperature maps to Kelvin via Planck's law — cool wisps glow ember-red, hot cores burn blue-white with Stefan-Boltzmann radiance scaling.",
     "tags": [
       "blackbody",
@@ -8861,7 +8861,7 @@
   {
     "id": "spec-blackbody-thermal",
     "name": "Blackbody Thermal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-blackbody-thermal.wgsl",
+    "url": "shaders/spec-blackbody-thermal.wgsl",
     "description": "Maps image luminance to physically-correct blackbody radiation colors with audio-driven temperature modulation, chromatic temperature gradient, temporal ember persistence via dataTextureC, and HDR glow.",
     "tags": [
       "blackbody",
@@ -8924,7 +8924,7 @@
   {
     "id": "spec-importance-sampled-bokeh",
     "name": "Importance Sampled Bokeh",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-importance-sampled-bokeh.wgsl",
+    "url": "shaders/spec-importance-sampled-bokeh.wgsl",
     "description": "Bokeh blur guided by image brightness using importance sampling. Bright pixels act as point light sources creating crisp bokeh highlights with smooth backgrounds via golden angle spiral distribution.",
     "tags": [
       "bokeh",
@@ -8979,7 +8979,7 @@
   {
     "id": "spec-iridescence-engine",
     "name": "Iridescence Engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-iridescence-engine.wgsl",
+    "url": "shaders/spec-iridescence-engine.wgsl",
     "description": "Thin-film interference simulation creating soap-bubble and oil-slick iridescence. Uses depth texture for film thickness and physically-correct optical path difference.",
     "tags": [
       "iridescence",
@@ -9035,7 +9035,7 @@
   {
     "id": "spec-prismatic-dispersion",
     "name": "Prismatic Dispersion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-prismatic-dispersion.wgsl",
+    "url": "shaders/spec-prismatic-dispersion.wgsl",
     "description": "4-band spectral dispersion through glass using Cauchy's equation. Treats RGBA as physical wavelengths with refractive index variation, reconstructing color via CIE color matching.",
     "tags": [
       "spectral",
@@ -9090,7 +9090,7 @@
   {
     "id": "spec-spherical-harmonics-light",
     "name": "Spherical Harmonics Light",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-spherical-harmonics-light.wgsl",
+    "url": "shaders/spec-spherical-harmonics-light.wgsl",
     "description": "Spherical harmonics lighting derived from image content. Computes SH coefficients from local image samples and applies them to depth-derived normals for realistic ambient lighting.",
     "tags": [
       "spherical-harmonics",
@@ -9144,7 +9144,7 @@
   {
     "id": "spec-temporal-path-tracer",
     "name": "Temporal Path Tracer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-temporal-path-tracer.wgsl",
+    "url": "shaders/spec-temporal-path-tracer.wgsl",
     "description": "2D path tracer with temporal accumulation. Casts light rays that bounce off image edges, accumulating Monte Carlo samples over time for soft global illumination and color bleeding.",
     "tags": [
       "path-tracing",
@@ -9200,7 +9200,7 @@
   {
     "id": "spectral-bleed-confine",
     "name": "Spectral Bleed Confine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-bleed-confine.wgsl",
+    "url": "shaders/spectral-bleed-confine.wgsl",
     "description": "Spectral Bleed Confine",
     "tags": [
       "advanced hybrid"
@@ -9251,7 +9251,7 @@
   {
     "id": "spectral-flow-sorting",
     "name": "Spectral Flow Sorting",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-flow-sorting.wgsl",
+    "url": "shaders/spectral-flow-sorting.wgsl",
     "description": "Optical flow-based pixel sorting with spectral analysis. Pixels flow and sort along motion vectors.",
     "features": [
       "mouse-driven",
@@ -9324,7 +9324,7 @@
   {
     "id": "spectral-flow-structure",
     "name": "Spectral Flow Structure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-flow-structure.wgsl",
+    "url": "shaders/spectral-flow-structure.wgsl",
     "description": "Structure-tensor-guided pixel sorting with Line Integral Convolution. Eigenvectors from the structure tensor drive sort direction; coherency modulates blend strength. LIC adds flow-line texture. Audio-reactive with mouse vortices.",
     "features": [
       "advanced-hybrid",
@@ -9398,7 +9398,7 @@
   {
     "id": "steamy-glass-volumetric",
     "name": "Steamy Glass Volumetric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/steamy-glass-volumetric.wgsl",
+    "url": "shaders/steamy-glass-volumetric.wgsl",
     "description": "Steamy Glass Volumetric",
     "tags": [
       "steamy-glass",
@@ -9455,7 +9455,7 @@
   {
     "id": "stellar-plasma-blackbody",
     "name": "Stellar Plasma Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/stellar-plasma-blackbody.wgsl",
+    "url": "shaders/stellar-plasma-blackbody.wgsl",
     "description": "Cosmic nebula domain-warped FBM blended with Planck's law blackbody thermal coloring. Energy intensity drives temperature mapping — cool voids glow ember-red, hot plasma cores burn blue-white with physically-correct radiance scaling.",
     "tags": [
       "blackbody",
@@ -9514,7 +9514,7 @@
   {
     "id": "tensor-flow-morphological",
     "name": "Tensor Flow Morphological",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tensor-flow-morphological.wgsl",
+    "url": "shaders/tensor-flow-morphological.wgsl",
     "description": "Depth-aware tensor eigenwarp with morphological post-processing. Erosion darkens compressed tensor regions, dilation brightens tensile regions. Gradient highlights edges created by tensor warping.",
     "features": [
       "advanced-hybrid",
@@ -9631,7 +9631,7 @@
   {
     "id": "thermal-touch-blackbody",
     "name": "Thermal Touch Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/thermal-touch-blackbody.wgsl",
+    "url": "shaders/thermal-touch-blackbody.wgsl",
     "description": "Mouse-driven thermal camera with blackbody radiation coloring. The cursor acts as a localized heat source and image brightness maps to physically-correct temperature via Planck's law.",
     "tags": [
       "thermal",
@@ -9686,7 +9686,7 @@
   {
     "id": "thermal-vision-blackbody",
     "name": "Thermal Vision Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/thermal-vision-blackbody.wgsl",
+    "url": "shaders/thermal-vision-blackbody.wgsl",
     "description": "Physically-correct thermal vision camera using blackbody radiation via Planck's law. Image luminance maps to real temperature colors, with mouse acting as a localized heat source and configurable sensor contrast.",
     "tags": [
       "thermal",
@@ -9742,7 +9742,7 @@
   {
     "id": "vaporwave-horizon-prismatic",
     "name": "Vaporwave Horizon Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vaporwave-horizon-prismatic.wgsl",
+    "url": "shaders/vaporwave-horizon-prismatic.wgsl",
     "description": "Vaporwave Horizon Prismatic",
     "tags": [
       "vaporwave-horizon",
@@ -9799,7 +9799,7 @@
   {
     "id": "vhs-tracking-bilateral",
     "name": "VHS Tracking Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vhs-tracking-bilateral.wgsl",
+    "url": "shaders/vhs-tracking-bilateral.wgsl",
     "description": "Full VHS signal chain physics with edge-preserving bilateral smoothing. Timebase jitter, chroma noise, and control track dropouts are filtered through a bilateral dream, creating a soft analog degradation while preserving edges.",
     "features": [
       "advanced-hybrid",
@@ -9870,7 +9870,7 @@
   {
     "id": "viscous-drag-bilateral",
     "name": "Viscous Drag Bilateral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/viscous-drag-bilateral.wgsl",
+    "url": "shaders/viscous-drag-bilateral.wgsl",
     "description": "Viscous Drag Bilateral",
     "tags": [
       "viscous-drag",
@@ -9927,7 +9927,7 @@
   {
     "id": "vortex-warp-coupled",
     "name": "Vortex Warp Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-warp-coupled.wgsl",
+    "url": "shaders/vortex-warp-coupled.wgsl",
     "description": "Catalog entry for Vortex Warp Coupled.",
     "tags": [
       "vortex-warp",
@@ -9984,7 +9984,7 @@
   {
     "id": "warp-drive-blackbody",
     "name": "Warp Drive Blackbody",
-    "url": "https://test.1ink.us/image_video_effects/shaders/warp-drive-blackbody.wgsl",
+    "url": "shaders/warp-drive-blackbody.wgsl",
     "description": "Catalog entry for Warp Drive Blackbody.",
     "tags": [
       "radial-blur",
@@ -10043,7 +10043,7 @@
   {
     "id": "wave-equation-rgba-fluid",
     "name": "Wave Equation RGBA Fluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/wave-equation-rgba-fluid.wgsl",
+    "url": "shaders/wave-equation-rgba-fluid.wgsl",
     "description": "Coupled wave equation and incompressible fluid simulation packed into RGBA32FLOAT. Wave height and velocity drive fluid motion while fluid pressure dampens waves. Dye advection visualizes the combined flow field with rainbow phase coloring.",
     "tags": [
       "wave",

--- a/public/shader-lists/artistic.json
+++ b/public/shader-lists/artistic.json
@@ -2,7 +2,7 @@
   {
     "id": "alpha-paint-thickness",
     "name": "Alpha Paint Thickness",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-paint-thickness.wgsl",
+    "url": "shaders/alpha-paint-thickness.wgsl",
     "description": "Impasto paint thickness simulation where alpha tracks paint depth. Thin paint creates transparent washes, medium shows full color, thick paint catches specular highlights and casts micro-shadows. Mouse paints with color-cycling brush; ripples create splatters.",
     "tags": [
       "paint",
@@ -61,7 +61,7 @@
   {
     "id": "alpha-watercolor-wetness",
     "name": "Alpha Watercolor Wetness",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-watercolor-wetness.wgsl",
+    "url": "shaders/alpha-watercolor-wetness.wgsl",
     "description": "Watercolor simulation with wetness map in alpha. Pigment flows with water gradients via capillary action. Wet areas allow bleeding; dry areas lock pigment. Mouse drops colored water; ripples add water drops. Authentic dark-edge effects at wet boundaries.",
     "tags": [
       "watercolor",
@@ -122,7 +122,7 @@
     "name": "Ambient Liquid",
     "category": "artistic",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ambient-liquid.wgsl",
+    "url": "shaders/ambient-liquid.wgsl",
     "description": "Curl-noise-driven ambient liquid distortion with mouse attraction, branchless ripple eddies, HSV color shift, depth-aware semantic alpha, and ACES tone mapping.",
     "features": [
       "mouse-driven",
@@ -193,7 +193,7 @@
   {
     "id": "anisotropic-kuwahara",
     "name": "Van Gogh Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/anisotropic-kuwahara.wgsl",
+    "url": "shaders/anisotropic-kuwahara.wgsl",
     "description": "Anisotropic Kuwahara filter creating painterly Van Gogh-style brushstroke effects.",
     "params": [
       {
@@ -239,7 +239,7 @@
   {
     "id": "artistic_painterly_oil",
     "name": "Oil Painting",
-    "url": "https://test.1ink.us/image_video_effects/shaders/artistic_painterly_oil.wgsl",
+    "url": "shaders/artistic_painterly_oil.wgsl",
     "description": "Oil painting effect with anisotropic Kuwahara filter, impasto texture, wet paint specular highlights, and canvas texture",
     "tags": [
       "oil",
@@ -293,7 +293,7 @@
   {
     "id": "astral-kaleidoscope-gemini",
     "name": "Astral Kaleidoscope Gemini",
-    "url": "https://test.1ink.us/image_video_effects/shaders/astral-kaleidoscope-gemini.wgsl",
+    "url": "shaders/astral-kaleidoscope-gemini.wgsl",
     "description": "An enhanced cosmic kaleidoscope with astral color schemes, featuring dynamic, time-driven evolution and intricate, mouse-driven fractal details.",
     "features": [
       "mouse-driven",
@@ -341,7 +341,7 @@
   {
     "id": "astral-kaleidoscope-grokcf1",
     "name": "Astral Kaleidoscope grokcf1",
-    "url": "https://test.1ink.us/image_video_effects/shaders/astral-kaleidoscope-grokcf1.wgsl",
+    "url": "shaders/astral-kaleidoscope-grokcf1.wgsl",
     "description": "An enhanced cosmic kaleidoscope with astral color schemes, featuring dynamic, time-driven evolution and intricate, mouse-driven fractal details.",
     "features": [
       "mouse-driven",
@@ -389,7 +389,7 @@
   {
     "id": "astral-kaleidoscope",
     "name": "Astral Kaleidoscope",
-    "url": "https://test.1ink.us/image_video_effects/shaders/astral-kaleidoscope.wgsl",
+    "url": "shaders/astral-kaleidoscope.wgsl",
     "description": "Cosmic kaleidoscope with astral color schemes.",
     "features": [
       "mouse-driven"
@@ -436,7 +436,7 @@
   {
     "id": "astral-veins",
     "name": "Astral Veins",
-    "url": "https://test.1ink.us/image_video_effects/shaders/astral-veins.wgsl",
+    "url": "shaders/astral-veins.wgsl",
     "description": "Glowing, flowing veins that wrap around geometry, pulse, and colour‑cycle. Click to seed new veins.",
     "params": [
       {
@@ -482,7 +482,7 @@
   {
     "id": "aurora-rift-2",
     "name": "Aurora Rift V2",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-2.wgsl",
+    "url": "shaders/aurora-rift-2.wgsl",
     "description": "Enhanced aurora effects with improved color gradients.",
     "features": [
       "mouse-driven"
@@ -529,7 +529,7 @@
   {
     "id": "aurora-rift-gemini",
     "name": "Aurora Rift Gemini",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-gemini.wgsl",
+    "url": "shaders/aurora-rift-gemini.wgsl",
     "description": "An enhanced simulation of aurora borealis, with dynamic, time-driven color shifts, deeper atmospheric rifts, and shimmering, mouse-driven particle effects.",
     "features": [
       "mouse-driven",
@@ -577,7 +577,7 @@
   {
     "id": "aurora-rift",
     "name": "Aurora Rift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift.wgsl",
+    "url": "shaders/aurora-rift.wgsl",
     "description": "Aurora borealis-inspired lighting effects with atmospheric rifts.",
     "features": [
       "mouse-driven"
@@ -624,7 +624,7 @@
   {
     "id": "bioluminescent",
     "name": "Bioluminescent Growth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bioluminescent.wgsl",
+    "url": "shaders/bioluminescent.wgsl",
     "description": "Living, organic growth patterns that spread across surfaces like glowing fungus. Click to plant spores, watch them grow over time with depth-aware branching.",
     "params": [
       {
@@ -676,7 +676,7 @@
   {
     "id": "boids",
     "name": "Boids Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/boids.wgsl",
+    "url": "shaders/boids.wgsl",
     "description": "Flocking boids with reveal masking and simple attraction mechanics.",
     "features": [
       "mouse-driven"
@@ -723,7 +723,7 @@
   {
     "id": "chromatic-crawler",
     "name": "Chromatic Crawler",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-crawler.wgsl",
+    "url": "shaders/chromatic-crawler.wgsl",
     "description": "Smooth hue-rotating regions that crawl across the screen with Voronoi-based patterns, temporal feedback trails, and alpha translucency blending.",
     "features": [
       "mouse-driven",
@@ -772,7 +772,7 @@
     "id": "chromatic-focus",
     "name": "Chromatic Focus",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-focus.wgsl",
+    "url": "shaders/chromatic-focus.wgsl",
     "description": "Breathing spectral focus keeps the cursor region crisp while the outer image blooms into colorful chromatic bokeh. Enhanced with OkLab mixing, iridescent thin-film interference, Mie scattering haze, split-tone grading, and ACES filmic tone mapping.",
     "features": [
       "mouse-driven",
@@ -829,7 +829,7 @@
   {
     "id": "chromatic-folds-2",
     "name": "Chromatic Folds V2",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-folds-2.wgsl",
+    "url": "shaders/chromatic-folds-2.wgsl",
     "description": "Enhanced geometric color folding with improved warping.",
     "features": [
       "mouse-driven"
@@ -876,7 +876,7 @@
   {
     "id": "chromatic-folds-gemini",
     "name": "Chromatic Folds Gemini",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-folds-gemini.wgsl",
+    "url": "shaders/chromatic-folds-gemini.wgsl",
     "description": "An advanced geometric color folding and warping effect with dynamic, time-driven animation, fractal layering, and interactive, mouse-driven vortex manipulation.",
     "features": [
       "mouse-driven",
@@ -924,7 +924,7 @@
   {
     "id": "chromatic-folds",
     "name": "Chromatic Folds",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-folds.wgsl",
+    "url": "shaders/chromatic-folds.wgsl",
     "description": "Geometric color folding and warping effects.",
     "features": [
       "mouse-driven"
@@ -971,7 +971,7 @@
   {
     "id": "chromatic-infection",
     "name": "Chromatic Infection",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-infection.wgsl",
+    "url": "shaders/chromatic-infection.wgsl",
     "description": "Strong colours spread like a living organism, infecting neutral regions with organic, pulsing tendrils. Watch vibrant hues consume the dull!",
     "params": [
       {
@@ -1018,7 +1018,7 @@
   {
     "id": "chromatic-manifold-2",
     "name": "Chromatic Manifold V2",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-manifold-2.wgsl",
+    "url": "shaders/chromatic-manifold-2.wgsl",
     "description": "Enhanced 4D topological color manifold.",
     "features": [
       "mouse-driven"
@@ -1065,7 +1065,7 @@
   {
     "id": "chromatic-manifold",
     "name": "Chromatic Manifold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-manifold.wgsl",
+    "url": "shaders/chromatic-manifold.wgsl",
     "description": "4D topological color manifold with HDR tears, temporal persistence, and depth-driven curvature.",
     "tags": [
       "filter",
@@ -1125,7 +1125,7 @@
   {
     "id": "chromatic-phase-inversion",
     "name": "Chromatic Phase Inversion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-phase-inversion.wgsl",
+    "url": "shaders/chromatic-phase-inversion.wgsl",
     "description": "Individual color channels are inverted by a slowly evolving temporal phase, causing color ghosts that drift ahead or behind the true image in surreal independent waves. Audio reactivity pulses phase speed and ghost offset with the beat.",
     "tags": [
       "chromatic",
@@ -1185,7 +1185,7 @@
   {
     "id": "chromatographic-separation",
     "name": "Chromatographic Separation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatographic-separation.wgsl",
+    "url": "shaders/chromatographic-separation.wgsl",
     "description": "RGB channel fluid simulation with separate viscosities, wind forces, and inter-layer drag.",
     "params": [
       {
@@ -1234,7 +1234,7 @@
   {
     "id": "cosmic-flow",
     "name": "Cosmic Flow Pro",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cosmic-flow.wgsl",
+    "url": "shaders/cosmic-flow.wgsl",
     "description": "Depth-aware ethereal energy field with domain warping, temporal trails, chromatic aberration, and multiple color modes ranges.",
     "params": [
       {
@@ -1286,7 +1286,7 @@
   {
     "id": "distortion_gravitational_lens",
     "name": "Gravitational Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/distortion_gravitational_lens.wgsl",
+    "url": "shaders/distortion_gravitational_lens.wgsl",
     "description": "Einstein ring gravitational lensing with Schwarzschild metric deflection, accretion disk blackbody radiation, and chromatic aberration",
     "tags": [
       "gravity",
@@ -1341,7 +1341,7 @@
   {
     "id": "dla-crystals",
     "name": "DLA Crystal Growth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/dla-crystals.wgsl",
+    "url": "shaders/dla-crystals.wgsl",
     "description": "Diffusion-limited aggregation creating fractal crystal structures that grow from click points.",
     "params": [
       {
@@ -1392,7 +1392,7 @@
   {
     "id": "double-exposure-zoom",
     "name": "Double Exposure Zoom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/double-exposure-zoom.wgsl",
+    "url": "shaders/double-exposure-zoom.wgsl",
     "description": "Multi-scale double exposure with luminance-based matte extraction, film stock color response curves, light leak artifacts, ACES tone mapping, and chromatic aberration on zoom edges. Bass drives zoom speed, mouse controls secondary exposure position with depth parallax.",
     "params": [
       {
@@ -1444,7 +1444,7 @@
   {
     "id": "echo-trace",
     "name": "Temporal Velocity Echo",
-    "url": "https://test.1ink.us/image_video_effects/shaders/echo-trace.wgsl",
+    "url": "shaders/echo-trace.wgsl",
     "description": "Predictive velocity echo field combining structure-tensor advection, smoothed mouse-motion extrapolation, deformed brush trails, curl-noise flow, and temporal feedback displacement.",
     "params": [
       {
@@ -1503,7 +1503,7 @@
     "id": "encaustic-wax",
     "name": "Encaustic Wax",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/encaustic-wax.wgsl",
+    "url": "shaders/encaustic-wax.wgsl",
     "description": "Thermal wax flow simulation with layered strata, subsurface scattering, metallic pigment sparkle, HDR specular ridges, ACES tone mapping, and canvas grain. Bass drives heat gun intensity; mouse applies local heat; depth controls wax thickness.",
     "features": [
       "mouse-driven",
@@ -1557,7 +1557,7 @@
     "id": "engraving-stipple",
     "name": "Engraving Stipple",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/engraving-stipple.wgsl",
+    "url": "shaders/engraving-stipple.wgsl",
     "description": "Upgraded copperplate engraving with gradient-aware contour hatching, burr effects at crossings, ink pooling, paper texture, and chromatic edge darkening. Bass drives tool pressure, mouse acts as burin, depth controls line width.",
     "features": [
       "mouse-driven",
@@ -1609,7 +1609,7 @@
   {
     "id": "fabric-step",
     "name": "Fabric of Reality",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fabric-step.wgsl",
+    "url": "shaders/fabric-step.wgsl",
     "description": "Mass-spring cloth simulation with Verlet integration, constraint solving, and interactive tearing mechanics.",
     "params": [
       {
@@ -1656,7 +1656,7 @@
   {
     "id": "film-cross-process",
     "name": "Film Cross-Process",
-    "url": "https://test.1ink.us/image_video_effects/shaders/film-cross-process.wgsl",
+    "url": "shaders/film-cross-process.wgsl",
     "description": "Simulates E6 slide film developed in C41 negative chemistry. Each RGB channel is routed through a different S-curve (lifted shadows, crushed mids, blown highlights), the colour gamut is skewed so greens shift cyan and reds shift orange-yellow, film grain is layered in, and the image is pushed toward the iconic high-contrast vivid-yet-desaturated cross-processed aesthetic. Bass boosts contrast punch; mids intensify the colour skew; treble raises grain texture.",
     "tags": [
       "film",
@@ -1714,7 +1714,7 @@
   {
     "id": "frosty-window",
     "name": "Frosty Window",
-    "url": "https://test.1ink.us/image_video_effects/shaders/frosty-window.wgsl",
+    "url": "shaders/frosty-window.wgsl",
     "description": "Animated frost crystal patterns on glass with audio-reactive growth and mouse-driven melting.",
     "params": [
       {
@@ -1767,7 +1767,7 @@
   {
     "id": "galaxy-sim",
     "name": "Galaxy Simulation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/galaxy.wgsl",
+    "url": "shaders/galaxy.wgsl",
     "description": "Audio-reactive spiral galaxy with breathing arms, diffraction-spike stars, mouse-parallax center, and silence-driven reverse flow.",
     "features": [
       "depth-aware",
@@ -1824,7 +1824,7 @@
   {
     "id": "gen-chrono-erosion-feedback-melting",
     "name": "Chrono Erosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chrono-erosion-feedback-melting.wgsl",
+    "url": "shaders/gen-chrono-erosion-feedback-melting.wgsl",
     "description": "Datamosh-like flow effect where video melts along a curl-noise vector field with feedback decay and audio-driven turbulence.",
     "features": [
       "audio-reactive",
@@ -1879,7 +1879,7 @@
   {
     "id": "glass_refraction_alpha",
     "name": "Glass Refraction RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass_refraction_alpha.wgsl",
+    "url": "shaders/glass_refraction_alpha.wgsl",
     "description": "Ray-marched glass blobs with Snell's law refraction, Fresnel reflectivity, chromatic dispersion. Alpha = transparency based on thickness and angle.",
     "tags": [
       "interactive",
@@ -1942,7 +1942,7 @@
   {
     "id": "green-tracer",
     "name": "Green Tracer World",
-    "url": "https://test.1ink.us/image_video_effects/shaders/green-tracer.wgsl",
+    "url": "shaders/green-tracer.wgsl",
     "description": "Surreal green video effect with persistent motion trails, edge glow, and film grain. Perfect for toxic/night‑vision aesthetics.",
     "params": [
       {
@@ -1990,7 +1990,7 @@
     "id": "halftone-reveal",
     "name": "Halftone Reveal",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/halftone-reveal.wgsl",
+    "url": "shaders/halftone-reveal.wgsl",
     "description": "CMYK halftone reveal with stipple patterns, per-channel rotated screening, dot-gain simulation, moiré overlap, paper texture, and depth-controlled perspective dot sizing.",
     "params": [
       {
@@ -2043,7 +2043,7 @@
   {
     "id": "holographic-contour",
     "name": "Holographic Contour",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-contour.wgsl",
+    "url": "shaders/holographic-contour.wgsl",
     "updated": true,
     "workgroup_size": [
       16,
@@ -2132,7 +2132,7 @@
     "id": "ink-diffusion",
     "name": "Ink Diffusion",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ink-diffusion.wgsl",
+    "url": "shaders/ink-diffusion.wgsl",
     "description": "Navier-Stokes advection-diffusion ink simulation in water with vorticity confinement and surface tension at boundaries. Sumi-e ink wash with turbulent eddies, paper fiber texture, chromatic edge darkening, ACES tone mapping, and HDR specular on wet regions.",
     "features": [
       "mouse-driven",
@@ -2194,7 +2194,7 @@
   {
     "id": "ink_dispersion_alpha",
     "name": "Ink Dispersion RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ink_dispersion_alpha.wgsl",
+    "url": "shaders/ink_dispersion_alpha.wgsl",
     "updated": true,
     "workgroup_size": [
       16,
@@ -2292,7 +2292,7 @@
   {
     "id": "ion-stream",
     "name": "Ion Stream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ion-stream.wgsl",
+    "url": "shaders/ion-stream.wgsl",
     "features": [
       "upgraded-rgba",
       "depth-aware",
@@ -2345,7 +2345,7 @@
   {
     "id": "iridescent-oil-slick",
     "name": "Iridescent Oil Slick",
-    "url": "https://test.1ink.us/image_video_effects/shaders/iridescent-oil-slick.wgsl",
+    "url": "shaders/iridescent-oil-slick.wgsl",
     "description": "Mesmerizing thin-film interference simulation that recreates the rainbow patterns of oil on water or soap bubbles. Features flowing organic motion, hexagonal bubble cells, and mouse-reactive disturbances.",
     "tags": [
       "iridescent",
@@ -2402,7 +2402,7 @@
     "id": "iso-hills",
     "name": "Iso Hills v2",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/iso-hills.wgsl",
+    "url": "shaders/iso-hills.wgsl",
     "description": "Topographic terrain rendering with fBm-generated hills, hydraulic erosion, contour hachures, and depth-based atmospheric haze. Mouse drops carve water channels; bass triggers rainfall.",
     "params": [
       {
@@ -2458,7 +2458,7 @@
   {
     "id": "lenia",
     "name": "Lenia Cellular Automata",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lenia.wgsl",
+    "url": "shaders/lenia.wgsl",
     "description": "Continuous cellular automata with audio-driven growth rate, chromatic species colors (R/G/B evolve at different thresholds), temporal accumulation, mouse life injection, and neighborhood kernel expansion.",
     "features": [
       "mouse-driven",
@@ -2514,7 +2514,7 @@
   {
     "id": "lidar",
     "name": "LiDAR Scanner Pro",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lidar.wgsl",
+    "url": "shaders/lidar.wgsl",
     "description": "Multi-mode LiDAR with point clouds, persistence trails, and 3D edge detection. Modes: Linear/Radial/Spiral scan.",
     "params": [
       {
@@ -2560,7 +2560,7 @@
   {
     "id": "liquid-prism-cascade",
     "name": "Liquid Prism Cascade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-prism-cascade.wgsl",
+    "url": "shaders/liquid-prism-cascade.wgsl",
     "updated": true,
     "workgroup_size": [
       16,
@@ -2659,7 +2659,7 @@
     "id": "luminance-wind",
     "name": "Luminance Wind",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luminance-wind.wgsl",
+    "url": "shaders/luminance-wind.wgsl",
     "description": "Pixels are blown by a curl-noise wind field. Lighter pixels travel further. Chromatic drift separates R/B channels. Audio gusts boost wind strength; depth creates parallax layering.",
     "params": [
       {
@@ -2717,7 +2717,7 @@
   {
     "id": "magnetic-dipole",
     "name": "Magnetic Dipole Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-dipole.wgsl",
+    "url": "shaders/magnetic-dipole.wgsl",
     "description": "Magnetic field visualization with iron filing alignment and dipole physics.",
     "params": [
       {
@@ -2763,7 +2763,7 @@
   {
     "id": "melting-oil",
     "name": "Melting Oil",
-    "url": "https://test.1ink.us/image_video_effects/shaders/melting-oil.wgsl",
+    "url": "shaders/melting-oil.wgsl",
     "description": "Sobel gradient-driven oil-paint flow with viscosity and hue shifts.",
     "features": [
       "mouse-driven",
@@ -2820,7 +2820,7 @@
   {
     "id": "mirror-dimension",
     "name": "Mirror Dimension",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mirror-dimension.wgsl",
+    "url": "shaders/mirror-dimension.wgsl",
     "description": "A rotating kaleidoscope that fractures reality. Mouse moves the center of symmetry.",
     "features": [
       "mouse-driven"
@@ -2863,7 +2863,7 @@
   {
     "id": "mosaic-reveal",
     "name": "Mosaic Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mosaic-reveal.wgsl",
+    "url": "shaders/mosaic-reveal.wgsl",
     "description": "Mosaic reveal with hexagonal/square grids, flood-fill reveal from the mouse, OkLab perceptual blending, audio-reactive blackbody rim glow, temporal trails, ACES tone mapping, and advanced layered alpha compositing.",
     "features": [
       "upgraded-rgba",
@@ -2922,7 +2922,7 @@
     "id": "mouse-pixel-sort",
     "name": "Mouse Pixel Sort",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-pixel-sort.wgsl",
+    "url": "shaders/mouse-pixel-sort.wgsl",
     "description": "Multi-layer luminance-based pixel sorting with FBM organic thresholds, curl-noise sorting directions, De Jong strange attractor warping, and Voronoi cellular patterns. Audio-reactive sparkle trails and dual-layer compositing.",
     "features": [
       "mouse-driven",
@@ -2981,7 +2981,7 @@
   {
     "id": "multi-turing",
     "name": "Multiscale Turing Patterns",
-    "url": "https://test.1ink.us/image_video_effects/shaders/multi-turing.wgsl",
+    "url": "shaders/multi-turing.wgsl",
     "description": "Multiple reaction-diffusion systems at different scales combined for organic pattern generation.",
     "params": [
       {
@@ -3027,7 +3027,7 @@
   {
     "id": "navier-stokes-dye",
     "name": "Navier-Stokes Dye",
-    "url": "https://test.1ink.us/image_video_effects/shaders/navier-stokes-dye.wgsl",
+    "url": "shaders/navier-stokes-dye.wgsl",
     "description": "Velocity advection and dye injection with a pressure-like solve placeholder.",
     "features": [
       "mouse-driven",
@@ -3084,7 +3084,7 @@
   {
     "id": "nebulous-dream",
     "name": "Nebulous Dream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/nebulous-dream.wgsl",
+    "url": "shaders/nebulous-dream.wgsl",
     "description": "Swirling vortex of rainbow candy clouds with fractal noise and flow fields.",
     "features": [
       "mouse-driven"
@@ -3131,7 +3131,7 @@
   {
     "id": "neon-contour-interactive",
     "name": "Neon Contour",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-contour-interactive.wgsl",
+    "url": "shaders/neon-contour-interactive.wgsl",
     "description": "Interactive edge detection with neon glow responsive to mouse proximity.",
     "features": [
       "mouse-driven",
@@ -3179,7 +3179,7 @@
   {
     "id": "neon-edge-diffusion",
     "name": "Neon Edge Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-edge-diffusion.wgsl",
+    "url": "shaders/neon-edge-diffusion.wgsl",
     "description": "Shared-memory Sobel edge detection with hex-bokeh neon glow, ACES tone mapping, and semantic alpha emission.",
     "features": [
       "mouse-driven",
@@ -3244,7 +3244,7 @@
   {
     "id": "neural-dreamscape",
     "name": "Neural Dreamscape",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-dreamscape.wgsl",
+    "url": "shaders/neural-dreamscape.wgsl",
     "description": "Neural network-inspired dreamlike visuals.",
     "features": [
       "mouse-driven"
@@ -3292,7 +3292,7 @@
     "id": "neural-resonance",
     "name": "Neural Resonance",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-resonance.wgsl",
+    "url": "shaders/neural-resonance.wgsl",
     "description": "A temporal synaptic feedback field bends the source image into chromatic neural currents around the cursor.",
     "features": [
       "mouse-driven",
@@ -3341,7 +3341,7 @@
   {
     "id": "parallax_depth_layers",
     "name": "Parallax Layers RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/parallax_depth_layers.wgsl",
+    "url": "shaders/parallax_depth_layers.wgsl",
     "updated": true,
     "workgroup_size": [
       16,
@@ -3439,7 +3439,7 @@
   {
     "id": "particle_dreams_alpha",
     "name": "Particle Dreams RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/particle_dreams_alpha.wgsl",
+    "url": "shaders/particle_dreams_alpha.wgsl",
     "updated": true,
     "workgroup_size": [
       16,
@@ -3535,7 +3535,7 @@
   {
     "id": "physarum-gemini",
     "name": "Physarum Gemini",
-    "url": "https://test.1ink.us/image_video_effects/shaders/physarum-gemini.wgsl",
+    "url": "shaders/physarum-gemini.wgsl",
     "description": "An advanced, agent-based slime mold simulation with emergent, time-driven growth patterns, complex nutrient interaction, and mouse-driven agent spawning.",
     "features": [
       "mouse-driven",
@@ -3583,7 +3583,7 @@
   {
     "id": "physarum-grokcf1",
     "name": "Physarum grokcf1",
-    "url": "https://test.1ink.us/image_video_effects/shaders/physarum-grokcf1.wgsl",
+    "url": "shaders/physarum-grokcf1.wgsl",
     "description": "An advanced, agent-based slime mold simulation with emergent, time-driven growth patterns, complex nutrient interaction, and mouse-driven agent spawning.",
     "features": [
       "mouse-driven",
@@ -3631,7 +3631,7 @@
   {
     "id": "physarum",
     "name": "Physarum Slime Mold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/physarum.wgsl",
+    "url": "shaders/physarum.wgsl",
     "description": "Agent-based slime mold texture feeder that creates trails and networks.",
     "features": [
       "mouse-driven",
@@ -3683,7 +3683,7 @@
   {
     "id": "plasma",
     "name": "Plasma Ball",
-    "url": "https://test.1ink.us/image_video_effects/shaders/plasma.wgsl",
+    "url": "shaders/plasma.wgsl",
     "description": "",
     "tags": [
       "procedural",
@@ -3735,7 +3735,7 @@
   {
     "id": "poincare-tile",
     "name": "Hyperbolic Tiling",
-    "url": "https://test.1ink.us/image_video_effects/shaders/poincare-tile.wgsl",
+    "url": "shaders/poincare-tile.wgsl",
     "description": "Poincaré disk hyperbolic geometry with Möbius transformations and animated tilings.",
     "params": [
       {
@@ -3780,7 +3780,7 @@
   {
     "id": "polka-dot-reveal",
     "name": "Polka Dot Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/polka-dot-reveal.wgsl",
+    "url": "shaders/polka-dot-reveal.wgsl",
     "description": "Phase-B advanced-alpha halftone effect with 16x16 workgroups, spring-damped mouse follow, attack/release audio envelope, per-cell hash jitter, and temporal feedback trails. Alpha is now composited through depth-layered fade, luminance keying, edge-preservation, and an interaction-energy boost so the 3-slot chain blends meaningfully.",
     "features": [
       "mouse-driven",
@@ -3843,7 +3843,7 @@
   {
     "id": "porcelain-fracture-glow",
     "name": "Porcelain Fracture Glow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/porcelain-fracture-glow.wgsl",
+    "url": "shaders/porcelain-fracture-glow.wgsl",
     "description": "The image is rendered on delicate porcelain that develops fine luminous cracks. The cracks follow image edges and can be drawn with the mouse. Bass makes the golden light pulse and sing through the fractures.",
     "tags": [
       "porcelain",
@@ -3900,7 +3900,7 @@
   {
     "id": "quantum-foam",
     "name": "Quantum Foam",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-foam.wgsl",
+    "url": "shaders/quantum-foam.wgsl",
     "description": "Quantum foam texture with spacetime fluctuations.",
     "features": [
       "mouse-driven",
@@ -3949,7 +3949,7 @@
   {
     "id": "quantum-fractal",
     "name": "Quantum Fractal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-fractal.wgsl",
+    "url": "shaders/quantum-fractal.wgsl",
     "description": "Fractal quantum interference patterns.",
     "tags": [
       "filter",
@@ -4009,7 +4009,7 @@
   {
     "id": "quantum-smear",
     "name": "Quantum Smear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-smear.wgsl",
+    "url": "shaders/quantum-smear.wgsl",
     "description": "Quantum particle disintegration with stochastic advection and pointillist effects.",
     "features": [
       "mouse-driven"
@@ -4056,7 +4056,7 @@
   {
     "id": "quantum-wormhole",
     "name": "Quantum Wormhole",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-wormhole.wgsl",
+    "url": "shaders/quantum-wormhole.wgsl",
     "description": "Wormhole-like spacetime distortion effects.",
     "features": [
       "mouse-driven"
@@ -4103,7 +4103,7 @@
   {
     "id": "radiating-displacement",
     "name": "Radiating Displacement",
-    "url": "https://test.1ink.us/image_video_effects/shaders/radiating-displacement.wgsl",
+    "url": "shaders/radiating-displacement.wgsl",
     "description": "Rippling displacement waves emanate only from strong colours; neutrals stay sharp. Mouse-click to seed ripples.",
     "params": [
       {
@@ -4150,7 +4150,7 @@
   {
     "id": "radiating-haze",
     "name": "Radiating Haze",
-    "url": "https://test.1ink.us/image_video_effects/shaders/radiating-haze.wgsl",
+    "url": "shaders/radiating-haze.wgsl",
     "description": "Animated aura around strong colours; browns, greys & blacks are ignored. Now with colour-mode switch.",
     "params": [
       {
@@ -4198,7 +4198,7 @@
     "id": "rain",
     "name": "Rain",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rain.wgsl",
+    "url": "shaders/rain.wgsl",
     "description": "Upgraded rain with gravity-accelerated streak physics, chromatic droplet lensing, HDR bloom on light sources, fog layers, and splash particles. Bass drives intensity, mouse creates wind gusts, depth controls droplet perspective.",
     "features": [
       "mouse-driven",
@@ -4252,7 +4252,7 @@
     "id": "rainbow-cloud",
     "name": "Rainbow Cloud",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rainbow-cloud.wgsl",
+    "url": "shaders/rainbow-cloud.wgsl",
     "description": "Ray-marched volumetric clouds with 3D Perlin noise density, Mie scattering, iridescent nacreous colors, HDR god rays through cloud gaps, ACES tone mapping, and atmospheric perspective. Bass drives cloud turbulence, mouse scatters cloud particles, depth controls density layering.",
     "features": [
       "mouse-driven",
@@ -4309,7 +4309,7 @@
   {
     "id": "reaction-diffusion",
     "name": "Reaction-Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/reaction-diffusion.wgsl",
+    "url": "shaders/reaction-diffusion.wgsl",
     "description": "Grey-Scott style color bleed with cross-channel inhibition.",
     "features": [
       "mouse-driven"
@@ -4356,7 +4356,7 @@
   {
     "id": "recursion-mirror-vortex",
     "name": "Recursion Mirror Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/recursion-mirror-vortex.wgsl",
+    "url": "shaders/recursion-mirror-vortex.wgsl",
     "description": "Nested Möbius-fold mirrors that fold the image into itself at precise singularity points, creating infinite-hallway illusions that remain spatially coherent.",
     "tags": [
       "mirror",
@@ -4413,7 +4413,7 @@
   {
     "id": "rorschach-inkblot",
     "name": "Rorschach Inkblot",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rorschach-inkblot.wgsl",
+    "url": "shaders/rorschach-inkblot.wgsl",
     "description": "Symmetrical inkblot visualization with audio-driven ink flow, chromatic ink tints, temporal ink diffusion memory, mouse-controlled symmetry axis, and depth-aware ink density.",
     "params": [
       {
@@ -4472,7 +4472,7 @@
     "id": "rotoscope-ink",
     "name": "Rotoscope Ink",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rotoscope-ink.wgsl",
+    "url": "shaders/rotoscope-ink.wgsl",
     "description": "Upgraded rotoscope ink with temporal edge detection, brushstroke-tapered outlines following motion vectors, paint-bucket bleed, film grain, and chromatic separation on fast edges. Bass drives jitter, mouse paints strokes, depth controls parallax.",
     "features": [
       "mouse-driven",
@@ -4525,7 +4525,7 @@
   {
     "id": "snow",
     "name": "Blizzard (Depth-Aware)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/snow.wgsl",
+    "url": "shaders/snow.wgsl",
     "tags": [
       "filter",
       "image-processing"
@@ -4571,7 +4571,7 @@
   {
     "id": "spec-blue-noise-stipple",
     "name": "Blue Noise Stipple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-blue-noise-stipple.wgsl",
+    "url": "shaders/spec-blue-noise-stipple.wgsl",
     "description": "Blue-noise dithered pointillism rendering. Uses golden-ratio low-discrepancy sequences for perceptually optimal, uniformly-spaced dot distributions with smooth gradients and no aliasing.",
     "tags": [
       "pointillism",
@@ -4626,7 +4626,7 @@
   {
     "id": "spectral-bleed-confinement",
     "name": "Spectral Bleed & Confinement",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-bleed-confinement.wgsl",
+    "url": "shaders/spectral-bleed-confinement.wgsl",
     "description": "Specific color bands leak outward from image edges while being electromagnetically confined by competing channels, creating glowing halos that feel physically constrained. Audio reactivity pulses bleed radius and adds beat-synchronized flashes.",
     "tags": [
       "spectral",
@@ -4689,7 +4689,7 @@
   {
     "id": "spectral-slit-scan",
     "name": "Spectral Slit Scan",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-slit-scan.wgsl",
+    "url": "shaders/spectral-slit-scan.wgsl",
     "category": "artistic",
     "description": "Multi-slit spectral scan effect with 3 simultaneous parametric slits (sine wave, spiral, radial). Chromatic time smearing decomposes RGB across temporal offsets. HDR streak accumulation with ACES tone mapping. Bass drives slit velocity, mouse positions add parallax, and depth creates layered slit separation.",
     "tags": [
@@ -4751,7 +4751,7 @@
   {
     "id": "spectrogram-displace-pass1",
     "name": "Spectrogram Displace (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectrogram-displace-pass1.wgsl",
+    "url": "shaders/spectrogram-displace-pass1.wgsl",
     "description": "Spectrogram field generation: synthetic audio analysis, frequency bin calculation, perceptual color mapping, and displacement vector computation. Outputs spectrogram data to dataTextureA.",
     "tags": [
       "spectrogram",
@@ -4807,7 +4807,7 @@
   {
     "id": "spectrogram-displace-pass2",
     "name": "Spectrogram Displace (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectrogram-displace-pass2.wgsl",
+    "url": "shaders/spectrogram-displace-pass2.wgsl",
     "description": "Image displacement and compositing pass: applies spectrogram-driven displacement to the input image, blends with spectrogram colors, applies frequency-based color grading and vignette, and reacts to bass audio input.",
     "tags": [
       "spectrogram",
@@ -4865,7 +4865,7 @@
   {
     "id": "spectrogram-displace",
     "name": "Spectrogram Displace",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectrogram-displace.wgsl",
+    "url": "shaders/spectrogram-displace.wgsl",
     "description": "Audio-driven per-pixel displacements from an FFT texture.",
     "features": [
       "mouse-driven",
@@ -4914,7 +4914,7 @@
   {
     "id": "speed-lines-focus",
     "name": "Speed Lines Focus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/speed-lines-focus.wgsl",
+    "url": "shaders/speed-lines-focus.wgsl",
     "description": "Applies a radial zoom blur and manga-style speed lines focused on the mouse.",
     "params": [
       {
@@ -4963,7 +4963,7 @@
   {
     "id": "spirograph-reveal",
     "name": "Spirograph Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spirograph-reveal.wgsl",
+    "url": "shaders/spirograph-reveal.wgsl",
     "category": "artistic",
     "description": "True epicycloid/hypocycloid spirograph with multiple rotating gears and gear-ratio modulated patterns. Features metallic ink aesthetic with specular highlights, gradient fills along curve length, and HDR bloom at cusps. Bass drives rotation speed, mouse modulates gear ratio, and depth creates 3D depth layers.",
     "tags": [
@@ -5024,7 +5024,7 @@
   {
     "id": "static-reveal",
     "name": "Static Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/static-reveal.wgsl",
+    "url": "/shaders/static-reveal.wgsl",
     "category": "artistic",
     "description": "Multi-layer temporal static grain with chromatic displacement and depth-reactive decay. Fine + coarse noise layers plus per-channel chromatic shift driven by treble. Mouse scratches reveal video; bass intensifies static flicker.",
     "features": [
@@ -5081,7 +5081,7 @@
   {
     "id": "stella-orbit",
     "name": "Stellar Orbit",
-    "url": "https://test.1ink.us/image_video_effects/shaders/stella-orbit.wgsl",
+    "url": "shaders/stella-orbit.wgsl",
     "description": "Orbital motion patterns with stellar particle systems.",
     "tags": [
       "filter",
@@ -5133,7 +5133,7 @@
   {
     "id": "stipple-render",
     "name": "Stipple Render",
-    "url": "https://test.1ink.us/image_video_effects/shaders/stipple-render.wgsl",
+    "url": "shaders/stipple-render.wgsl",
     "category": "artistic",
     "description": "Weighted Voronoi stippling with Lloyd's relaxation approximation. Dot sizes match local luminance using blue noise distribution. Ink-on-paper aesthetic with dot bleeding, cross-hatching, and ACES tone mapping.",
     "params": [
@@ -5185,7 +5185,7 @@
   {
     "id": "temporal-echo",
     "name": "Temporal Echo",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-echo.wgsl",
+    "url": "shaders/temporal-echo.wgsl",
     "description": "Feedback buffer and history texture for temporally offset echoes.",
     "features": [
       "mouse-driven",
@@ -5238,7 +5238,7 @@
     "id": "thermal-vision",
     "name": "Thermal Vision",
     "category": "artistic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/thermal-vision.wgsl",
+    "url": "shaders/thermal-vision.wgsl",
     "description": "Heat-signature camera with FBM sensor noise, audio-reactive sensitivity, depth-aware fade, ACES tone mapping, IGN dither, blackbody temperature, split-tone, hue-preserve clamp and vignette.",
     "workgroup_size": [
       16,
@@ -5304,7 +5304,7 @@
   {
     "id": "voronoi-dynamics",
     "name": "Voronoi Bubbles",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-dynamics.wgsl",
+    "url": "shaders/voronoi-dynamics.wgsl",
     "description": "Dynamic Voronoi cells with bubble physics, iridescent edges, and interactive centroids.",
     "params": [
       {
@@ -5350,7 +5350,7 @@
   {
     "id": "voronoi",
     "name": "Voronoi Tessellation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi.wgsl",
+    "url": "shaders/voronoi.wgsl",
     "description": "Animated Voronoi reconstruction (simplified feature detection).",
     "features": [
       "mouse-driven",
@@ -5399,7 +5399,7 @@
   {
     "id": "vortex-prism",
     "name": "Vortex Prism",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-prism.wgsl",
+    "url": "shaders/vortex-prism.wgsl",
     "description": "Twists the image around the mouse cursor, separating colors like a prism.",
     "params": [
       {

--- a/public/shader-lists/distortion.json
+++ b/public/shader-lists/distortion.json
@@ -2,7 +2,7 @@
   {
     "id": "black-hole",
     "name": "Gravitational Lensing",
-    "url": "https://test.1ink.us/image_video_effects/shaders/black-hole.wgsl",
+    "url": "shaders/black-hole.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -49,7 +49,7 @@
     "id": "bubble-lens",
     "name": "Bubble Lens",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bubble-lens.wgsl",
+    "url": "shaders/bubble-lens.wgsl",
     "description": "A thin-film soap bubble lens magnifies the source image and blooms into beat-reactive interference colors around the cursor.",
     "features": [
       "mouse-driven",
@@ -96,7 +96,7 @@
   },
   {
     "id": "chromatic-swirl",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-swirl.wgsl",
+    "url": "shaders/chromatic-swirl.wgsl",
     "icon": "cyclone",
     "features": [
       "mouse-driven"
@@ -144,7 +144,7 @@
     "name": "Complex Exponent Warp",
     "category": "distortion",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/complex-exponent-warp.wgsl",
+    "url": "shaders/complex-exponent-warp.wgsl",
     "description": "Applies a complex domain distortion z -> z^p with FBM pre-warp, mouse-driven exponent, depth-aware fog, chromatic aberration, and ACES tone mapping.",
     "features": [
       "mouse-driven",
@@ -216,7 +216,7 @@
   {
     "id": "crystal-facets",
     "name": "Crystal Facets",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystal-facets.wgsl",
+    "url": "shaders/crystal-facets.wgsl",
     "description": "Physical crystal refraction with light transmission. Simulates radial-cut crystal with proper Fresnel reflection, internal scattering from fractures, and chromatic dispersion based on refractive index.",
     "params": [
       {
@@ -273,7 +273,7 @@
     "id": "cyber-lens",
     "name": "Cyber Lens",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-lens.wgsl",
+    "url": "shaders/cyber-lens.wgsl",
     "description": "AR-style cybernetic lens with cyan holographic HUD, targeting reticle, scan lines, hex threat zones, glitch artifacts, chromatic aberration, and depth-parallax layers. Bass drives HUD flicker; mouse moves the reticle; depth controls layer parallax.",
     "features": [
       "mouse-driven",
@@ -328,7 +328,7 @@
     "id": "data-slicer",
     "name": "Data Slicer",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-slicer.wgsl",
+    "url": "shaders/data-slicer.wgsl",
     "description": "Beat-reactive fractal tape-slice glitch with FBM domain warping, Voronoi cellular cracks, quasicrystal patterns, and 6-octave temporal jitter. Slices distort organically with curl-noise chromatic aberration and audio-reactive sparkle trails.",
     "params": [
       {
@@ -388,7 +388,7 @@
   {
     "id": "dimension-slicer",
     "name": "Dimension Slicer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/dimension-slicer.wgsl",
+    "url": "shaders/dimension-slicer.wgsl",
     "description": "Opens a dimensional rift with temporal slice rotation memory, chromatic inside-slice dispersion, audio-driven slice width modulation, depth-aware zoom warp, and edge glow.",
     "features": [
       "mouse-driven",
@@ -446,7 +446,7 @@
   {
     "id": "elastic-strip",
     "name": "Elastic Strip",
-    "url": "https://test.1ink.us/image_video_effects/shaders/elastic-strip.wgsl",
+    "url": "shaders/elastic-strip.wgsl",
     "description": "Spring physics strips with chromatic stretch and audio frequency response. Each strip oscillates at bass-driven frequencies, depth modulates stiffness, and treble adds chromatic edge glow on stretched boundaries.",
     "params": [
       {
@@ -502,7 +502,7 @@
   {
     "id": "elastic-surface",
     "name": "Elastic Surface",
-    "url": "https://test.1ink.us/image_video_effects/shaders/elastic-surface.wgsl",
+    "url": "shaders/elastic-surface.wgsl",
     "description": "Spring-mass elastic membrane with wave propagation, surface tension coupling, depth-aware deformation, and ripple-reactive impulses.",
     "params": [
       {
@@ -558,7 +558,7 @@
   {
     "id": "ethereal-swirl",
     "name": "Ethereal Swirl",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ethereal-swirl.wgsl",
+    "url": "shaders/ethereal-swirl.wgsl",
     "description": "Ethereal swirling motion with soft gradients.",
     "features": [
       "mouse-driven",
@@ -610,7 +610,7 @@
   {
     "id": "fluid-grid",
     "name": "Fluid Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fluid-grid.wgsl",
+    "url": "shaders/fluid-grid.wgsl",
     "description": "Flowing grid distortion with fluid dynamics.",
     "params": [
       {
@@ -655,7 +655,7 @@
   {
     "id": "fractal-glass-distort",
     "name": "IFS Attractor Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-glass-distort.wgsl",
+    "url": "shaders/fractal-glass-distort.wgsl",
     "description": "Iterated Function System (IFS) attractor density field drives refraction index. Barnsley-style 4-contraction IFS evaluated per-pixel with iridescent chromatic dispersion through the fractal structure. Audio-driven contraction modulation.",
     "features": [
       "mouse-driven",
@@ -706,7 +706,7 @@
     "id": "fractal-image-surf",
     "name": "Fractal Image Surf",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-image-surf.wgsl",
+    "url": "shaders/fractal-image-surf.wgsl",
     "description": "Multi-octave FBM domain warping with Jacobian-preserving displacement. Morphs between Julia, Mandelbrot, and Burning Ship fractals driven by bass.",
     "params": [
       {
@@ -763,7 +763,7 @@
   {
     "id": "fractal-kaleidoscope",
     "name": "Fractal Kaleidoscope",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-kaleidoscope.wgsl",
+    "url": "shaders/fractal-kaleidoscope.wgsl",
     "description": "Fractal patterns in a kaleidoscope arrangement.",
     "tags": [
       "filter",
@@ -807,7 +807,7 @@
   {
     "id": "gemstone-fractures",
     "name": "Gemstone Fractures",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gemstone-fractures.wgsl",
+    "url": "shaders/gemstone-fractures.wgsl",
     "features": [
       "alpha-transmission",
       "physical-refraction"
@@ -859,7 +859,7 @@
   {
     "id": "gen-chromatic-vortex",
     "name": "Chromatic Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromatic-vortex.wgsl",
+    "url": "shaders/gen-chromatic-vortex.wgsl",
     "description": "Rotates image in polar coordinates with psychedelic color-space warping, chromatic sector dispersion, temporal spiral drift via dataTextureC, and audio-driven YUV hue rotation.",
     "features": [
       "mouse-driven",
@@ -920,7 +920,7 @@
   {
     "id": "glass-brick-distortion",
     "name": "Glass Brick Distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-brick-distortion.wgsl",
+    "url": "shaders/glass-brick-distortion.wgsl",
     "description": "Physical glass brick wall with per-channel IOR chromatic dispersion (Snell's law), Schlick-Fresnel highlights, Beer-Lambert absorption, depth-aware thickness, audio-reactive refraction pulse, and ripple-driven brick wobble. Mouse cursor clears a window through the glass.",
     "features": [
       "mouse-driven",
@@ -978,7 +978,7 @@
     "id": "glass-brick-wall",
     "name": "Glass Brick Wall",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-brick-wall.wgsl",
+    "url": "shaders/glass-brick-wall.wgsl",
     "description": "Refractive glass brick wall with FBM-perturbed normals, multi-frequency caustic patterns, chromatic dispersion through wavelength-dependent refraction, depth-layer compositing, and internal reflections. Beat-driven caustics and Voronoi cellular caustic enhancement.",
     "features": [
       "mouse-driven",
@@ -1040,7 +1040,7 @@
   {
     "id": "glitch-slice-mirror",
     "name": "Glitch Slice Mirror",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glitch-slice-mirror.wgsl",
+    "url": "shaders/glitch-slice-mirror.wgsl",
     "description": "Mirrors the image at the mouse position with digital glitch artifacts, chromatic aberration, and scanlines along the seam. Audio-reactive intensity boost.",
     "features": [
       "mouse-driven",
@@ -1093,7 +1093,7 @@
   {
     "id": "gravity-well",
     "name": "Gravity Well",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gravity-well.wgsl",
+    "url": "shaders/gravity-well.wgsl",
     "description": "Schwarzschild-inspired lensing with photon-sphere rings, gravitational redshift, and Doppler-bright accretion flow.",
     "features": [
       "mouse-driven",
@@ -1141,7 +1141,7 @@
   {
     "id": "heat-haze-gpt52",
     "name": "Heat Haze Mirage gpt52",
-    "url": "https://test.1ink.us/image_video_effects/shaders/heat-haze-gpt52.wgsl",
+    "url": "shaders/heat-haze-gpt52.wgsl",
     "description": "Layered heat shimmer with chromatic dispersion, rising mirage flow, and bass-reactive intensity.",
     "params": [
       {
@@ -1195,7 +1195,7 @@
   {
     "id": "heat-haze",
     "name": "Heat Haze",
-    "url": "https://test.1ink.us/image_video_effects/shaders/heat-haze.wgsl",
+    "url": "shaders/heat-haze.wgsl",
     "description": "Interactive heat distortion with thermal glow, mouse-driven heat injection, diffusion, and audio-reactive shimmer.",
     "params": [
       {
@@ -1245,7 +1245,7 @@
     "id": "infinite-zoom-lens",
     "name": "Infinite Zoom Lens",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/infinite-zoom-lens.wgsl",
+    "url": "shaders/infinite-zoom-lens.wgsl",
     "description": "Droste effect with recursive self-similar zoom via logarithmic spiral Möbius transformation. Escher-like infinite recursion with chromatic aberration on spiral arms, HDR bloom on focal points, film grain, and temporal feedback.",
     "features": [
       "mouse-driven",
@@ -1297,7 +1297,7 @@
   {
     "id": "infinite-zoom",
     "name": "Infinite Zoom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/infinite-zoom.wgsl",
+    "url": "shaders/infinite-zoom.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -1351,7 +1351,7 @@
   {
     "id": "interactive-rgb-split",
     "name": "Interactive RGB Split",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-rgb-split.wgsl",
+    "url": "shaders/interactive-rgb-split.wgsl",
     "description": "Smooth alpha-channel translucency blending driven by a single displacement field. Spectral tint via mix, depth-aware compositing, and audio-reactive bass response.",
     "features": [
       "mouse-driven",
@@ -1399,7 +1399,7 @@
   {
     "id": "interactive-zoom-blur",
     "name": "Interactive Zoom Blur",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-zoom-blur.wgsl",
+    "url": "shaders/interactive-zoom-blur.wgsl",
     "description": "Radial zoom blur centered on the mouse cursor with temporal blur trail persistence, chromatic radial streak separation, depth-scaled blur attenuation, dithered sampling, and audio-reactive intensity.",
     "features": [
       "mouse-driven",
@@ -1458,7 +1458,7 @@
   {
     "id": "julia-warp",
     "name": "Julia Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/julia-warp.wgsl",
+    "url": "shaders/julia-warp.wgsl",
     "description": "Julia fractal-based warping with orbit traps for psychedelic coloring.",
     "features": [
       "mouse-driven",
@@ -1511,7 +1511,7 @@
   {
     "id": "kaleidoscope",
     "name": "Rose FBM Kaleidoscope",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kaleidoscope.wgsl",
+    "url": "shaders/kaleidoscope.wgsl",
     "tags": [
       "filter",
       "image-processing",
@@ -1560,7 +1560,7 @@
   },
   {
     "id": "liquid-prism",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-prism.wgsl",
+    "url": "shaders/liquid-prism.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive"
@@ -1618,7 +1618,7 @@
       "upgraded-rgba",
       "depth-aware"
     ],
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-swirl.wgsl",
+    "url": "shaders/liquid-swirl.wgsl",
     "description": "Swirls the image around the cursor like mixing paint.",
     "params": [
       {
@@ -1663,7 +1663,7 @@
   {
     "id": "liquid-warp-interactive",
     "name": "Liquid Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-warp-interactive.wgsl",
+    "url": "shaders/liquid-warp-interactive.wgsl",
     "description": "Fluid-like distortion driven by mouse flow and noise.",
     "features": [
       "mouse-driven"
@@ -1707,7 +1707,7 @@
   {
     "id": "log-polar-droste",
     "name": "Log-Polar Droste",
-    "url": "https://test.1ink.us/image_video_effects/shaders/log-polar-droste.wgsl",
+    "url": "shaders/log-polar-droste.wgsl",
     "description": "Infinite recursive zoom with spiral distortion creating Droste/Escher-like effects.",
     "params": [
       {
@@ -1753,7 +1753,7 @@
   {
     "id": "luma-glass",
     "name": "Luma Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-glass.wgsl",
+    "url": "shaders/luma-glass.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1806,7 +1806,7 @@
   },
   {
     "id": "luminescent-glass-tiles",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luminescent-glass-tiles.wgsl",
+    "url": "shaders/luminescent-glass-tiles.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -1855,7 +1855,7 @@
   {
     "id": "magnetic-field",
     "name": "Magnetic Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-field.wgsl",
+    "url": "shaders/magnetic-field.wgsl",
     "description": "Multi-pole magnetic field simulation with curl-noise particle traces and audio-reactive attraction. Field lines wiggle organically via FBM curl, depth modulates field strength, and treble adds particle sparkle.",
     "params": [
       {
@@ -1909,7 +1909,7 @@
   },
   {
     "id": "parallax-shift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/parallax-shift.wgsl",
+    "url": "shaders/parallax-shift.wgsl",
     "description": "Uses luminance as depth to create a mouse-controlled 3D parallax effect.",
     "params": [
       {
@@ -1960,7 +1960,7 @@
   {
     "id": "perspective-tilt",
     "name": "Perspective Tilt",
-    "url": "https://test.1ink.us/image_video_effects/shaders/perspective-tilt.wgsl",
+    "url": "shaders/perspective-tilt.wgsl",
     "description": "Rotates the image plane in 3D space based on mouse position (Pitch/Yaw). Zoom param adjusts distance.",
     "params": [
       {
@@ -2015,7 +2015,7 @@
   {
     "id": "phase-shift",
     "name": "Phase Shift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phase-shift.wgsl",
+    "url": "shaders/phase-shift.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -2062,7 +2062,7 @@
   {
     "id": "pixel-sort-glitch",
     "name": "Pixel Sort Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-sort-glitch.wgsl",
+    "url": "shaders/pixel-sort-glitch.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -2117,7 +2117,7 @@
   {
     "id": "pixel-storm",
     "name": "Pixel Storm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-storm.wgsl",
+    "url": "shaders/pixel-storm.wgsl",
     "description": "Mouse movement creates a chaotic storm of pixels.",
     "params": [
       {
@@ -2161,7 +2161,7 @@
   {
     "id": "pixelate-blast",
     "name": "Pixelate Blast",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixelate-blast.wgsl",
+    "url": "shaders/pixelate-blast.wgsl",
     "description": "Catalog entry for Pixelate Blast.",
     "tags": [
       "mouse-driven",
@@ -2219,7 +2219,7 @@
     "id": "predator-camouflage",
     "name": "Predator Camouflage",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/predator-camouflage.wgsl",
+    "url": "shaders/predator-camouflage.wgsl",
     "description": "Upgraded active camouflage with chromatophore pigment-sac simulation, predator thermal vision (IR false-color), heat-map distortion, HDR bloom on heat signatures, ACES tone mapping, and chromatic separation on camouflage edges. Bass drives chromatophore oscillation, mouse acts as prey heat source, depth controls thermal haze.",
     "params": [
       {
@@ -2281,7 +2281,7 @@
   {
     "id": "prism-displacement",
     "name": "Prism Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/prism-displacement.wgsl",
+    "url": "shaders/prism-displacement.wgsl",
     "description": "Prismatic lens effect with chromatic angular dispersion, temporal lens rotation memory, depth-weighted magnification, audio-reactive refraction responding to bass, and edge shine.",
     "features": [
       "mouse-driven",
@@ -2340,7 +2340,7 @@
   {
     "id": "prismatic-mosaic",
     "name": "Prismatic Mosaic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/prismatic-mosaic.wgsl",
+    "url": "shaders/prismatic-mosaic.wgsl",
     "description": "Color tiles break apart and reassemble into shifting prisms, turning strong colors into a kaleidoscopic mosaic that ripples across the image.",
     "params": [
       {
@@ -2398,7 +2398,7 @@
   {
     "id": "radial-rgb",
     "name": "Radial RGB",
-    "url": "https://test.1ink.us/image_video_effects/shaders/radial-rgb.wgsl",
+    "url": "shaders/radial-rgb.wgsl",
     "description": "Spectral chromatic aberration with lens distortion, anamorphic stretch, single-sample spectral tint via mix(), alpha translucency blending, and vignette.",
     "params": [
       {
@@ -2450,7 +2450,7 @@
   {
     "id": "refraction-tunnel",
     "name": "Refraction Tunnel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/refraction-tunnel.wgsl",
+    "url": "shaders/refraction-tunnel.wgsl",
     "description": "Multi-layer chromatic refraction through a cylindrical tunnel with Snell's-law dispersion, rainbow caustics, volumetric fog, and anamorphic streaks.",
     "params": [
       {
@@ -2501,7 +2501,7 @@
   {
     "id": "scan-distort-gpt52",
     "name": "Scan Distort Matrix gpt52",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scan-distort-gpt52.wgsl",
+    "url": "shaders/scan-distort-gpt52.wgsl",
     "description": "High-density scanlines with 3-band frequency distortion, FBM-perturbed scan positions, rolling jitter, curvature, chromatic tearing, mids-driven band distortion, domain-warped FBM displacement, and an audio-reactive color palette.",
     "params": [
       {
@@ -2559,7 +2559,7 @@
     "id": "sine-wave",
     "name": "Sine Wave",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sine-wave.wgsl",
+    "url": "shaders/sine-wave.wgsl",
     "description": "Multi-frequency sine wave interference with traveling wave packets, water caustics, chromatic dispersion on crests, and HDR specular highlights. Bass drives wave amplitude, mouse creates wave sources, depth controls attenuation.",
     "features": [
       "mouse-driven",
@@ -2615,7 +2615,7 @@
   {
     "id": "sonic-boom",
     "name": "Sonic Boom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sonic-boom.wgsl",
+    "url": "shaders/sonic-boom.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2663,7 +2663,7 @@
   {
     "id": "spec-bicubic-crystal",
     "name": "Bicubic Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-bicubic-crystal.wgsl",
+    "url": "shaders/spec-bicubic-crystal.wgsl",
     "description": "Bicubic Catmull-Rom crystalline distortion. Full 16-sample bicubic interpolation for perfectly smooth magnification, applied to prismatic crystalline faceting with chromatic separation.",
     "tags": [
       "bicubic",
@@ -2718,7 +2718,7 @@
   {
     "id": "spectral-vortex",
     "name": "Spectral Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-vortex.wgsl",
+    "url": "shaders/spectral-vortex.wgsl",
     "description": "Spectral color vortex with twisted distortions and alpha-channel translucency blending. Alpha encodes curl magnitude / maxCurl for energy-based translucency, with depth-aware compositing and audio-reactive twist.",
     "tags": [
       "filter",
@@ -2776,7 +2776,7 @@
   {
     "id": "spiral-lens",
     "name": "Spiral Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spiral-lens.wgsl",
+    "url": "shaders/spiral-lens.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2840,7 +2840,7 @@
   {
     "id": "temporal-distortion-field",
     "name": "Temporal Distortion Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-distortion-field.wgsl",
+    "url": "shaders/temporal-distortion-field.wgsl",
     "description": "Creates a localized time-dilation field with chromatic time-lag splitting (R past / G present / B future), temporal freeze memory refinement, depth-aware field radius modulation, and fbm warp.",
     "params": [
       {
@@ -2898,7 +2898,7 @@
   {
     "id": "tensor-flow-sculpt",
     "name": "Tensor Flow Sculpt",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tensor-flow-sculpt.wgsl",
+    "url": "shaders/tensor-flow-sculpt.wgsl",
     "description": "Catalog entry for Tensor Flow Sculpt.",
     "tags": [
       "depth-aware",
@@ -2953,7 +2953,7 @@
   {
     "id": "voronoi-chaos",
     "name": "Voronoi Chaos",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-chaos.wgsl",
+    "url": "shaders/voronoi-chaos.wgsl",
     "description": "Breaks the image into Voronoi cells that shift chaotically based on time and mouse proximity.",
     "params": [
       {
@@ -3001,7 +3001,7 @@
   {
     "id": "voronoi-faceted-glass",
     "name": "Voronoi Faceted Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-faceted-glass.wgsl",
+    "url": "shaders/voronoi-faceted-glass.wgsl",
     "description": "Cellular glass distortion effect.",
     "params": [
       {
@@ -3048,7 +3048,7 @@
   {
     "id": "vortex-distortion",
     "name": "Lamb-Oseen Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-distortion.wgsl",
+    "url": "shaders/vortex-distortion.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -3097,7 +3097,7 @@
   {
     "id": "vortex-pass1",
     "name": "Clean Vortex (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-pass1.wgsl",
+    "url": "shaders/vortex-pass1.wgsl",
     "description": "Vortex dynamics pass: four animated vortex centers, Biot-Savart velocity field, vorticity confinement, and turbulent FBM noise. Outputs velocity and vorticity field to dataTextureA.",
     "tags": [
       "vortex",
@@ -3154,7 +3154,7 @@
   {
     "id": "vortex-pass2",
     "name": "Clean Vortex (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-pass2.wgsl",
+    "url": "shaders/vortex-pass2.wgsl",
     "description": "Fluid vortex distortion rendering pass with chromatic velocity blur offsets, temporal vorticity accumulation, audio-driven swirl intensity, iridescent tint based on curl, and palette grading.",
     "tags": [
       "vortex",
@@ -3216,7 +3216,7 @@
   {
     "id": "vortex-warp",
     "name": "Vortex Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-warp.wgsl",
+    "url": "shaders/vortex-warp.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -3267,7 +3267,7 @@
   {
     "id": "vortex",
     "name": "Clean Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex.wgsl",
+    "url": "shaders/vortex.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -3320,7 +3320,7 @@
     "id": "zoom-burst",
     "name": "Zoom Burst",
     "category": "distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/zoom-burst.wgsl",
+    "url": "shaders/zoom-burst.wgsl",
     "description": "Exponential zoom burst with radial motion blur, angular streak sampling, starburst light rays, chromatic radial dispersion, HDR bloom, film grain, and ACES tone mapping. Bass accelerates the burst; mouse positions the center; depth controls streak perspective.",
     "features": [
       "mouse-driven",

--- a/public/shader-lists/generative.json
+++ b/public/shader-lists/generative.json
@@ -2,7 +2,7 @@
   {
     "id": "4d-projection-dream-weavers",
     "name": "4D Projection Dream Weavers",
-    "url": "https://test.1ink.us/image_video_effects/shaders/4d-projection-dream-weavers.wgsl",
+    "url": "shaders/4d-projection-dream-weavers.wgsl",
     "category": "generative",
     "description": "A continuous slice through 4-dimensional fractal space. The mouse smoothly controls two extra dimensions, allowing genuine exploration of higher-dimensional forms. Audio modulates scale, speed, and detail.",
     "features": [
@@ -69,7 +69,7 @@
   {
     "id": "acoustic-string-theory",
     "name": "Acoustic String Theory",
-    "url": "https://test.1ink.us/image_video_effects/shaders/acoustic-string-theory.wgsl",
+    "url": "shaders/acoustic-string-theory.wgsl",
     "category": "generative",
     "description": "Vibrating string harmonics visualized as oscillating sine waves in perspective, with audio-driven pluck and resonance.",
     "tags": [
@@ -131,7 +131,7 @@
   {
     "id": "atmos_volumetric_fog",
     "name": "Volumetric Fog",
-    "url": "https://test.1ink.us/image_video_effects/shaders/atmos_volumetric_fog.wgsl",
+    "url": "shaders/atmos_volumetric_fog.wgsl",
     "description": "Volumetric fog with ray marching, Mie/Rayleigh scattering, height-based density, god rays, and mouse-controlled light source",
     "tags": [
       "volumetric",
@@ -194,7 +194,7 @@
   {
     "id": "audio_geometric_pulse",
     "name": "Geometric Pulse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/audio_geometric_pulse.wgsl",
+    "url": "shaders/audio_geometric_pulse.wgsl",
     "description": "Audio-reactive geometric patterns with kaleidoscope symmetry, shape morphing, neon glow, and frequency band visualization",
     "tags": [
       "geometric",
@@ -253,7 +253,7 @@
     "id": "aurora-borealis-loom",
     "name": "Aurora Borealis Loom",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-borealis-loom.wgsl",
+    "url": "shaders/aurora-borealis-loom.wgsl",
     "description": "Aurora curtains woven like fabric on a celestial loom. Threads of light interlace with weft and warp patterns. Bass swells the weave, mids shift hue through the spectrum, treble adds bead-like ionization nodes. Mouse pulls the fabric.",
     "features": [
       "audio-reactive",
@@ -318,7 +318,7 @@
     "id": "aurora-curtain",
     "name": "Aurora Curtain",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-curtain.wgsl",
+    "url": "shaders/aurora-curtain.wgsl",
     "description": "Chapman layer auroral excitation with Kelvin-Helmholtz instability and domain-warped curtain folds. Physically inspired colors by altitude via OkLab mixing: red O(1D) high, green O(1S) mid, blue N2+ low. Enhanced with Fresnel rim lighting on folds, temporal feedback trails, two-tone atmospheric key/fill, starfield blackbody temperatures, and audio-reactive chromatic aberration. Mouse drags magnetic zenith; depth drives extinction. Phase B adds advanced alpha compositing: depth-layered fade, luminance-key transparency, edge-preserve curtain opacity, and alpha-aware temporal feedback.",
     "features": [
       "audio-reactive",
@@ -383,7 +383,7 @@
   {
     "id": "bio_lenia_continuous",
     "name": "Lenia Continuous",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bio_lenia_continuous.wgsl",
+    "url": "shaders/bio_lenia_continuous.wgsl",
     "description": "Continuous cellular automata (Lenia) with smooth growth functions, multiple kernel radii, and biological emergence patterns",
     "tags": [
       "lenia",
@@ -441,7 +441,7 @@
   {
     "id": "gen-bioluminescent-abyss",
     "name": "Bioluminescent Abyss",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioluminescent-abyss.wgsl",
+    "url": "shaders/gen-bioluminescent-abyss.wgsl",
     "description": "An infinite deep underwater landscape with swaying tube worms and thermal vents, featuring bioluminescence and deep sea atmosphere.",
     "tags": [
       "underwater",
@@ -503,7 +503,7 @@
     "id": "bioluminescent-bloom",
     "name": "Bioluminescent Bloom",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bioluminescent-bloom.wgsl",
+    "url": "shaders/bioluminescent-bloom.wgsl",
     "description": "Deep-ocean bioluminescent colony driven by Gray-Scott reaction-diffusion with chemotaxis and quorum-sensing glow activation. Background tendrils provide ambient light. Audio injects nutrients and triggers stress flashes; mouse drops nutrient pellets. Depth attenuates bioluminescence.",
     "features": [
       "audio-reactive",
@@ -568,7 +568,7 @@
   {
     "id": "bubble-chamber",
     "name": "Bubble Chamber",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bubble-chamber.wgsl",
+    "url": "shaders/bubble-chamber.wgsl",
     "description": "Simulates subatomic particle trails in a magnetic field using a feedback loop.",
     "features": [
       "mouse-driven",
@@ -620,7 +620,7 @@
   {
     "id": "chromatic-ghost-tunnel",
     "name": "Chromatic Ghost Tunnel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-ghost-tunnel.wgsl",
+    "url": "shaders/chromatic-ghost-tunnel.wgsl",
     "description": "A perspective tunnel of chromatic ghost echoes. Each ring is RGB-split by audio bands. Bass warps tunnel depth, mids add spiral rotation, treble creates stroboscopic ring flashes. Mouse steers tunnel flight.",
     "tags": [
       "generative",
@@ -679,7 +679,7 @@
   {
     "id": "chrono-voronoi-mycelium",
     "name": "Chrono-Voronoi Mycelium",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chrono-voronoi-mycelium.wgsl",
+    "url": "shaders/chrono-voronoi-mycelium.wgsl",
     "category": "generative",
     "description": "A living fungal network that grows across multiple time scales. Voronoi cells represent fungal colonies; cell edges glow as mycelium hyphae. Different generations coexist as translucent layers. Temporal feedback accumulates growth rings. Bass = nutrient pulse triggers spore bursts and faster spread via golden-ratio seed displacement. Mouse inoculates new colonies. ACES tonemapped with chromatic aberration.",
     "features": [
@@ -752,7 +752,7 @@
     "id": "coral-growth",
     "name": "Coral Growth",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/coral-growth.wgsl",
+    "url": "shaders/coral-growth.wgsl",
     "description": "Procedural coral and lichen branching structures that grow organically across cells. Audio accelerates growth and adds color vibrancy.",
     "features": [
       "audio-reactive",
@@ -809,7 +809,7 @@
   {
     "id": "cosmic-jellyfish",
     "name": "Cosmic Jellyfish",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cosmic-jellyfish.wgsl",
+    "url": "shaders/cosmic-jellyfish.wgsl",
     "description": "A majestic, translucent jellyfish floating in a cosmic void, with bioluminescent glow and rhythmic pulsation.",
     "tags": [
       "3d",
@@ -867,7 +867,7 @@
   {
     "id": "cosmic-web",
     "name": "Cosmic Web Filament",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cosmic-web.wgsl",
+    "url": "shaders/cosmic-web.wgsl",
     "description": "Simulates the large-scale structure of the universe with dark matter filaments and voids. Mouse acts as a gravity well; audio and depth drive intensity and color shifts. Alpha is layered via luminance keying, edge preservation, and depth fade.",
     "tags": [
       "space",
@@ -929,7 +929,7 @@
     "id": "crystalline-fracture",
     "name": "Crystalline Fracture",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystalline-fracture.wgsl",
+    "url": "shaders/crystalline-fracture.wgsl",
     "description": "Fracture mechanics simulation with stress intensity factor-driven crack propagation, branching, percolation connectivity, and hackle marks on translucent crystal surfaces. Thin-film iridescence and subsurface scattering. Audio loads stress and triggers catastrophic failure; mouse applies point stress. Depth controls crystal thickness perspective.",
     "features": [
       "audio-reactive",
@@ -998,7 +998,7 @@
     "id": "crystalline-veins",
     "name": "Crystalline Veins",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystalline-veins.wgsl",
+    "url": "shaders/crystalline-veins.wgsl",
     "description": "Mineral vein patterns growing through dark stone. FBM-based crack and vein generation with gold, copper, and silver chromatic veins. Bass drives vein pulse, mids control growth density, treble adds crystalline sparkles. Mouse attracts vein growth.",
     "features": [
       "audio-reactive",
@@ -1064,7 +1064,7 @@
     "id": "deep-sea-thermal-vent",
     "name": "Deep Sea Thermal Vent",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/deep-sea-thermal-vent.wgsl",
+    "url": "shaders/deep-sea-thermal-vent.wgsl",
     "description": "Hydrothermal vent on the ocean floor: billowing mineral-rich plumes rise upward, glowing with chemosynthetic life. Bass swells the plumes, mids add particle turbulence, treble creates bioluminescent microbe flashes. Mouse distorts vent flow.",
     "features": [
       "audio-reactive",
@@ -1131,7 +1131,7 @@
     "id": "electric-eel-storm",
     "name": "Electric Eel Storm",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/electric-eel-storm.wgsl",
+    "url": "shaders/electric-eel-storm.wgsl",
     "description": "Electric eels swimming through a conductive storm cloud, discharging arcs between them. Bass drives eel body pulses, mids create storm cloud turbulence, treble triggers lightning arc flashes. Mouse attracts the eel school.",
     "features": [
       "audio-reactive",
@@ -1196,7 +1196,7 @@
   {
     "id": "emergent-calligraphic-weave",
     "name": "Emergent Calligraphic Weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/emergent-calligraphic-weave.wgsl",
+    "url": "shaders/emergent-calligraphic-weave.wgsl",
     "category": "generative",
     "description": "Sumi-e ink wash simulation with pressure-sensitive Bézier brush strokes, ink viscosity flow, paper absorption capillary action, and dry-brush texture. Audio drives brush speed and splatter; mouse acts as the brush with pressure from click duration. Depth scales paper grain.",
     "features": [
@@ -1273,7 +1273,7 @@
   {
     "id": "fire_smoke_volumetric",
     "name": "Fire Smoke Volumetric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fire_smoke_volumetric.wgsl",
+    "url": "shaders/fire_smoke_volumetric.wgsl",
     "description": "Volumetric fire and smoke simulation with chromatic temperature gradients (R hot to B cool), temporal smoke persistence via dataTextureC, audio-driven turbulence enhancement, physical transmittance, and depth-layered alpha.",
     "tags": [
       "fire",
@@ -1338,7 +1338,7 @@
   {
     "id": "fractal-ice-palace",
     "name": "Fractal Ice Palace",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-ice-palace.wgsl",
+    "url": "shaders/fractal-ice-palace.wgsl",
     "category": "generative",
     "description": "Recursive ice crystal palace with fractal branching architecture. Chromatic ice refractions: blue core, cyan edges, white sparkle. Bass shakes the palace, mids control recursion depth visually, treble adds frost glitter. Mouse melts local ice.",
     "tags": [
@@ -1463,7 +1463,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-3d-sierpinski-chaos",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-3d-sierpinski-chaos.wgsl",
+    "url": "shaders/gen-3d-sierpinski-chaos.wgsl",
     "features": []
   },
   {
@@ -1523,7 +1523,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-4d-projection-dream-weavers",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-4d-projection-dream-weavers.wgsl",
+    "url": "shaders/gen-4d-projection-dream-weavers.wgsl",
     "features": []
   },
   {
@@ -1583,7 +1583,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-abyssal-chrono-coral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-abyssal-chrono-coral.wgsl",
+    "url": "shaders/gen-abyssal-chrono-coral.wgsl",
     "features": []
   },
   {
@@ -1640,7 +1640,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-abyssal-leviathan-scales",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-abyssal-leviathan-scales.wgsl",
+    "url": "shaders/gen-abyssal-leviathan-scales.wgsl",
     "features": []
   },
   {
@@ -1693,14 +1693,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-abyssal-quantum-leviathan-skeleton",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-abyssal-quantum-leviathan-skeleton.wgsl",
+    "url": "shaders/gen-abyssal-quantum-leviathan-skeleton.wgsl",
     "features": []
   },
   {
     "id": "gen-acid-lissajous",
     "name": "Acid Lissajous",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-acid-lissajous.wgsl",
+    "url": "shaders/gen-acid-lissajous.wgsl",
     "tags": [
       "psychedelic",
       "neon",
@@ -1773,7 +1773,7 @@
   {
     "id": "gen-alien-flora-ecosystem",
     "name": "Gen Alien Flora Ecosystem",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-alien-flora-ecosystem.wgsl",
+    "url": "shaders/gen-alien-flora-ecosystem.wgsl",
     "description": "Gen Alien Flora Ecosystem",
     "tags": [
       "multi-species-flora",
@@ -1889,7 +1889,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-alien-flora",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-alien-flora.wgsl",
+    "url": "shaders/gen-alien-flora.wgsl",
     "features": []
   },
   {
@@ -1947,7 +1947,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-alpha-aurora",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-alpha-aurora.wgsl",
+    "url": "shaders/gen-alpha-aurora.wgsl",
     "features": []
   },
   {
@@ -2007,7 +2007,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-aperiodic-monotile",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-aperiodic-monotile.wgsl",
+    "url": "shaders/gen-aperiodic-monotile.wgsl",
     "features": []
   },
   {
@@ -2066,7 +2066,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-apollonian-gasket",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-apollonian-gasket.wgsl",
+    "url": "shaders/gen-apollonian-gasket.wgsl",
     "features": []
   },
   {
@@ -2128,7 +2128,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-art-deco-sky",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-art-deco-sky.wgsl",
+    "url": "shaders/gen-art-deco-sky.wgsl",
     "features": []
   },
   {
@@ -2185,7 +2185,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-astral-silk-chrono-weaver-arachnid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-astral-silk-chrono-weaver-arachnid.wgsl",
+    "url": "shaders/gen-astral-silk-chrono-weaver-arachnid.wgsl",
     "features": []
   },
   {
@@ -2245,7 +2245,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-astro-kinetic-chrono-orrery",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-astro-kinetic-chrono-orrery.wgsl",
+    "url": "shaders/gen-astro-kinetic-chrono-orrery.wgsl",
     "features": []
   },
   {
@@ -2302,7 +2302,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-astro-mechanical-quantum-furnace-engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-astro-mechanical-quantum-furnace-engine.wgsl",
+    "url": "shaders/gen-astro-mechanical-quantum-furnace-engine.wgsl",
     "features": []
   },
   {
@@ -2362,7 +2362,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-audio-spirograph",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-audio-spirograph.wgsl",
+    "url": "shaders/gen-audio-spirograph.wgsl",
     "features": []
   },
   {
@@ -2421,7 +2421,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-audiovisual-mandelbulb-raymarcher",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-audiovisual-mandelbulb-raymarcher.wgsl",
+    "url": "shaders/gen-audiovisual-mandelbulb-raymarcher.wgsl",
     "features": []
   },
   {
@@ -2477,7 +2477,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-aurora-borealis-synthesis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-aurora-borealis-synthesis.wgsl",
+    "url": "shaders/gen-aurora-borealis-synthesis.wgsl",
     "features": []
   },
   {
@@ -2538,7 +2538,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-aurora-silk",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-aurora-silk.wgsl",
+    "url": "shaders/gen-aurora-silk.wgsl",
     "features": [
       "hdr",
       "aces-tone-mapping",
@@ -2610,7 +2610,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-auroral-ferrofluid-monolith",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-auroral-ferrofluid-monolith.wgsl",
+    "url": "shaders/gen-auroral-ferrofluid-monolith.wgsl",
     "features": []
   },
   {
@@ -2675,7 +2675,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-barnsley-fern",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-barnsley-fern.wgsl",
+    "url": "shaders/gen-barnsley-fern.wgsl",
     "features": [
       "barnsley-ifs",
       "voronoi-displacement",
@@ -2743,7 +2743,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-belousov-zhabotinsky",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-belousov-zhabotinsky.wgsl",
+    "url": "shaders/gen-belousov-zhabotinsky.wgsl",
     "features": []
   },
   {
@@ -2803,7 +2803,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bifurcation-diagram",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bifurcation-diagram.wgsl",
+    "url": "shaders/gen-bifurcation-diagram.wgsl",
     "features": []
   },
   {
@@ -2861,14 +2861,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bio-luminescent-jelly",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bio-luminescent-jelly.wgsl",
+    "url": "shaders/gen-bio-luminescent-jelly.wgsl",
     "features": []
   },
   {
     "id": "gen-bioelectric-pulse",
     "name": "Bioelectric Pulse",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioelectric-pulse.wgsl",
+    "url": "shaders/gen-bioelectric-pulse.wgsl",
     "description": "Reaction-diffusion-like organic pulses through a noise-driven substrate. Audio energizes the pulse field, and mouse activation emits a secondary bioelectric wave.",
     "features": [
       "generative",
@@ -2989,7 +2989,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bioluminescent-aether-jellyfish-swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioluminescent-aether-jellyfish-swarm.wgsl",
+    "url": "shaders/gen-bioluminescent-aether-jellyfish-swarm.wgsl",
     "features": []
   },
   {
@@ -3042,13 +3042,13 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bioluminescent-aether-pulsar",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioluminescent-aether-pulsar.wgsl",
+    "url": "shaders/gen-bioluminescent-aether-pulsar.wgsl",
     "features": []
   },
   {
     "id": "gen-bioluminescent-chrono-plasma-astro-owl",
     "name": "Bioluminescent Chrono-Plasma Astro-Owl",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioluminescent-chrono-plasma-astro-owl.wgsl",
+    "url": "shaders/gen-bioluminescent-chrono-plasma-astro-owl.wgsl",
     "description": "A hyper-dimensional, cyber-organic celestial owl forged from liquid chrono-plasma and shattered quantum-glass.",
     "category": "generative",
     "tags": [
@@ -3149,7 +3149,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bioluminescent-reaction-diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioluminescent-reaction-diffusion.wgsl",
+    "url": "shaders/gen-bioluminescent-reaction-diffusion.wgsl",
     "features": []
   },
   {
@@ -3210,7 +3210,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-biomechanical-hive",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-biomechanical-hive.wgsl",
+    "url": "shaders/gen-biomechanical-hive.wgsl",
     "features": []
   },
   {
@@ -3268,7 +3268,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bioreactor-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bioreactor-bloom.wgsl",
+    "url": "shaders/gen-bioreactor-bloom.wgsl",
     "features": []
   },
   {
@@ -3332,7 +3332,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-bismuth-crystal-citadel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bismuth-crystal-citadel.wgsl",
+    "url": "shaders/gen-bismuth-crystal-citadel.wgsl",
     "features": []
   },
   {
@@ -3348,7 +3348,7 @@
       "bismuth"
     ],
     "description": "A hyper-dimensional, continually self-assembling bismuth crystal matrix orbiting a microscopic gravitational singularity, its iridescent geometric steps carving sharp staircases into the fabric of spacetime. The scene blends hard-edged, prismatic synthetic-architecture with chaotic fluid distortions driven by an intense sub-bass core.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-bismuth-singularity-loom-engine.wgsl",
+    "url": "shaders/gen-bismuth-singularity-loom-engine.wgsl",
     "workgroup_size": [
       16,
       16,
@@ -3450,7 +3450,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-brutalist-monument",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-brutalist-monument.wgsl",
+    "url": "shaders/gen-brutalist-monument.wgsl",
     "features": []
   },
   {
@@ -3511,7 +3511,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-buddhabrot-aura",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-buddhabrot-aura.wgsl",
+    "url": "shaders/gen-buddhabrot-aura.wgsl",
     "features": []
   },
   {
@@ -3572,7 +3572,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-aether-seraphim-wings",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-aether-seraphim-wings.wgsl",
+    "url": "shaders/gen-celestial-aether-seraphim-wings.wgsl",
     "features": []
   },
   {
@@ -3634,7 +3634,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-forge",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-forge.wgsl",
+    "url": "shaders/gen-celestial-forge.wgsl",
     "features": []
   },
   {
@@ -3687,7 +3687,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-glass-tornado",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-glass-tornado.wgsl",
+    "url": "shaders/gen-celestial-glass-tornado.wgsl",
     "features": []
   },
   {
@@ -3744,7 +3744,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-nanite-swarm-nebula",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-nanite-swarm-nebula.wgsl",
+    "url": "shaders/gen-celestial-nanite-swarm-nebula.wgsl",
     "features": []
   },
   {
@@ -3804,7 +3804,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-prism-orchid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-prism-orchid.wgsl",
+    "url": "shaders/gen-celestial-prism-orchid.wgsl",
     "features": []
   },
   {
@@ -3862,7 +3862,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-quantum-glass-dragonfly",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-quantum-glass-dragonfly.wgsl",
+    "url": "shaders/gen-celestial-quantum-glass-dragonfly.wgsl",
     "features": []
   },
   {
@@ -3920,7 +3920,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-weave.wgsl",
+    "url": "shaders/gen-celestial-weave.wgsl",
     "features": []
   },
   {
@@ -3977,7 +3977,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-celestial-yggdrasil-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-celestial-yggdrasil-matrix.wgsl",
+    "url": "shaders/gen-celestial-yggdrasil-matrix.wgsl",
     "features": []
   },
   {
@@ -4033,7 +4033,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cellular-automata-tapestry",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cellular-automata-tapestry.wgsl",
+    "url": "shaders/gen-cellular-automata-tapestry.wgsl",
     "features": []
   },
   {
@@ -4092,7 +4092,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chaos-game-ifs",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chaos-game-ifs.wgsl",
+    "url": "shaders/gen-chaos-game-ifs.wgsl",
     "features": []
   },
   {
@@ -4154,7 +4154,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chromatic-acid-drip",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromatic-acid-drip.wgsl",
+    "url": "shaders/gen-chromatic-acid-drip.wgsl",
     "features": []
   },
   {
@@ -4213,7 +4213,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chromatic-glass-lattice",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromatic-glass-lattice.wgsl",
+    "url": "shaders/gen-chromatic-glass-lattice.wgsl",
     "features": []
   },
   {
@@ -4275,7 +4275,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chromatic-metamorphosis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromatic-metamorphosis.wgsl",
+    "url": "shaders/gen-chromatic-metamorphosis.wgsl",
     "features": []
   },
   {
@@ -4333,7 +4333,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chromatic-singularity-loom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromatic-singularity-loom.wgsl",
+    "url": "shaders/gen-chromatic-singularity-loom.wgsl",
     "features": []
   },
   {
@@ -4393,7 +4393,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chromatic-zonohedron",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromatic-zonohedron.wgsl",
+    "url": "shaders/gen-chromatic-zonohedron.wgsl",
     "features": [
       "generative",
       "geometry",
@@ -4459,13 +4459,13 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chromodynamic-plasma-collider",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chromodynamic-plasma-collider.wgsl",
+    "url": "shaders/gen-chromodynamic-plasma-collider.wgsl",
     "features": []
   },
   {
     "id": "gen-chrono-kitsune-prism-weaver",
     "name": "Chrono-Kitsune Prism Weaver",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chrono-kitsune-prism-weaver.wgsl",
+    "url": "shaders/gen-chrono-kitsune-prism-weaver.wgsl",
     "category": "generative",
     "description": "A living prismatic kitsune spirit weaving through a chrono-void lattice with deep temporal feedback and audio reactivity.",
     "workgroup_size": [
@@ -4576,7 +4576,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chrono-mycelial-tapestry",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chrono-mycelial-tapestry.wgsl",
+    "url": "shaders/gen-chrono-mycelial-tapestry.wgsl",
     "features": []
   },
   {
@@ -4637,7 +4637,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chrono-voronoi-mycelium",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chrono-voronoi-mycelium.wgsl",
+    "url": "shaders/gen-chrono-voronoi-mycelium.wgsl",
     "features": []
   },
   {
@@ -4695,7 +4695,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chronodynamic-aether-weaver-automata",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chronodynamic-aether-weaver-automata.wgsl",
+    "url": "shaders/gen-chronodynamic-aether-weaver-automata.wgsl",
     "features": []
   },
   {
@@ -4759,7 +4759,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chronos-labyrinth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chronos-labyrinth.wgsl",
+    "url": "shaders/gen-chronos-labyrinth.wgsl",
     "features": []
   },
   {
@@ -4818,7 +4818,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-chronos-monolith-resonator",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-chronos-monolith-resonator.wgsl",
+    "url": "shaders/gen-chronos-monolith-resonator.wgsl",
     "features": []
   },
   {
@@ -4878,7 +4878,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-conway-game-of-life",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-conway-game-of-life.wgsl",
+    "url": "shaders/gen-conway-game-of-life.wgsl",
     "features": []
   },
   {
@@ -4940,7 +4940,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-coral-reef-colony",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-coral-reef-colony.wgsl",
+    "url": "shaders/gen-coral-reef-colony.wgsl",
     "features": []
   },
   {
@@ -5002,7 +5002,7 @@
     "supportsDepth": true,
     "supportsDof": false,
     "updated": true,
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cosmic-clockwork-dyson-sphere.wgsl",
+    "url": "shaders/gen-cosmic-clockwork-dyson-sphere.wgsl",
     "features": []
   },
   {
@@ -5061,7 +5061,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cosmic-slime-mold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cosmic-slime-mold.wgsl",
+    "url": "shaders/gen-cosmic-slime-mold.wgsl",
     "features": []
   },
   {
@@ -5125,7 +5125,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cosmic-web-filament",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cosmic-web-filament.wgsl",
+    "url": "shaders/gen-cosmic-web-filament.wgsl",
     "features": []
   },
   {
@@ -5183,7 +5183,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cryogenic-frost-plasma-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cryogenic-frost-plasma-matrix.wgsl",
+    "url": "shaders/gen-cryogenic-frost-plasma-matrix.wgsl",
     "features": []
   },
   {
@@ -5248,7 +5248,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-crystal-caverns",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-crystal-caverns.wgsl",
+    "url": "shaders/gen-crystal-caverns.wgsl",
     "features": []
   },
   {
@@ -5308,12 +5308,12 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-crystal-lattice-growth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-crystal-lattice-growth.wgsl",
+    "url": "shaders/gen-crystal-lattice-growth.wgsl",
     "features": []
   },
   {
     "id": "gen-crystalline-chrono-dyson",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-crystalline-chrono-dyson.wgsl",
+    "url": "shaders/gen-crystalline-chrono-dyson.wgsl",
     "name": "Crystalline Chrono Dyson",
     "category": "generative",
     "filename": "gen-crystalline-chrono-dyson.wgsl",
@@ -5433,7 +5433,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-crystalline-mandala-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-crystalline-mandala-bloom.wgsl",
+    "url": "shaders/gen-crystalline-mandala-bloom.wgsl",
     "features": []
   },
   {
@@ -5491,7 +5491,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cyber-organic-liquid-neon-pulsar",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cyber-organic-liquid-neon-pulsar.wgsl",
+    "url": "shaders/gen-cyber-organic-liquid-neon-pulsar.wgsl",
     "features": []
   },
   {
@@ -5551,7 +5551,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cyber-terminal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cyber-terminal.wgsl",
+    "url": "shaders/gen-cyber-terminal.wgsl",
     "features": []
   },
   {
@@ -5608,7 +5608,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cybernetic-ferro-coral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cybernetic-ferro-coral.wgsl",
+    "url": "shaders/gen-cybernetic-ferro-coral.wgsl",
     "features": []
   },
   {
@@ -5665,7 +5665,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cybernetic-liquid-chrome-engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cybernetic-liquid-chrome-engine.wgsl",
+    "url": "shaders/gen-cybernetic-liquid-chrome-engine.wgsl",
     "features": []
   },
   {
@@ -5722,7 +5722,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cybernetic-mycelium-neural-web",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cybernetic-mycelium-neural-web.wgsl",
+    "url": "shaders/gen-cybernetic-mycelium-neural-web.wgsl",
     "features": []
   },
   {
@@ -5783,7 +5783,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cycloid-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cycloid-bloom.wgsl",
+    "url": "shaders/gen-cycloid-bloom.wgsl",
     "features": []
   },
   {
@@ -5845,7 +5845,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cymatic-plasma-mandalas",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cymatic-plasma-mandalas.wgsl",
+    "url": "shaders/gen-cymatic-plasma-mandalas.wgsl",
     "features": []
   },
   {
@@ -5906,7 +5906,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-cymatic-quantum-silk-loom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-cymatic-quantum-silk-loom.wgsl",
+    "url": "shaders/gen-cymatic-quantum-silk-loom.wgsl",
     "features": []
   },
   {
@@ -5964,7 +5964,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-de-jong-attractor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-de-jong-attractor.wgsl",
+    "url": "shaders/gen-de-jong-attractor.wgsl",
     "features": []
   },
   {
@@ -6024,7 +6024,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-depth-refracted-liquid-stained-glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-depth-refracted-liquid-stained-glass.wgsl",
+    "url": "shaders/gen-depth-refracted-liquid-stained-glass.wgsl",
     "features": []
   },
   {
@@ -6086,7 +6086,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-dla-copper-deposition",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-dla-copper-deposition.wgsl",
+    "url": "shaders/gen-dla-copper-deposition.wgsl",
     "features": []
   },
   {
@@ -6147,7 +6147,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-dmt-fractal-zoom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-dmt-fractal-zoom.wgsl",
+    "url": "shaders/gen-dmt-fractal-zoom.wgsl",
     "features": []
   },
   {
@@ -6207,7 +6207,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-dragon-curve",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-dragon-curve.wgsl",
+    "url": "shaders/gen-dragon-curve.wgsl",
     "features": []
   },
   {
@@ -6260,7 +6260,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-dynamic-tessellation-ornate-fractal-tiles",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-dynamic-tessellation-ornate-fractal-tiles.wgsl",
+    "url": "shaders/gen-dynamic-tessellation-ornate-fractal-tiles.wgsl",
     "features": []
   },
   {
@@ -6318,7 +6318,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-echo-dunes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-echo-dunes.wgsl",
+    "url": "shaders/gen-echo-dunes.wgsl",
     "features": []
   },
   {
@@ -6376,7 +6376,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-eldritch-quantum-fractal-eye",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-eldritch-quantum-fractal-eye.wgsl",
+    "url": "shaders/gen-eldritch-quantum-fractal-eye.wgsl",
     "features": []
   },
   {
@@ -6429,7 +6429,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-eldritch-tesseract-hive-mind",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-eldritch-tesseract-hive-mind.wgsl",
+    "url": "shaders/gen-eldritch-tesseract-hive-mind.wgsl",
     "features": []
   },
   {
@@ -6488,7 +6488,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-electric-kaleidoscope-storm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-electric-kaleidoscope-storm.wgsl",
+    "url": "shaders/gen-electric-kaleidoscope-storm.wgsl",
     "features": []
   },
   {
@@ -6550,7 +6550,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-emergent-calligraphic-ecosystems",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-emergent-calligraphic-ecosystems.wgsl",
+    "url": "shaders/gen-emergent-calligraphic-ecosystems.wgsl",
     "features": []
   },
   {
@@ -6614,7 +6614,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-emergent-script-gardens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-emergent-script-gardens.wgsl",
+    "url": "shaders/gen-emergent-script-gardens.wgsl",
     "features": []
   },
   {
@@ -6678,7 +6678,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-erosion-strata",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-erosion-strata.wgsl",
+    "url": "shaders/gen-erosion-strata.wgsl",
     "features": []
   },
   {
@@ -6738,7 +6738,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-anemone-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-anemone-bloom.wgsl",
+    "url": "shaders/gen-ethereal-anemone-bloom.wgsl",
     "features": []
   },
   {
@@ -6799,12 +6799,12 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-aurora-ghost-orchid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-aurora-ghost-orchid.wgsl",
+    "url": "shaders/gen-ethereal-aurora-ghost-orchid.wgsl",
     "features": []
   },
   {
     "id": "gen-ethereal-chrono-plasma-void-manta",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-chrono-plasma-void-manta.wgsl",
+    "url": "shaders/gen-ethereal-chrono-plasma-void-manta.wgsl",
     "name": "Ethereal Chrono-Plasma Void-Manta",
     "category": "generative",
     "description": "A majestic, hyper-organic cybernetic space-manta ray gliding through a dark-matter ocean, its translucent biomimetic wings rippling with shifting auroral temporal energy as it consumes deep acoustic bass frequencies.",
@@ -6897,14 +6897,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-cyber-aurora-hummingbird-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-cyber-aurora-hummingbird-core.wgsl",
+    "url": "shaders/gen-ethereal-cyber-aurora-hummingbird-core.wgsl",
     "features": []
   },
   {
     "id": "gen-ethereal-cyber-chrono-nebula-phoenix",
     "name": "Ethereal Cyber-Chrono Nebula-Phoenix",
     "description": "A majestic, hyper-organic cybernetic phoenix rising from a deep-space nebula, its wings woven from liquid auroral plasma and shattered quantum glass that burst into geometric temporal fractals upon acoustic climax.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-cyber-chrono-nebula-phoenix.wgsl",
+    "url": "shaders/gen-ethereal-cyber-chrono-nebula-phoenix.wgsl",
     "category": "generative",
     "tags": [
       "organic",
@@ -6997,7 +6997,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-cyber-chrono-void-whale",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-cyber-chrono-void-whale.wgsl",
+    "url": "shaders/gen-ethereal-cyber-chrono-void-whale.wgsl",
     "features": []
   },
   {
@@ -7014,7 +7014,7 @@
       "void"
     ],
     "description": "A majestic, hyper-dimensional cyber-dragon forged from flowing quantum plasma and crystalline temporal scales, soaring through a massive, slowly collapsing dark-matter nebula while radiating bioluminescent shockwaves synced to heavy acoustic bass drops.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-cyber-plasma-void-dragon.wgsl",
+    "url": "shaders/gen-ethereal-cyber-plasma-void-dragon.wgsl",
     "updatedParams": [
       {
         "index": 0,
@@ -7114,7 +7114,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-glass-flora-terrarium",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-glass-flora-terrarium.wgsl",
+    "url": "shaders/gen-ethereal-glass-flora-terrarium.wgsl",
     "features": []
   },
   {
@@ -7172,7 +7172,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-quantum-hologram-bonsai",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-quantum-hologram-bonsai.wgsl",
+    "url": "shaders/gen-ethereal-quantum-hologram-bonsai.wgsl",
     "features": []
   },
   {
@@ -7225,7 +7225,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-quantum-medusa",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-quantum-medusa.wgsl",
+    "url": "shaders/gen-ethereal-quantum-medusa.wgsl",
     "features": []
   },
   {
@@ -7288,7 +7288,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ethereal-silk-veil",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ethereal-silk-veil.wgsl",
+    "url": "shaders/gen-ethereal-silk-veil.wgsl",
     "features": []
   },
   {
@@ -7348,7 +7348,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-evolutionary-cellular-gardens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-evolutionary-cellular-gardens.wgsl",
+    "url": "shaders/gen-evolutionary-cellular-gardens.wgsl",
     "features": []
   },
   {
@@ -7412,7 +7412,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-feedback-echo-chamber",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-feedback-echo-chamber.wgsl",
+    "url": "shaders/gen-feedback-echo-chamber.wgsl",
     "features": []
   },
   {
@@ -7475,7 +7475,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-audio-symphony",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-audio-symphony.wgsl",
+    "url": "shaders/gen-fireworks-audio-symphony.wgsl",
     "features": []
   },
   {
@@ -7539,7 +7539,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-chrysanthemum",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-chrysanthemum.wgsl",
+    "url": "shaders/gen-fireworks-chrysanthemum.wgsl",
     "features": []
   },
   {
@@ -7600,7 +7600,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-comet-trail",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-comet-trail.wgsl",
+    "url": "shaders/gen-fireworks-comet-trail.wgsl",
     "features": []
   },
   {
@@ -7662,7 +7662,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-crackle-palm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-crackle-palm.wgsl",
+    "url": "shaders/gen-fireworks-crackle-palm.wgsl",
     "features": []
   },
   {
@@ -7722,7 +7722,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-crossette",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-crossette.wgsl",
+    "url": "shaders/gen-fireworks-crossette.wgsl",
     "features": []
   },
   {
@@ -7784,7 +7784,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-dahlia-burst",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-dahlia-burst.wgsl",
+    "url": "shaders/gen-fireworks-dahlia-burst.wgsl",
     "features": [
       "fireworks",
       "audio-reactive",
@@ -7850,7 +7850,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-fan-shell",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-fan-shell.wgsl",
+    "url": "shaders/gen-fireworks-fan-shell.wgsl",
     "features": []
   },
   {
@@ -7911,7 +7911,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-horse-tail",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-horse-tail.wgsl",
+    "url": "shaders/gen-fireworks-horse-tail.wgsl",
     "features": []
   },
   {
@@ -7972,7 +7972,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-kamuro-gold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-kamuro-gold.wgsl",
+    "url": "shaders/gen-fireworks-kamuro-gold.wgsl",
     "features": []
   },
   {
@@ -8036,7 +8036,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-nocturne",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-nocturne.wgsl",
+    "url": "shaders/gen-fireworks-nocturne.wgsl",
     "features": []
   },
   {
@@ -8097,7 +8097,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-ring-shell",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-ring-shell.wgsl",
+    "url": "shaders/gen-fireworks-ring-shell.wgsl",
     "features": []
   },
   {
@@ -8157,7 +8157,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-roman-candle",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-roman-candle.wgsl",
+    "url": "shaders/gen-fireworks-roman-candle.wgsl",
     "features": []
   },
   {
@@ -8221,7 +8221,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-smoke-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-smoke-bloom.wgsl",
+    "url": "shaders/gen-fireworks-smoke-bloom.wgsl",
     "features": []
   },
   {
@@ -8283,7 +8283,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-strobe-shell",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-strobe-shell.wgsl",
+    "url": "shaders/gen-fireworks-strobe-shell.wgsl",
     "features": []
   },
   {
@@ -8347,7 +8347,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-willow-cascade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-willow-cascade.wgsl",
+    "url": "shaders/gen-fireworks-willow-cascade.wgsl",
     "features": []
   },
   {
@@ -8410,7 +8410,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fireworks-wind-ripple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fireworks-wind-ripple.wgsl",
+    "url": "shaders/gen-fireworks-wind-ripple.wgsl",
     "features": []
   },
   {
@@ -8470,7 +8470,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fourier-epicycles",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fourier-epicycles.wgsl",
+    "url": "shaders/gen-fourier-epicycles.wgsl",
     "features": []
   },
   {
@@ -8528,7 +8528,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fractal-bioluminescence-spore-network",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fractal-bioluminescence-spore-network.wgsl",
+    "url": "shaders/gen-fractal-bioluminescence-spore-network.wgsl",
     "features": []
   },
   {
@@ -8593,7 +8593,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fractal-clockwork",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fractal-clockwork.wgsl",
+    "url": "shaders/gen-fractal-clockwork.wgsl",
     "features": []
   },
   {
@@ -8655,7 +8655,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fractal-ember-lattice",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fractal-ember-lattice.wgsl",
+    "url": "shaders/gen-fractal-ember-lattice.wgsl",
     "features": []
   },
   {
@@ -8717,7 +8717,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-fractured-monolith",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-fractured-monolith.wgsl",
+    "url": "shaders/gen-fractured-monolith.wgsl",
     "features": []
   },
   {
@@ -8775,7 +8775,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-galactic-aether-crystal-geode-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-galactic-aether-crystal-geode-core.wgsl",
+    "url": "shaders/gen-galactic-aether-crystal-geode-core.wgsl",
     "features": []
   },
   {
@@ -8833,7 +8833,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ghost-flame",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ghost-flame.wgsl",
+    "url": "shaders/gen-ghost-flame.wgsl",
     "features": []
   },
   {
@@ -8891,12 +8891,12 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-glacial-aether-quantum-cavern",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-glacial-aether-quantum-cavern.wgsl",
+    "url": "shaders/gen-glacial-aether-quantum-cavern.wgsl",
     "features": []
   },
   {
     "id": "gen-glass-mosaic-liquid-refraction",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-glass-mosaic-liquid-refraction.wgsl",
+    "url": "shaders/gen-glass-mosaic-liquid-refraction.wgsl",
     "name": "Glass Mosaic Liquid Refraction",
     "category": "generative",
     "filename": "gen-glass-mosaic-liquid-refraction.wgsl",
@@ -9022,7 +9022,7 @@
     "supportsDepth": true,
     "supportsDof": false,
     "updated": true,
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-gravitational-strain.wgsl",
+    "url": "shaders/gen-gravitational-strain.wgsl",
     "features": []
   },
   {
@@ -9084,7 +9084,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-gravito-phononic-accretion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-gravito-phononic-accretion.wgsl",
+    "url": "shaders/gen-gravito-phononic-accretion.wgsl",
     "features": []
   },
   {
@@ -9137,7 +9137,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-graviton-plasma-lotus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-graviton-plasma-lotus.wgsl",
+    "url": "shaders/gen-graviton-plasma-lotus.wgsl",
     "features": []
   },
   {
@@ -9194,7 +9194,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-holographic-bismuth-core-reactor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-bismuth-core-reactor.wgsl",
+    "url": "shaders/gen-holographic-bismuth-core-reactor.wgsl",
     "features": []
   },
   {
@@ -9256,14 +9256,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-holographic-data-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-data-core.wgsl",
+    "url": "shaders/gen-holographic-data-core.wgsl",
     "features": []
   },
   {
     "id": "gen-holographic-fracture",
     "name": "Holographic Fracture",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-fracture.wgsl",
+    "url": "shaders/gen-holographic-fracture.wgsl",
     "description": "Iridescent cracked planes with SDF fracture lines and thin-film holographic shards. Audio drives crack glow, and mouse interaction spawns new radial cracks.",
     "features": [
       "generative",
@@ -9385,7 +9385,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-holographic-lens-flare-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-lens-flare-matrix.wgsl",
+    "url": "shaders/gen-holographic-lens-flare-matrix.wgsl",
     "features": []
   },
   {
@@ -9443,7 +9443,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-holographic-membrane",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-membrane.wgsl",
+    "url": "shaders/gen-holographic-membrane.wgsl",
     "features": []
   },
   {
@@ -9500,7 +9500,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-holographic-plasma-geode",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-plasma-geode.wgsl",
+    "url": "shaders/gen-holographic-plasma-geode.wgsl",
     "features": []
   },
   {
@@ -9561,7 +9561,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-holographic-rainbow-surface",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-holographic-rainbow-surface.wgsl",
+    "url": "shaders/gen-holographic-rainbow-surface.wgsl",
     "features": []
   },
   {
@@ -9623,7 +9623,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hopf-fibration-fiber-bundle",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hopf-fibration-fiber-bundle.wgsl",
+    "url": "shaders/gen-hopf-fibration-fiber-bundle.wgsl",
     "features": []
   },
   {
@@ -9683,7 +9683,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyper-bismuth-clockwork",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyper-bismuth-clockwork.wgsl",
+    "url": "shaders/gen-hyper-bismuth-clockwork.wgsl",
     "features": []
   },
   {
@@ -9743,7 +9743,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyper-dimensional-bismuth-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyper-dimensional-bismuth-matrix.wgsl",
+    "url": "shaders/gen-hyper-dimensional-bismuth-matrix.wgsl",
     "features": []
   },
   {
@@ -9800,7 +9800,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyper-dimensional-tesseract-labyrinth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyper-dimensional-tesseract-labyrinth.wgsl",
+    "url": "shaders/gen-hyper-dimensional-tesseract-labyrinth.wgsl",
     "features": []
   },
   {
@@ -9862,7 +9862,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyper-labyrinth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyper-labyrinth.wgsl",
+    "url": "shaders/gen-hyper-labyrinth.wgsl",
     "features": []
   },
   {
@@ -9922,7 +9922,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyper-rainbow-vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyper-rainbow-vortex.wgsl",
+    "url": "shaders/gen-hyper-rainbow-vortex.wgsl",
     "features": []
   },
   {
@@ -9975,7 +9975,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyper-refractive-rain-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyper-refractive-rain-matrix.wgsl",
+    "url": "shaders/gen-hyper-refractive-rain-matrix.wgsl",
     "features": []
   },
   {
@@ -10035,7 +10035,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyperbolic-crystal-symbiosis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyperbolic-crystal-symbiosis.wgsl",
+    "url": "shaders/gen-hyperbolic-crystal-symbiosis.wgsl",
     "features": []
   },
   {
@@ -10096,7 +10096,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyperbolic-tessellation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyperbolic-tessellation.wgsl",
+    "url": "shaders/gen-hyperbolic-tessellation.wgsl",
     "features": []
   },
   {
@@ -10156,7 +10156,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hyperbolic-tree",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hyperbolic-tree.wgsl",
+    "url": "shaders/gen-hyperbolic-tree.wgsl",
     "features": []
   },
   {
@@ -10216,7 +10216,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-hypnotic-vortex-tunnel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-hypnotic-vortex-tunnel.wgsl",
+    "url": "shaders/gen-hypnotic-vortex-tunnel.wgsl",
     "features": []
   },
   {
@@ -10277,7 +10277,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-ifs-fractal-flame",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-ifs-fractal-flame.wgsl",
+    "url": "shaders/gen-ifs-fractal-flame.wgsl",
     "features": [
       "depth-aware",
       "alpha-layered",
@@ -10345,7 +10345,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-image-pixel-detonation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-image-pixel-detonation.wgsl",
+    "url": "shaders/gen-image-pixel-detonation.wgsl",
     "features": []
   },
   {
@@ -10408,7 +10408,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-image-pyro",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-image-pyro.wgsl",
+    "url": "shaders/gen-image-pyro.wgsl",
     "features": []
   },
   {
@@ -10470,7 +10470,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-inverse-mandelbrot",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-inverse-mandelbrot.wgsl",
+    "url": "shaders/gen-inverse-mandelbrot.wgsl",
     "features": []
   },
   {
@@ -10532,7 +10532,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-islamic-star-rose",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-islamic-star-rose.wgsl",
+    "url": "shaders/gen-islamic-star-rose.wgsl",
     "features": []
   },
   {
@@ -10589,7 +10589,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-isometric-city",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-isometric-city.wgsl",
+    "url": "shaders/gen-isometric-city.wgsl",
     "features": []
   },
   {
@@ -10646,7 +10646,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-kinetic-neo-brutalist-megastructure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-kinetic-neo-brutalist-megastructure.wgsl",
+    "url": "shaders/gen-kinetic-neo-brutalist-megastructure.wgsl",
     "features": []
   },
   {
@@ -10705,7 +10705,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-klein-bottle-walk",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-klein-bottle-walk.wgsl",
+    "url": "shaders/gen-klein-bottle-walk.wgsl",
     "features": []
   },
   {
@@ -10765,7 +10765,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-koch-snowflake-storm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-koch-snowflake-storm.wgsl",
+    "url": "shaders/gen-koch-snowflake-storm.wgsl",
     "features": []
   },
   {
@@ -10822,7 +10822,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-kryonic-quantum-aether-fractal-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-kryonic-quantum-aether-fractal-core.wgsl",
+    "url": "shaders/gen-kryonic-quantum-aether-fractal-core.wgsl",
     "features": []
   },
   {
@@ -10882,7 +10882,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-langton-ant",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-langton-ant.wgsl",
+    "url": "shaders/gen-langton-ant.wgsl",
     "features": []
   },
   {
@@ -10947,7 +10947,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-lenia-2",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-lenia-2.wgsl",
+    "url": "shaders/gen-lenia-2.wgsl",
     "features": []
   },
   {
@@ -11007,7 +11007,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-lichen-reaction-diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-lichen-reaction-diffusion.wgsl",
+    "url": "shaders/gen-lichen-reaction-diffusion.wgsl",
     "features": []
   },
   {
@@ -11070,7 +11070,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-lichtenberg-storm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-lichtenberg-storm.wgsl",
+    "url": "shaders/gen-lichtenberg-storm.wgsl",
     "features": []
   },
   {
@@ -11134,7 +11134,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-liquid-crystal-hive-mind",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-liquid-crystal-hive-mind.wgsl",
+    "url": "shaders/gen-liquid-crystal-hive-mind.wgsl",
     "features": []
   },
   {
@@ -11192,7 +11192,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-liquid-neon-cyber-metropolis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-liquid-neon-cyber-metropolis.wgsl",
+    "url": "shaders/gen-liquid-neon-cyber-metropolis.wgsl",
     "features": []
   },
   {
@@ -11252,7 +11252,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-liquid-rainbow-glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-liquid-rainbow-glass.wgsl",
+    "url": "shaders/gen-liquid-rainbow-glass.wgsl",
     "features": []
   },
   {
@@ -11312,13 +11312,13 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-live-studio-tab",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-live-studio-tab.wgsl",
+    "url": "shaders/gen-live-studio-tab.wgsl",
     "features": []
   },
   {
     "id": "gen-lorenz-attractor-flow",
     "name": "Lorenz Attractor Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lorenz-attractor-flow.wgsl",
+    "url": "shaders/lorenz-attractor-flow.wgsl",
     "description": "Real-time visualization of the Lorenz strange attractor using GPU-accelerated ODE integration. Features chaotic butterfly-wing patterns, mouse perturbation, temporal feedback, chromatic dispersion, and temporal color evolution.",
     "features": [
       "generative",
@@ -11430,7 +11430,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-lorenz-attractor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-lorenz-attractor.wgsl",
+    "url": "shaders/gen-lorenz-attractor.wgsl",
     "features": []
   },
   {
@@ -11438,7 +11438,7 @@
     "name": "Luminescent Aether-Plasma Nebula-Koi",
     "category": "generative",
     "description": "A hyper-organic, glowing biomechanical space-koi woven from flowing aether-plasma and shattered chromatic crystal, swimming gracefully through a volumetric quantum nebula while reacting dynamically to ambient acoustic frequencies.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-aether-plasma-nebula-koi.wgsl",
+    "url": "shaders/gen-luminescent-aether-plasma-nebula-koi.wgsl",
     "tags": [
       "organic",
       "quantum",
@@ -11539,7 +11539,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminescent-chrono-fluid-astrolabe",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-chrono-fluid-astrolabe.wgsl",
+    "url": "shaders/gen-luminescent-chrono-fluid-astrolabe.wgsl",
     "features": []
   },
   {
@@ -11553,7 +11553,7 @@
       "volumetric"
     ],
     "description": "A hyper-majestic, biomechanical celestial stag woven from shattered chrono-prisms and glowing liquid-aurora, elegantly galloping through a volumetric cosmic-rift while its crystalline antlers carve temporal geometric fractals into the void.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-chrono-prism-astro-stag.wgsl",
+    "url": "shaders/gen-luminescent-chrono-prism-astro-stag.wgsl",
     "workgroup_size": [
       16,
       16,
@@ -11656,7 +11656,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminescent-cyber-chrono-void-turtle",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-cyber-chrono-void-turtle.wgsl",
+    "url": "shaders/gen-luminescent-cyber-chrono-void-turtle.wgsl",
     "features": []
   },
   {
@@ -11713,7 +11713,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminescent-quantum-glass-phoenix-egg",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-quantum-glass-phoenix-egg.wgsl",
+    "url": "shaders/gen-luminescent-quantum-glass-phoenix-egg.wgsl",
     "features": []
   },
   {
@@ -11772,7 +11772,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminescent-quantum-void-anglerfish",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-quantum-void-anglerfish.wgsl",
+    "url": "shaders/gen-luminescent-quantum-void-anglerfish.wgsl",
     "features": []
   },
   {
@@ -11829,7 +11829,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminescent-quantum-void-astral-turtle",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminescent-quantum-void-astral-turtle.wgsl",
+    "url": "shaders/gen-luminescent-quantum-void-astral-turtle.wgsl",
     "features": []
   },
   {
@@ -11887,7 +11887,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminous-cauldron",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminous-cauldron.wgsl",
+    "url": "shaders/gen-luminous-cauldron.wgsl",
     "features": []
   },
   {
@@ -11945,7 +11945,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-luminous-fluid-chladni-resonator",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-luminous-fluid-chladni-resonator.wgsl",
+    "url": "shaders/gen-luminous-fluid-chladni-resonator.wgsl",
     "features": []
   },
   {
@@ -12004,7 +12004,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-dipole-field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-dipole-field.wgsl",
+    "url": "shaders/gen-magnetic-dipole-field.wgsl",
     "features": []
   },
   {
@@ -12064,7 +12064,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-ferrofluid-sculpture",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-ferrofluid-sculpture.wgsl",
+    "url": "shaders/gen-magnetic-ferrofluid-sculpture.wgsl",
     "features": []
   },
   {
@@ -12125,7 +12125,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-ferrofluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-ferrofluid.wgsl",
+    "url": "shaders/gen-magnetic-ferrofluid.wgsl",
     "features": []
   },
   {
@@ -12185,7 +12185,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-field-lines",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-field-lines.wgsl",
+    "url": "shaders/gen-magnetic-field-lines.wgsl",
     "features": []
   },
   {
@@ -12243,7 +12243,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-field-warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-field-warp.wgsl",
+    "url": "shaders/gen-magnetic-field-warp.wgsl",
     "features": []
   },
   {
@@ -12301,7 +12301,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-kelp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-kelp.wgsl",
+    "url": "shaders/gen-magnetic-kelp.wgsl",
     "features": []
   },
   {
@@ -12362,7 +12362,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-magnetic-storm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-magnetic-storm.wgsl",
+    "url": "shaders/gen-magnetic-storm.wgsl",
     "features": []
   },
   {
@@ -12421,7 +12421,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-mandelbox-explorer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-mandelbox-explorer.wgsl",
+    "url": "shaders/gen-mandelbox-explorer.wgsl",
     "features": []
   },
   {
@@ -12481,7 +12481,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-metaball-soft-body",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-metaball-soft-body.wgsl",
+    "url": "shaders/gen-metaball-soft-body.wgsl",
     "features": []
   },
   {
@@ -12543,7 +12543,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-micro-cosmos",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-micro-cosmos.wgsl",
+    "url": "shaders/gen-micro-cosmos.wgsl",
     "features": []
   },
   {
@@ -12612,7 +12612,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-minimal-surface-soap-iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-minimal-surface-soap-iridescence.wgsl",
+    "url": "shaders/gen-minimal-surface-soap-iridescence.wgsl",
     "features": [
       "hdr",
       "aces-tone-mapping",
@@ -12687,7 +12687,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-molten-planetary-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-molten-planetary-core.wgsl",
+    "url": "shaders/gen-molten-planetary-core.wgsl",
     "features": []
   },
   {
@@ -12747,7 +12747,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-multi-scale-evolutionary-cellular-gardens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-multi-scale-evolutionary-cellular-gardens.wgsl",
+    "url": "shaders/gen-multi-scale-evolutionary-cellular-gardens.wgsl",
     "features": []
   },
   {
@@ -12807,7 +12807,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-murmuration-phantom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-murmuration-phantom.wgsl",
+    "url": "shaders/gen-murmuration-phantom.wgsl",
     "features": []
   },
   {
@@ -12867,7 +12867,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-mycelium-network",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-mycelium-network.wgsl",
+    "url": "shaders/gen-mycelium-network.wgsl",
     "features": []
   },
   {
@@ -12928,7 +12928,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-navier-stokes-ink",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-navier-stokes-ink.wgsl",
+    "url": "shaders/gen-navier-stokes-ink.wgsl",
     "features": []
   },
   {
@@ -12987,7 +12987,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-nebula-light-trail-swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-nebula-light-trail-swarm.wgsl",
+    "url": "shaders/gen-nebula-light-trail-swarm.wgsl",
     "features": []
   },
   {
@@ -13051,7 +13051,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-nebular-chrono-astrolabe",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-nebular-chrono-astrolabe.wgsl",
+    "url": "shaders/gen-nebular-chrono-astrolabe.wgsl",
     "features": []
   },
   {
@@ -13112,7 +13112,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-acid-geometry",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-acid-geometry.wgsl",
+    "url": "shaders/gen-neon-acid-geometry.wgsl",
     "features": []
   },
   {
@@ -13173,7 +13173,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-cyber-mandala",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-cyber-mandala.wgsl",
+    "url": "shaders/gen-neon-cyber-mandala.wgsl",
     "features": []
   },
   {
@@ -13233,7 +13233,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-lotus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-lotus.wgsl",
+    "url": "shaders/gen-neon-lotus.wgsl",
     "features": []
   },
   {
@@ -13296,7 +13296,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-neural-network",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-neural-network.wgsl",
+    "url": "shaders/gen-neon-neural-network.wgsl",
     "features": []
   },
   {
@@ -13354,7 +13354,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-plasma-biomechanical-hive",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-plasma-biomechanical-hive.wgsl",
+    "url": "shaders/gen-neon-plasma-biomechanical-hive.wgsl",
     "features": []
   },
   {
@@ -13412,7 +13412,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-snowfall",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-snowfall.wgsl",
+    "url": "shaders/gen-neon-snowfall.wgsl",
     "features": []
   },
   {
@@ -13472,7 +13472,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-stellated-octahedron",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-stellated-octahedron.wgsl",
+    "url": "shaders/gen-neon-stellated-octahedron.wgsl",
     "features": [
       "generative",
       "geometry",
@@ -13542,7 +13542,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neon-tropical-paradise",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neon-tropical-paradise.wgsl",
+    "url": "shaders/gen-neon-tropical-paradise.wgsl",
     "features": []
   },
   {
@@ -13599,14 +13599,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neural-bioluminescence-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neural-bioluminescence-matrix.wgsl",
+    "url": "shaders/gen-neural-bioluminescence-matrix.wgsl",
     "features": []
   },
   {
     "id": "gen-neural-dust",
     "name": "Neural Dust",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neural-dust.wgsl",
+    "url": "shaders/gen-neural-dust.wgsl",
     "description": "Drifting luminous particle field driven by domain-warped FBM. Audio reactivity controls density and jitter, while mouse gravity attracts nearby dust motes.",
     "features": [
       "generative",
@@ -13733,7 +13733,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neural-fractal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neural-fractal.wgsl",
+    "url": "shaders/gen-neural-fractal.wgsl",
     "features": []
   },
   {
@@ -13792,7 +13792,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neural-network-glow-synaptic-pulse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neural-network-glow-synaptic-pulse.wgsl",
+    "url": "shaders/gen-neural-network-glow-synaptic-pulse.wgsl",
     "features": []
   },
   {
@@ -13855,7 +13855,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neuro-cosmos",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neuro-cosmos.wgsl",
+    "url": "shaders/gen-neuro-cosmos.wgsl",
     "features": []
   },
   {
@@ -13914,7 +13914,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neuro-fluid-plasma-lotus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neuro-fluid-plasma-lotus.wgsl",
+    "url": "shaders/gen-neuro-fluid-plasma-lotus.wgsl",
     "features": []
   },
   {
@@ -13972,7 +13972,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neuro-kinetic-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neuro-kinetic-bloom.wgsl",
+    "url": "shaders/gen-neuro-kinetic-bloom.wgsl",
     "features": []
   },
   {
@@ -14029,14 +14029,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-neuro-kinetic-liquid-gold-lotus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-neuro-kinetic-liquid-gold-lotus.wgsl",
+    "url": "shaders/gen-neuro-kinetic-liquid-gold-lotus.wgsl",
     "features": []
   },
   {
     "id": "gen-newton-fractal",
     "name": "Newton Fractal",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-newton-fractal.wgsl",
+    "url": "shaders/gen-newton-fractal.wgsl",
     "tags": [
       "generative",
       "fractal",
@@ -14159,7 +14159,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-obsidian-echo-chamber",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-obsidian-echo-chamber.wgsl",
+    "url": "shaders/gen-obsidian-echo-chamber.wgsl",
     "features": []
   },
   {
@@ -14217,7 +14217,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-opal-circuit",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-opal-circuit.wgsl",
+    "url": "shaders/gen-opal-circuit.wgsl",
     "features": []
   },
   {
@@ -14277,7 +14277,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-percolation-threshold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-percolation-threshold.wgsl",
+    "url": "shaders/gen-percolation-threshold.wgsl",
     "features": []
   },
   {
@@ -14337,7 +14337,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-phase-transition-memory-weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-phase-transition-memory-weave.wgsl",
+    "url": "shaders/gen-phase-transition-memory-weave.wgsl",
     "features": []
   },
   {
@@ -14395,7 +14395,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-photonic-crystal-brain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-photonic-crystal-brain.wgsl",
+    "url": "shaders/gen-photonic-crystal-brain.wgsl",
     "features": []
   },
   {
@@ -14457,7 +14457,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-phyllotaxis-galaxy-spiral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-phyllotaxis-galaxy-spiral.wgsl",
+    "url": "shaders/gen-phyllotaxis-galaxy-spiral.wgsl",
     "features": []
   },
   {
@@ -14514,7 +14514,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-physarum-sacred-geometry",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-physarum-sacred-geometry.wgsl",
+    "url": "shaders/gen-physarum-sacred-geometry.wgsl",
     "features": []
   },
   {
@@ -14575,7 +14575,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-plasma-mandala",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-plasma-mandala.wgsl",
+    "url": "shaders/gen-plasma-mandala.wgsl",
     "features": []
   },
   {
@@ -14637,7 +14637,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-plasma-psychedelic-wormhole",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-plasma-psychedelic-wormhole.wgsl",
+    "url": "shaders/gen-plasma-psychedelic-wormhole.wgsl",
     "features": []
   },
   {
@@ -14698,7 +14698,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-polar-rainbow-explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-polar-rainbow-explosion.wgsl",
+    "url": "shaders/gen-polar-rainbow-explosion.wgsl",
     "features": []
   },
   {
@@ -14759,7 +14759,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prism-tide",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prism-tide.wgsl",
+    "url": "shaders/gen-prism-tide.wgsl",
     "features": [
       "procedural",
       "audio-reactive",
@@ -14829,7 +14829,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-aether-loom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-aether-loom.wgsl",
+    "url": "shaders/gen-prismatic-aether-loom.wgsl",
     "features": []
   },
   {
@@ -14890,7 +14890,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-bismuth-lattice",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-bismuth-lattice.wgsl",
+    "url": "shaders/gen-prismatic-bismuth-lattice.wgsl",
     "features": []
   },
   {
@@ -14948,15 +14948,67 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-crystal-growth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-crystal-growth.wgsl",
+    "url": "shaders/gen-prismatic-crystal-growth.wgsl",
     "features": []
+  },
+  {
+    "id": "gen-prismatic-cyber-aether-void-kitsune",
+    "name": "Prismatic Cyber-Aether Void-Kitsune",
+    "category": "generative",
+    "tags": [
+      "kitsune",
+      "cybernetic",
+      "prismatic",
+      "aether",
+      "volumetric",
+      "fractal",
+      "audio-reactive"
+    ],
+    "description": "A hyper-majestic, cybernetic celestial kitsune forged from shattered prismatic glass and liquid quantum-aether, bounding violently through a multi-dimensional volumetric particle-storm while its nine radiant tails carve temporal auroral rifts into the void.",
+    "url": "shaders/gen-prismatic-cyber-aether-void-kitsune.wgsl",
+    "updatedParams": [
+      {
+        "index": 0,
+        "name": "Tail Dispersion",
+        "default": 1,
+        "min": 0.1,
+        "max": 3,
+        "step": 0.05
+      },
+      {
+        "index": 1,
+        "name": "Current Warp",
+        "default": 0.6,
+        "min": 0,
+        "max": 2,
+        "step": 0.05
+      },
+      {
+        "index": 2,
+        "name": "Storm Density",
+        "default": 0.5,
+        "min": 0,
+        "max": 1,
+        "step": 0.01
+      },
+      {
+        "index": 3,
+        "name": "Rune Glow",
+        "default": 1.2,
+        "min": 0,
+        "max": 3,
+        "step": 0.1
+      }
+    ],
+    "supportsDepth": true,
+    "supportsDof": false
   },
   {
     "id": "gen-prismatic-cyber-aurora-astral-dragonfly",
     "name": "Prismatic Cyber-Aurora Astral-Dragonfly",
     "description": "A majestic, hyper-organic biomechanical dragonfly forged from liquid auroral plasma and shattered chromatic crystal.",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-cyber-aurora-astral-dragonfly.wgsl",
+    "url": "shaders/gen-prismatic-cyber-aurora-astral-dragonfly.wgsl",
     "uniforms": [
       {
         "name": "Wingspan",
@@ -15033,7 +15085,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-cyber-auroral-manta-swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-cyber-auroral-manta-swarm.wgsl",
+    "url": "shaders/gen-prismatic-cyber-auroral-manta-swarm.wgsl",
     "features": []
   },
   {
@@ -15042,7 +15094,7 @@
     "category": "generative",
     "description": "A hyper-majestic, biomechanical celestial peacock woven from shattered quantum glass and glowing liquid-aurora.",
     "author": "Jules",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-cyber-chrono-nebula-peacock.wgsl",
+    "url": "shaders/gen-prismatic-cyber-chrono-nebula-peacock.wgsl",
     "tags": [
       "organic",
       "quantum",
@@ -15090,7 +15142,7 @@
   {
     "id": "gen-prismatic-cyber-chrono-void-kitsune",
     "name": "Prismatic Cyber-Chrono Void-Kitsune",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-cyber-chrono-void-kitsune.wgsl",
+    "url": "shaders/gen-prismatic-cyber-chrono-void-kitsune.wgsl",
     "category": "generative",
     "tags": [
       "cosmic",
@@ -15188,7 +15240,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-fractal-dunes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-fractal-dunes.wgsl",
+    "url": "shaders/gen-prismatic-fractal-dunes.wgsl",
     "features": []
   },
   {
@@ -15246,7 +15298,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-ion-cascade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-ion-cascade.wgsl",
+    "url": "shaders/gen-prismatic-ion-cascade.wgsl",
     "features": []
   },
   {
@@ -15306,7 +15358,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-mobius-helix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-mobius-helix.wgsl",
+    "url": "shaders/gen-prismatic-mobius-helix.wgsl",
     "features": [
       "generative",
       "geometry",
@@ -15372,7 +15424,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-quantum-fractal-nautilus-engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-quantum-fractal-nautilus-engine.wgsl",
+    "url": "shaders/gen-prismatic-quantum-fractal-nautilus-engine.wgsl",
     "features": []
   },
   {
@@ -15430,7 +15482,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-prismatic-void-weaver-ouroboros",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-prismatic-void-weaver-ouroboros.wgsl",
+    "url": "shaders/gen-prismatic-void-weaver-ouroboros.wgsl",
     "features": []
   },
   {
@@ -15490,7 +15542,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-protocell-division",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-protocell-division.wgsl",
+    "url": "shaders/gen-protocell-division.wgsl",
     "features": []
   },
   {
@@ -15547,7 +15599,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-psychedelic-layered-time-stamps",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-psychedelic-layered-time-stamps.wgsl",
+    "url": "shaders/gen-psychedelic-layered-time-stamps.wgsl",
     "features": []
   },
   {
@@ -15606,7 +15658,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-psychedelic-moire-flower",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-psychedelic-moire-flower.wgsl",
+    "url": "shaders/gen-psychedelic-moire-flower.wgsl",
     "features": []
   },
   {
@@ -15663,12 +15715,12 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-psychedelic-time-warp-kaleidoscope",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-psychedelic-time-warp-kaleidoscope.wgsl",
+    "url": "shaders/gen-psychedelic-time-warp-kaleidoscope.wgsl",
     "features": []
   },
   {
     "id": "gen-quantum-aether-origami",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-aether-origami.wgsl",
+    "url": "shaders/gen-quantum-aether-origami.wgsl",
     "name": "Quantum Aether Origami",
     "category": "generative",
     "filename": "gen-quantum-aether-origami.wgsl",
@@ -15782,7 +15834,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-chrome-serpent-ouroboros",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-chrome-serpent-ouroboros.wgsl",
+    "url": "shaders/gen-quantum-chrome-serpent-ouroboros.wgsl",
     "features": []
   },
   {
@@ -15844,7 +15896,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-entangled-ferrofluid-engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-entangled-ferrofluid-engine.wgsl",
+    "url": "shaders/gen-quantum-entangled-ferrofluid-engine.wgsl",
     "features": []
   },
   {
@@ -15902,7 +15954,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-fluorescent-aether-moth-swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-fluorescent-aether-moth-swarm.wgsl",
+    "url": "shaders/gen-quantum-fluorescent-aether-moth-swarm.wgsl",
     "features": []
   },
   {
@@ -15959,7 +16011,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-fluorescent-nebula-anemone",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-fluorescent-nebula-anemone.wgsl",
+    "url": "shaders/gen-quantum-fluorescent-nebula-anemone.wgsl",
     "features": []
   },
   {
@@ -16017,7 +16069,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-foam-alpha",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-foam-alpha.wgsl",
+    "url": "shaders/gen-quantum-foam-alpha.wgsl",
     "features": []
   },
   {
@@ -16080,7 +16132,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-foam",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-foam.wgsl",
+    "url": "shaders/gen-quantum-foam.wgsl",
     "features": [
       "worley-noise",
       "lod-scaling",
@@ -16150,7 +16202,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-mycelium",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-mycelium.wgsl",
+    "url": "shaders/gen-quantum-mycelium.wgsl",
     "features": []
   },
   {
@@ -16211,14 +16263,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-neural-lace",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-neural-lace.wgsl",
+    "url": "shaders/gen-quantum-neural-lace.wgsl",
     "features": []
   },
   {
     "id": "gen-quantum-pollen",
     "name": "Quantum Pollen",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-pollen.wgsl",
+    "url": "shaders/gen-quantum-pollen.wgsl",
     "tags": [
       "generative",
       "particles",
@@ -16344,7 +16396,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-singularity-forge",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-singularity-forge.wgsl",
+    "url": "shaders/gen-quantum-singularity-forge.wgsl",
     "features": []
   },
   {
@@ -16407,7 +16459,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-quantum-superposition",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quantum-superposition.wgsl",
+    "url": "shaders/gen-quantum-superposition.wgsl",
     "features": []
   },
   {
@@ -16471,7 +16523,7 @@
     "supportsDepth": true,
     "supportsDof": false,
     "updated": true,
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-quasicrystal.wgsl",
+    "url": "shaders/gen-quasicrystal.wgsl",
     "features": [
       "audio-reactive"
     ]
@@ -16531,7 +16583,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-radiant-chrono-glass-nautilus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-radiant-chrono-glass-nautilus.wgsl",
+    "url": "shaders/gen-radiant-chrono-glass-nautilus.wgsl",
     "features": []
   },
   {
@@ -16584,13 +16636,13 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-radiant-cyber-chrono-void-stag",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-radiant-cyber-chrono-void-stag.wgsl",
+    "url": "shaders/gen-radiant-cyber-chrono-void-stag.wgsl",
     "features": []
   },
   {
     "id": "gen-radiant-cyber-plasma-astro-griffin",
     "name": "Radiant Cyber-Plasma Astro-Griffin",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-radiant-cyber-plasma-astro-griffin.wgsl",
+    "url": "shaders/gen-radiant-cyber-plasma-astro-griffin.wgsl",
     "description": "A hyper-majestic, biomechanical celestial griffin woven from shattered chrono-prisms and glowing liquid-plasma.",
     "category": "generative",
     "tags": [
@@ -16696,7 +16748,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-radiant-quantum-crystalline-forge",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-radiant-quantum-crystalline-forge.wgsl",
+    "url": "shaders/gen-radiant-quantum-crystalline-forge.wgsl",
     "features": []
   },
   {
@@ -16753,7 +16805,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-radiant-quantum-plasma-kraken-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-radiant-quantum-plasma-kraken-core.wgsl",
+    "url": "shaders/gen-radiant-quantum-plasma-kraken-core.wgsl",
     "features": []
   },
   {
@@ -16812,7 +16864,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-rainbow-firefly-dance",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-rainbow-firefly-dance.wgsl",
+    "url": "shaders/gen-rainbow-firefly-dance.wgsl",
     "features": []
   },
   {
@@ -16873,7 +16925,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-rainbow-icosahedron-cascade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-rainbow-icosahedron-cascade.wgsl",
+    "url": "shaders/gen-rainbow-icosahedron-cascade.wgsl",
     "features": [
       "generative",
       "geometry",
@@ -16938,7 +16990,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-raptor-mini",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-raptor-mini.wgsl",
+    "url": "shaders/gen-raptor-mini.wgsl",
     "features": []
   },
   {
@@ -17000,14 +17052,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-recursive-ancestral-terrains",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-recursive-ancestral-terrains.wgsl",
+    "url": "shaders/gen-recursive-ancestral-terrains.wgsl",
     "features": []
   },
   {
     "id": "gen-relay-psychedelia",
     "name": "Relay Psychedelia",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-relay-psychedelia.wgsl",
+    "url": "shaders/gen-relay-psychedelia.wgsl",
     "description": "Multi-agent relay generative shader — warped fbm field, palette-driven color, temporal feedback. See agents/RELAY_PROTOCOL.md.",
     "tags": [
       "generative",
@@ -17122,7 +17174,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-resonant-crystal-canyons",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-resonant-crystal-canyons.wgsl",
+    "url": "shaders/gen-resonant-crystal-canyons.wgsl",
     "features": []
   },
   {
@@ -17179,7 +17231,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-resonant-quantum-obsidian-scarab-engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-resonant-quantum-obsidian-scarab-engine.wgsl",
+    "url": "shaders/gen-resonant-quantum-obsidian-scarab-engine.wgsl",
     "features": []
   },
   {
@@ -17239,7 +17291,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-resonant-quantum-plasma-dragon-eye",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-resonant-quantum-plasma-dragon-eye.wgsl",
+    "url": "shaders/gen-resonant-quantum-plasma-dragon-eye.wgsl",
     "features": []
   },
   {
@@ -17300,7 +17352,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-rgb-diffraction",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-rgb-diffraction.wgsl",
+    "url": "shaders/gen-rgb-diffraction.wgsl",
     "features": []
   },
   {
@@ -17357,7 +17409,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sentient-aether-flora-biosphere",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-aether-flora-biosphere.wgsl",
+    "url": "shaders/gen-sentient-aether-flora-biosphere.wgsl",
     "features": []
   },
   {
@@ -17411,7 +17463,7 @@
       }
     ],
     "id": "gen-sentient-aether-plasma-nebula-moth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-aether-plasma-nebula-moth.wgsl",
+    "url": "shaders/gen-sentient-aether-plasma-nebula-moth.wgsl",
     "supportsDepth": true,
     "supportsDof": false,
     "updated": true,
@@ -17467,14 +17519,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sentient-cyber-aurora-void-owl",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-cyber-aurora-void-owl.wgsl",
+    "url": "shaders/gen-sentient-cyber-aurora-void-owl.wgsl",
     "features": []
   },
   {
     "id": "gen-sentient-cyber-chrono-void-serpent",
     "name": "Sentient Cyber-Chrono Void-Serpent",
     "description": "A hyper-dimensional, endlessly twisting biomechanical serpent forged from shattered chrono-glass and liquid auroral plasma, slithering aggressively through a violently decaying temporal cosmic-rift. This shader blends razor-sharp synthetic scales and recursive geometric fracturing with fluid, audio-reactive bioluminescent shockwaves.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-cyber-chrono-void-serpent.wgsl",
+    "url": "shaders/gen-sentient-cyber-chrono-void-serpent.wgsl",
     "tags": [
       "organic",
       "cybernetic",
@@ -17571,7 +17623,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sentient-ferro-silicate-swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-ferro-silicate-swarm.wgsl",
+    "url": "shaders/gen-sentient-ferro-silicate-swarm.wgsl",
     "features": []
   },
   {
@@ -17628,7 +17680,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sentient-liquid-neon-fractal-heart",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-liquid-neon-fractal-heart.wgsl",
+    "url": "shaders/gen-sentient-liquid-neon-fractal-heart.wgsl",
     "features": []
   },
   {
@@ -17687,7 +17739,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sentient-quantum-chrono-leviathan-moth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl",
+    "url": "shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl",
     "features": []
   },
   {
@@ -17752,7 +17804,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-showcase-crystalline-pulse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-showcase-crystalline-pulse.wgsl",
+    "url": "shaders/gen-showcase-crystalline-pulse.wgsl",
     "features": []
   },
   {
@@ -17815,7 +17867,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-showcase-kinetic-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-showcase-kinetic-bloom.wgsl",
+    "url": "shaders/gen-showcase-kinetic-bloom.wgsl",
     "features": []
   },
   {
@@ -17879,7 +17931,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-showcase-nebula-core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-showcase-nebula-core.wgsl",
+    "url": "shaders/gen-showcase-nebula-core.wgsl",
     "features": []
   },
   {
@@ -17938,7 +17990,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sierpinski-tetrahedron",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sierpinski-tetrahedron.wgsl",
+    "url": "shaders/gen-sierpinski-tetrahedron.wgsl",
     "features": []
   },
   {
@@ -17991,7 +18043,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-silica-tsunami",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-silica-tsunami.wgsl",
+    "url": "shaders/gen-silica-tsunami.wgsl",
     "features": []
   },
   {
@@ -18051,7 +18103,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-singularity-forge",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-singularity-forge.wgsl",
+    "url": "shaders/gen-singularity-forge.wgsl",
     "features": []
   },
   {
@@ -18111,13 +18163,13 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-solar-wind-ribbons",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-solar-wind-ribbons.wgsl",
+    "url": "shaders/gen-solar-wind-ribbons.wgsl",
     "features": []
   },
   {
     "id": "gen-sonic-lava-flow",
     "name": "Sonic Lava Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sonic-lava-flow.wgsl",
+    "url": "shaders/gen-sonic-lava-flow.wgsl",
     "category": "generative",
     "description": "Navier-Stokes-style fluid solver with domain-warped FBM, Voronoi crust detail, Beer-Lambert volumetric glow, Fresnel molten surface, enhanced curl noise, and deep audio reactivity creating a living molten world.",
     "features": [
@@ -18235,7 +18287,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-sonoluminescent-chrono-geode-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-sonoluminescent-chrono-geode-matrix.wgsl",
+    "url": "shaders/gen-sonoluminescent-chrono-geode-matrix.wgsl",
     "features": []
   },
   {
@@ -18293,7 +18345,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-spectral-ferrofluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-spectral-ferrofluid.wgsl",
+    "url": "shaders/gen-spectral-ferrofluid.wgsl",
     "features": []
   },
   {
@@ -18354,7 +18406,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-stable-fluids-jos-stam",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-stable-fluids-jos-stam.wgsl",
+    "url": "shaders/gen-stable-fluids-jos-stam.wgsl",
     "features": []
   },
   {
@@ -18414,7 +18466,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-stardust-nebula",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-stardust-nebula.wgsl",
+    "url": "shaders/gen-stardust-nebula.wgsl",
     "features": []
   },
   {
@@ -18467,7 +18519,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-stellar-plasma-ouroboros",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-stellar-plasma-ouroboros.wgsl",
+    "url": "shaders/gen-stellar-plasma-ouroboros.wgsl",
     "features": []
   },
   {
@@ -18527,7 +18579,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-stellar-web-loom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-stellar-web-loom.wgsl",
+    "url": "shaders/gen-stellar-web-loom.wgsl",
     "features": []
   },
   {
@@ -18589,7 +18641,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-strange-field-flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-strange-field-flow.wgsl",
+    "url": "shaders/gen-strange-field-flow.wgsl",
     "features": []
   },
   {
@@ -18649,7 +18701,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-string-theory",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-string-theory.wgsl",
+    "url": "shaders/gen-string-theory.wgsl",
     "features": []
   },
   {
@@ -18707,7 +18759,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-superfluid-quantum-foam",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-superfluid-quantum-foam.wgsl",
+    "url": "shaders/gen-superfluid-quantum-foam.wgsl",
     "features": []
   },
   {
@@ -18767,7 +18819,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-supernova-remnant",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-supernova-remnant.wgsl",
+    "url": "shaders/gen-supernova-remnant.wgsl",
     "features": []
   },
   {
@@ -18825,7 +18877,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-symbiotic-chrono-mycelium-engine",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-symbiotic-chrono-mycelium-engine.wgsl",
+    "url": "shaders/gen-symbiotic-chrono-mycelium-engine.wgsl",
     "features": []
   },
   {
@@ -18885,7 +18937,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-symbiotic-light-networks",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-symbiotic-light-networks.wgsl",
+    "url": "shaders/gen-symbiotic-light-networks.wgsl",
     "features": []
   },
   {
@@ -18945,7 +18997,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-symbiotic-plasma-reef-matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-symbiotic-plasma-reef-matrix.wgsl",
+    "url": "shaders/gen-symbiotic-plasma-reef-matrix.wgsl",
     "features": []
   },
   {
@@ -19005,7 +19057,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-tectonic-plasma-crucible",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-tectonic-plasma-crucible.wgsl",
+    "url": "shaders/gen-tectonic-plasma-crucible.wgsl",
     "features": []
   },
   {
@@ -19064,7 +19116,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-temporal-motion-smear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-temporal-motion-smear.wgsl",
+    "url": "shaders/gen-temporal-motion-smear.wgsl",
     "features": []
   },
   {
@@ -19123,7 +19175,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-thermal-rainbow-topography",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-thermal-rainbow-topography.wgsl",
+    "url": "shaders/gen-thermal-rainbow-topography.wgsl",
     "features": []
   },
   {
@@ -19183,7 +19235,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-topological-acoustic-knots",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-topological-acoustic-knots.wgsl",
+    "url": "shaders/gen-topological-acoustic-knots.wgsl",
     "features": []
   },
   {
@@ -19248,7 +19300,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-topological-phase-weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-topological-phase-weave.wgsl",
+    "url": "shaders/gen-topological-phase-weave.wgsl",
     "features": []
   },
   {
@@ -19307,14 +19359,14 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-topology-flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-topology-flow.wgsl",
+    "url": "shaders/gen-topology-flow.wgsl",
     "features": []
   },
   {
     "id": "gen-torus-knot-rainbow",
     "name": "Torus Knot Rainbow",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-torus-knot-rainbow.wgsl",
+    "url": "shaders/gen-torus-knot-rainbow.wgsl",
     "tags": [
       "psychedelic",
       "colorful",
@@ -19434,7 +19486,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-translucent-nebula",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-translucent-nebula.wgsl",
+    "url": "shaders/gen-translucent-nebula.wgsl",
     "features": []
   },
   {
@@ -19495,7 +19547,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-turing-morphogenesis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-turing-morphogenesis.wgsl",
+    "url": "shaders/gen-turing-morphogenesis.wgsl",
     "features": []
   },
   {
@@ -19554,7 +19606,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-velocity-bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-velocity-bloom.wgsl",
+    "url": "shaders/gen-velocity-bloom.wgsl",
     "features": []
   },
   {
@@ -19614,7 +19666,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-verlet-cloth-wind",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-verlet-cloth-wind.wgsl",
+    "url": "shaders/gen-verlet-cloth-wind.wgsl",
     "features": []
   },
   {
@@ -19674,7 +19726,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-vitreous-chrono-chandelier",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-vitreous-chrono-chandelier.wgsl",
+    "url": "shaders/gen-vitreous-chrono-chandelier.wgsl",
     "features": []
   },
   {
@@ -19737,7 +19789,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-volcanic-ink",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-volcanic-ink.wgsl",
+    "url": "shaders/gen-volcanic-ink.wgsl",
     "features": [
       "audio-reactive",
       "LOD-scaling",
@@ -19804,7 +19856,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-von-karman-vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-von-karman-vortex.wgsl",
+    "url": "shaders/gen-von-karman-vortex.wgsl",
     "features": [
       "audio-reactive"
     ]
@@ -19866,7 +19918,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-voronoi-crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-voronoi-crystal.wgsl",
+    "url": "shaders/gen-voronoi-crystal.wgsl",
     "features": []
   },
   {
@@ -19928,7 +19980,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-vortex-cathedral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-vortex-cathedral.wgsl",
+    "url": "shaders/gen-vortex-cathedral.wgsl",
     "features": [
       "volumetric-god-rays",
       "starburst-diffraction",
@@ -19995,7 +20047,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-wasm-hls-physarum-swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-wasm-hls-physarum-swarm.wgsl",
+    "url": "shaders/gen-wasm-hls-physarum-swarm.wgsl",
     "features": []
   },
   {
@@ -20054,7 +20106,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-worley-cellular-noise",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-worley-cellular-noise.wgsl",
+    "url": "shaders/gen-worley-cellular-noise.wgsl",
     "features": []
   },
   {
@@ -20114,7 +20166,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-xeno-botanical-synth-flora",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-xeno-botanical-synth-flora.wgsl",
+    "url": "shaders/gen-xeno-botanical-synth-flora.wgsl",
     "features": []
   },
   {
@@ -20172,7 +20224,7 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-xeno-mycelial-resonance-web",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-xeno-mycelial-resonance-web.wgsl",
+    "url": "shaders/gen-xeno-mycelial-resonance-web.wgsl",
     "features": []
   },
   {
@@ -20232,13 +20284,13 @@
     "supportsDof": false,
     "updated": true,
     "id": "gen-zeta-function-landscape",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen-zeta-function-landscape.wgsl",
+    "url": "shaders/gen-zeta-function-landscape.wgsl",
     "features": []
   },
   {
     "id": "gen-capabilities",
     "name": "System Monitor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_capabilities.wgsl",
+    "url": "shaders/gen_capabilities.wgsl",
     "description": "Cyberpunk system monitor demonstrating mouse inputs, time, and frame feedback.",
     "features": [
       "mouse-driven"
@@ -20293,7 +20345,7 @@
   {
     "id": "gen-cyclic-automaton",
     "name": "Greenberg-Hastings Automaton",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_cyclic_automaton.wgsl",
+    "url": "shaders/gen_cyclic_automaton.wgsl",
     "description": "Excitable cellular medium with firing, refractory cooling, bass-driven spontaneous ignition, and mouse-triggered wavefronts.",
     "features": [
       "upgraded-rgba",
@@ -20352,7 +20404,7 @@
   {
     "id": "gen-fluffy-raincloud",
     "name": "Vorticity Raincloud",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_fluffy_raincloud.wgsl",
+    "url": "shaders/gen_fluffy_raincloud.wgsl",
     "description": "Audio-reactive cloudscape with curl-noise advection, buoyant thunderheads, Mie silver lining, and rain sheets driven by stored flow.",
     "features": [
       "upgraded-rgba",
@@ -20411,7 +20463,7 @@
   {
     "id": "gen-grid",
     "name": "Domain-Warped FBM Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grid.wgsl",
+    "url": "shaders/gen_grid.wgsl",
     "description": "Audio-reactive domain-warped FBM grid with mouse gravity well, recursive moiré sub-grids, chromatic dispersion edges, and temporal motion blur.",
     "features": [
       "mouse-driven",
@@ -20473,7 +20525,7 @@
   {
     "id": "gen-grok41-mandelbrot",
     "name": "Buddhabrot Nebula",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grok41_mandelbrot.wgsl",
+    "url": "shaders/gen_grok41_mandelbrot.wgsl",
     "description": "Audio-reactive Buddhabrot orbit accumulation with bass-breathing sample count, mids hue shift, treble sparkle stars, mouse-driven panning, orbital rainbow trails, and ACES temporal accumulation.",
     "features": [
       "mouse-driven",
@@ -20535,7 +20587,7 @@
   {
     "id": "gen-grok41-plasma",
     "name": "Spherical Harmonics Plasma",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grok41_plasma.wgsl",
+    "url": "shaders/gen_grok41_plasma.wgsl",
     "description": "Audio-reactive 3D gas giant using Y(l,m) spherical harmonics with HDR ACES tone mapping, Rayleigh limb scattering, mouse-driven light, and treble-triggered lightning tendrils.",
     "features": [
       "mouse-driven",
@@ -20598,7 +20650,7 @@
   {
     "id": "gen-grok4-life",
     "name": "SmoothLife Predator-Prey",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grok4_life.wgsl",
+    "url": "shaders/gen_grok4_life.wgsl",
     "description": "Two-species SmoothLife cellular automaton with Lotka-Volterra predator-prey dynamics. Species A (green prey) uses Rafler 2011 birth/survival rules; species B (red predator) grows on prey density and decays without it. Audio bass drives prey birth-rate, treble drives predator decay, mids control coupling strength.",
     "features": [
       "mouse-driven",
@@ -20652,7 +20704,7 @@
   {
     "id": "gen-grok4-perlin",
     "name": "Stratified Erosion Terrain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grok4_perlin.wgsl",
+    "url": "shaders/gen_grok4_perlin.wgsl",
     "description": "Depth-aware terrain with sediment transport, layered rock hardness, reflective valley water tables, wind abrasion, and bass-driven seismic uplift.",
     "features": [
       "upgraded-rgba",
@@ -20714,7 +20766,7 @@
   {
     "id": "gen-grokcf-interference",
     "name": "Cylindrical Drum Modes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grokcf_interference.wgsl",
+    "url": "shaders/gen_grokcf_interference.wgsl",
     "description": "Vibrating circular membrane Bessel function modal synthesis: u_{mn} = J_m(α_{mn}·r/R)·cos(mφ)·cos(ω_{mn}·t). GPU polynomial Bessel J₀–J₃ (Abramowitz & Stegun). Audio bands activate mode families (bass→radial, mids→azimuthal, treble→higher-order). Chladni node-line colouring.",
     "features": [
       "upgraded-rgba",
@@ -20779,7 +20831,7 @@
   {
     "id": "gen-grokcf-voronoi",
     "name": "Worley Cellular",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_grokcf_voronoi.wgsl",
+    "url": "shaders/gen_grokcf_voronoi.wgsl",
     "description": "Audio-reactive Worley cellular fields with thin-film interference edge glow and micro-cosmic starfields hidden inside each cell.",
     "features": [
       "mouse-driven",
@@ -20842,7 +20894,7 @@
   {
     "id": "gen-hyper-warp",
     "name": "Hyper Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_hyper_warp.wgsl",
+    "url": "shaders/gen_hyper_warp.wgsl",
     "description": "Advanced domain warping with fractal noise and reaction-diffusion feedback.",
     "features": [
       "aces-tone-map",
@@ -20904,7 +20956,7 @@
   {
     "id": "gen-julia-set",
     "name": "Julia Set — Orbit Trap",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_julia_set.wgsl",
+    "url": "shaders/gen_julia_set.wgsl",
     "description": "Generalised Julia set iteration z^n+c for n=2..6 with smooth (continuous) iteration count μ=i−log₂(log₂|z|), multi-trap orbit colouring (circle, line, cross traps), and animated Julia parameter c orbiting a Mandelbrot cardioid boundary. Audio-driven trap scale.",
     "features": [
       "audio-reactive",
@@ -20961,7 +21013,7 @@
   {
     "id": "gen-kimi-crystal",
     "name": "Kimi Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_kimi_crystal.wgsl",
+    "url": "shaders/gen_kimi_crystal.wgsl",
     "description": "Animated crystalline structures growing on a hexagonal grid with physical light transmission. Features ice IOR-based Fresnel reflection, purity-based absorption, and variable crystal thickness.",
     "features": [
       "mouse-driven",
@@ -21021,7 +21073,7 @@
   {
     "id": "gen-kimi-nebula",
     "name": "Kimi Nebula",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_kimi_nebula.wgsl",
+    "url": "shaders/gen_kimi_nebula.wgsl",
     "description": "Cosmic nebula cloud swirls with ethereal gas formations, twinkling stars, and mouse-driven stellar winds.",
     "features": [
       "aces-tone-map",
@@ -21085,7 +21137,7 @@
   {
     "id": "gen_mandelbulb_3d",
     "name": "Mandelbulb 3D",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_mandelbulb_3d.wgsl",
+    "url": "shaders/gen_mandelbulb_3d.wgsl",
     "description": "3D Mandelbulb fractal with ray marching, orbit trap coloring, soft shadows, and distance-based alpha for atmospheric depth",
     "tags": [
       "mandelbulb",
@@ -21144,7 +21196,7 @@
   {
     "id": "gen-orb",
     "name": "Lorenz Strange Attractor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_orb.wgsl",
+    "url": "shaders/gen_orb.wgsl",
     "description": "Audio-reactive Lorenz strange attractor (σ, ρ, β) with bioluminescent depth halos and persistent scent trails. Mids drive rotation, bass adds streams, treble jitters chaos.",
     "features": [
       "mouse-driven",
@@ -21207,7 +21259,7 @@
   {
     "id": "gen-psychedelic-spiral",
     "name": "Superformula Spirograph Spiral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_psychedelic_spiral.wgsl",
+    "url": "shaders/gen_psychedelic_spiral.wgsl",
     "description": "Superformula-driven spirograph spiral with nested epicycles, audio-reactive petal modulation, mouse-centered orbit drift, and temporal feedback warping.",
     "features": [
       "mouse-driven",
@@ -21271,7 +21323,7 @@
   {
     "id": "gen_quantum_foam",
     "name": "Quantum Foam",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_quantum_foam.wgsl",
+    "url": "shaders/gen_quantum_foam.wgsl",
     "description": "Quantum vacuum fluctuation visualization with virtual particle pairs, entanglement webs, and HDR volumetric glow",
     "tags": [
       "quantum",
@@ -21329,7 +21381,7 @@
   {
     "id": "gen-rainbow-smoke",
     "name": "Rainbow Smoke with Dual Scattering",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_rainbow_smoke.wgsl",
+    "url": "shaders/gen_rainbow_smoke.wgsl",
     "description": "Multi-scale rainbow smoke with vorticity confinement, buoyancy, Rayleigh edge glow, and Mie-lit cores driven by bass and treble.",
     "features": [
       "upgraded-rgba",
@@ -21388,7 +21440,7 @@
   {
     "id": "gen-reaction-diffusion",
     "name": "FitzHugh-Nagumo Excitable Media",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_reaction_diffusion.wgsl",
+    "url": "shaders/gen_reaction_diffusion.wgsl",
     "description": "Dual-mode excitable media: Gray-Scott morphogenesis or FitzHugh-Nagumo action-potential waves with mouse/current injection and bass-triggered pulses.",
     "features": [
       "upgraded-rgba",
@@ -21454,7 +21506,7 @@
   {
     "id": "gen-trails",
     "name": "Boids Flocking",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_trails.wgsl",
+    "url": "shaders/gen_trails.wgsl",
     "description": "Audio-reactive Reynolds boids flocking with bass-driven panic, mids cohesion, treble flash bursts, mouse attraction, motion-blur streaks, and pheromone trails.",
     "features": [
       "mouse-driven",
@@ -21517,7 +21569,7 @@
   {
     "id": "gen-wave-equation",
     "name": "Fluid Ripples",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gen_wave_equation.wgsl",
+    "url": "shaders/gen_wave_equation.wgsl",
     "description": "Audio-reactive water ripple simulation with wave interference. Bass amplifies wave energy and mouse-driven pulses. Parameters control intensity, speed, scale, and damping detail.",
     "features": [
       "mouse-driven",
@@ -21576,7 +21628,7 @@
   {
     "id": "generative-psy-swirls",
     "name": "Psychedelic Swirls",
-    "url": "https://test.1ink.us/image_video_effects/shaders/generative-psy-swirls.wgsl",
+    "url": "shaders/generative-psy-swirls.wgsl",
     "description": "Multi-layer polar swirl vortex with chromatic hue separation per layer, temporal swirl accumulation, audio-driven twist modulation, HSV rainbow cycles, and ripple glow trails.",
     "features": [
       "mouse-driven",
@@ -21641,7 +21693,7 @@
   {
     "id": "generative-turing-veins",
     "name": "Turing Veins Generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/generative-turing-veins.wgsl",
+    "url": "shaders/generative-turing-veins.wgsl",
     "description": "Multiscale reaction-diffusion Turing patterns generating organic vein/network structures with bioluminescent glow, chromatic activator/inhibitor separation, temporal colony evolution via dataTextureC, and audio-driven feed rate modulation.",
     "features": [
       "mouse-driven",
@@ -21705,7 +21757,7 @@
   {
     "id": "gravito-phononic-accretion",
     "name": "Gravito-Phononic Accretion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gravito-phononic-accretion.wgsl",
+    "url": "shaders/gravito-phononic-accretion.wgsl",
     "category": "generative",
     "description": "SPH density estimation around orbiting accretors with cubic-spline kernel, shock-wave detection, and temperature-based blackbody coloring. Bass adds mass to primaries, mids drive orbital precession, treble creates acoustic standing waves. Mouse introduces a rogue body with tidal forces. Ripples seed density perturbations.",
     "features": [
@@ -21774,7 +21826,7 @@
   {
     "id": "holographic-crystal",
     "name": "Holographic Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-crystal.wgsl",
+    "url": "shaders/holographic-crystal.wgsl",
     "category": "generative",
     "description": "Crystal facet interference patterns with rainbow holographic shifts. Mouse tilts the crystal lattice.",
     "tags": [
@@ -21837,7 +21889,7 @@
     "id": "holographic-entropy-vortex",
     "name": "Holographic Entropy Vortex",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-entropy-vortex.wgsl",
+    "url": "shaders/holographic-entropy-vortex.wgsl",
     "description": "A swirling entropy vortex with holographic color shifts, iridescent thin-film interference, and atmospheric depth.",
     "features": [
       "mouse-driven",
@@ -21891,7 +21943,7 @@
     "id": "holographic_interference",
     "name": "Holographic Interference",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic_interference.wgsl",
+    "url": "shaders/holographic_interference.wgsl",
     "description": "Laser interference pattern simulation with multiple coherent sources, object beam and reference beam phase accumulation, speckle pattern, chromatic dispersion on holographic fringes, HDR bloom, and ACES tone mapping. Bass drives reference beam angle, mouse moves the virtual object, depth controls holographic parallax.",
     "tags": [
       "holographic",
@@ -21959,7 +22011,7 @@
   {
     "id": "hyperbolic-crystal-symbiosis",
     "name": "Hyperbolic Crystal Symbiosis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyperbolic-crystal-symbiosis.wgsl",
+    "url": "shaders/hyperbolic-crystal-symbiosis.wgsl",
     "category": "generative",
     "description": "Voronoi crystal facets on a true Poincaré disk with geodesic distance and Gray-Scott reaction-diffusion. Kaleidoscope symmetry mirrors the domain into audio-reactive sectors, while an audio-driven palette shifts crystal hues with bass, mids and treble. Iridescent thin-film coloring on facet edges with HDR bloom at triple junctions. Bass drives crystal growth, mids morph curvature, treble adds sparkle. Mouse warps the disk center; click ripples propagate through the crystal, and organic drift warps the domain. smin blends Euclidean and hyperbolic metrics for smooth geometric transitions. Chromatic aberration and temporal luma feedback add a living, layered glow.",
     "features": [
@@ -22042,7 +22094,7 @@
   {
     "id": "interactive_neural_swarm",
     "name": "Neural Swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive_neural_swarm.wgsl",
+    "url": "shaders/interactive_neural_swarm.wgsl",
     "description": "Agent-based neural network visualization with signal propagation, connection weights, and emergent activation patterns",
     "tags": [
       "neural",
@@ -22102,7 +22154,7 @@
   {
     "id": "kimi_flock_symphony",
     "name": "Kimi Flock Symphony",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_flock_symphony.wgsl",
+    "url": "shaders/kimi_flock_symphony.wgsl",
     "description": "Advanced particle flocking simulation with musical visualization, featuring separation, alignment, cohesion, and mouse interaction.",
     "tags": [
       "boids",
@@ -22163,7 +22215,7 @@
   {
     "id": "kimi-fractal-dreams",
     "name": "Kimi Fractal Dreams",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_fractal_dreams.wgsl",
+    "url": "shaders/kimi_fractal_dreams.wgsl",
     "description": "Multi-layer fractal with orbit traps, burning ship variant, and smooth color cycling.",
     "features": [
       "mouse-driven",
@@ -22219,7 +22271,7 @@
   {
     "id": "kimi-nebula-depth",
     "name": "Kimi Nebula Depth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_nebula_depth.wgsl",
+    "url": "shaders/kimi_nebula_depth.wgsl",
     "description": "Volumetric nebula with 3D noise, ray marching, and depth-based color grading.",
     "features": [
       "mouse-driven",
@@ -22273,7 +22325,7 @@
   {
     "id": "kimi-quantum-field",
     "name": "Kimi Quantum Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_quantum_field.wgsl",
+    "url": "shaders/kimi_quantum_field.wgsl",
     "description": "Wave interference patterns with uncertainty visualization and probability densities.",
     "features": [
       "mouse-driven",
@@ -22329,7 +22381,7 @@
   {
     "id": "lava-lamp-blobs",
     "name": "Lava Lamp Blobs",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lava-lamp-blobs.wgsl",
+    "url": "shaders/lava-lamp-blobs.wgsl",
     "category": "generative",
     "description": "Metaball lava blobs rise and merge with chromatic warm-cool color shifts and audio-reactive heat.",
     "tags": [
@@ -22391,7 +22443,7 @@
   {
     "id": "liquid_crystal_birefringence",
     "name": "Liquid Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid_crystal_birefringence.wgsl",
+    "url": "shaders/liquid_crystal_birefringence.wgsl",
     "description": "Liquid crystal optical effects with birefringent double refraction, twisted nematic polarization rotation, and Schlieren texture",
     "tags": [
       "interactive",
@@ -22453,7 +22505,7 @@
   {
     "id": "liquid_magnetic_ferro",
     "name": "Magnetic Ferrofluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid_magnetic_ferro.wgsl",
+    "url": "shaders/liquid_magnetic_ferro.wgsl",
     "description": "Interactive ferrofluid simulation with magnetic field lines, Rosensweig instability spike formation, and metallic iridescent rendering",
     "tags": [
       "ferrofluid",
@@ -22511,7 +22563,7 @@
   {
     "id": "magnetic-flux-garden",
     "name": "Magnetic Flux Garden",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-flux-garden.wgsl",
+    "url": "shaders/magnetic-flux-garden.wgsl",
     "category": "generative",
     "description": "Ferrofluid-like magnetic field lines curve between cursor poles, blooming with organic turbulence and treble seeds.",
     "tags": [
@@ -22573,7 +22625,7 @@
   {
     "id": "molten-gold",
     "name": "Molten Gold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/molten-gold.wgsl",
+    "url": "shaders/molten-gold.wgsl",
     "category": "generative",
     "description": "Molten gold liquid metal effect with flowing fBM noise. Hypnotic idle animation with satisfying mouse claim interaction. Audio-reactive: bass fuels glow, treble adds specular highlights, mid drives ripple shimmer.",
     "features": [
@@ -22637,7 +22689,7 @@
     "id": "morphogenic-resonance",
     "name": "Morphogenic Resonance",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/morphogenic-resonance.wgsl",
+    "url": "shaders/morphogenic-resonance.wgsl",
     "description": "Organic shapes that morph between geometric and biological forms via sinusoidal interpolation. Bass drives morph speed, mids add surface ripple resonance, treble creates edge discharge. Mouse warps the morph field.",
     "features": [
       "audio-reactive",
@@ -22700,7 +22752,7 @@
   {
     "id": "multi-scale-evolutionary-cellular-gardens",
     "name": "Multi-Scale Evolutionary Cellular Gardens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/multi-scale-evolutionary-cellular-gardens.wgsl",
+    "url": "shaders/multi-scale-evolutionary-cellular-gardens.wgsl",
     "category": "generative",
     "description": "Two competing cellular species whose growth rules slowly evolve under audio pressure. The garden changes its fundamental behavior over time while remaining visually coherent.",
     "features": [
@@ -22768,7 +22820,7 @@
     "id": "mycelium-network",
     "name": "Mycelium Network",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mycelium-network.wgsl",
+    "url": "shaders/mycelium-network.wgsl",
     "description": "Underground fungal hyphae network with pulsing nutrient flows traveling along branches. Audio triggers bright nutrient pulses.",
     "features": [
       "audio-reactive",
@@ -22826,7 +22878,7 @@
   {
     "id": "nebula-gyroid",
     "name": "Nebula Gyroid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/nebula-gyroid.wgsl",
+    "url": "shaders/nebula-gyroid.wgsl",
     "description": "Ethereal, flowing organic form created with raymarched gyroid SDFs. Features iridescent lighting, multiple blended gyroid layers, and mouse-reactive domain warping for a fluid geometry effect.",
     "tags": [
       "generative",
@@ -22896,7 +22948,7 @@
   {
     "id": "neon-fern-garden",
     "name": "Neon Fern Garden",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-fern-garden.wgsl",
+    "url": "shaders/neon-fern-garden.wgsl",
     "category": "generative",
     "description": "Procedurally generated fern fronds unfurling in neon colors against dark soil. Bass drives growth animation, mids control frond density, treble creates dewdrop sparkles. Mouse attracts or repels frond tips.",
     "tags": [
@@ -22968,7 +23020,7 @@
     "id": "neural-mandala",
     "name": "Neural Mandala",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-mandala.wgsl",
+    "url": "shaders/neural-mandala.wgsl",
     "description": "Concentric geometric rings with interconnected node networks that pulse and evolve. Audio drives ring expansion and node brightness.",
     "features": [
       "audio-reactive",
@@ -23025,7 +23077,7 @@
   {
     "id": "neural-synapse-web",
     "name": "Neural Synapse Web",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-synapse-web.wgsl",
+    "url": "shaders/neural-synapse-web.wgsl",
     "category": "generative",
     "description": "Pulsing neural network nodes connected by synaptic signal lines, with audio-triggered pulses traveling connections.",
     "tags": [
@@ -23087,7 +23139,7 @@
   {
     "id": "phase-memory-weave",
     "name": "Phase Memory Weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phase-memory-weave.wgsl",
+    "url": "shaders/phase-memory-weave.wgsl",
     "category": "generative",
     "description": "Continuous Ginzburg-Landau order parameter with Allen-Cahn interface energy and exponential-decay memory kernel. Opalescent thin-film interference on phase boundaries with fluid caustics and crystalline subsurface scattering. Bass nucleates crystal seeds, mids control grain boundary mobility, treble adds capillary waves. Mouse deposits heat or cold based on click parity.",
     "features": [
@@ -23155,7 +23207,7 @@
   {
     "id": "phosphorescent-jellyfish",
     "name": "Phosphorescent Jellyfish",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phosphorescent-jellyfish.wgsl",
+    "url": "shaders/phosphorescent-jellyfish.wgsl",
     "description": "Glowing jellyfish with trailing tentacle bioluminescence. Bass pulses the bell contraction, mids create tentacle wave motion, treble adds individual photophore sparkles. Mouse attracts the jellyfish swarm.",
     "tags": [
       "generative",
@@ -23214,7 +23266,7 @@
   {
     "id": "plasma-jet-stream",
     "name": "Plasma Jet Stream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/plasma-jet-stream.wgsl",
+    "url": "shaders/plasma-jet-stream.wgsl",
     "category": "generative",
     "description": "High-energy plasma jets radiate from center with bass-driven intensity, mids-driven spread, and treble sparks.",
     "tags": [
@@ -23277,7 +23329,7 @@
     "id": "plasma-orb",
     "name": "Plasma Orb",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/plasma-orb.wgsl",
+    "url": "shaders/plasma-orb.wgsl",
     "description": "Magnetohydrodynamic plasma orb with tokamak-style field lines, Alfvén waves, magnetic reconnection flares, and synchrotron emission. Audio drives plasma temperature and field chaos; mouse pinches the orb. Depth controls field line density perspective.",
     "features": [
       "audio-reactive",
@@ -23341,7 +23393,7 @@
   {
     "id": "psy-swirls",
     "name": "Psychedelic Rainbow Swirls",
-    "url": "https://test.1ink.us/image_video_effects/shaders/generative-psy-swirls.wgsl",
+    "url": "shaders/generative-psy-swirls.wgsl",
     "description": "Generative swirling vortex fields with multi-layer procedural noise flow, spectral rainbow HSV cycles from polar angles, temporal twisting, and psychedelic distortion. Mouse attracts swirls; ripples spawn color bursts.",
     "params": [
       {
@@ -23405,7 +23457,7 @@
     "id": "quantum-foam-lattice",
     "name": "Quantum Foam Lattice",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-foam-lattice.wgsl",
+    "url": "shaders/quantum-foam-lattice.wgsl",
     "description": "Quantum foam visualization: bubbling vacuum fluctuations forming a crystalline lattice that pulses to bass. Mids drive lattice distortions, treble creates sparkles at node intersections. Mouse warps the lattice locally.",
     "features": [
       "audio-reactive",
@@ -23471,7 +23523,7 @@
   {
     "id": "recursive-ancestral-terrains",
     "name": "Recursive Ancestral Terrains",
-    "url": "https://test.1ink.us/image_video_effects/shaders/recursive-ancestral-terrains.wgsl",
+    "url": "shaders/recursive-ancestral-terrains.wgsl",
     "category": "generative",
     "description": "A fractal landscape where different ancestral 'lineages' of terrain rules coexist. Moving the mouse selects which generational traits are expressed in different regions, revealing the evolutionary history of the land.",
     "features": [
@@ -23539,7 +23591,7 @@
   {
     "id": "retro_phosphor_dream",
     "name": "Phosphor Dream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/retro_phosphor_dream.wgsl",
+    "url": "shaders/retro_phosphor_dream.wgsl",
     "description": "Authentic CRT simulation with RGB phosphor triads, persistence afterglow, interlaced flicker, barrel distortion, and chromatic aberration",
     "tags": [
       "crt",
@@ -23596,7 +23648,7 @@
   {
     "id": "sacred-geometry-torus",
     "name": "Sacred Geometry Torus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sacred-geometry-torus.wgsl",
+    "url": "shaders/sacred-geometry-torus.wgsl",
     "category": "generative",
     "description": "Golden ratio torus knots and sacred geometry nodes rotate in layered phi-harmonic patterns driven by bass.",
     "tags": [
@@ -23660,7 +23712,7 @@
     "id": "sand-dunes",
     "name": "Sand Dunes",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sand-dunes.wgsl",
+    "url": "shaders/sand-dunes.wgsl",
     "description": "Bagnold dune physics with domain-warped anisotropic fBm, GGX sun glints on grain faces, Rayleigh-Mie atmospheric haze, and temporal sand-drift feedback. Separation bubbles at crests, ripple superposition on slip faces, OkLab desert palette, subsurface scattering and HDR saltation sparkles. Audio drives wind migration, treble sparkles and temporal blend. Mouse creates wind shadows. Depth controls atmospheric haze.",
     "features": [
       "audio-reactive",
@@ -23729,7 +23781,7 @@
   {
     "id": "solar-flare-cascade",
     "name": "Solar Flare Cascade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/solar-flare-cascade.wgsl",
+    "url": "shaders/solar-flare-cascade.wgsl",
     "category": "generative",
     "description": "Solar prominence and flare cascades erupting from a stellar limb. Bass drives flare intensity, mids create magnetic loop structures, treble adds coronal mass ejection particles. Mouse position shifts the stellar limb.",
     "tags": [
@@ -23798,7 +23850,7 @@
   {
     "id": "spec-analytic-noise-flow",
     "name": "Analytic Noise Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-analytic-noise-flow.wgsl",
+    "url": "shaders/spec-analytic-noise-flow.wgsl",
     "description": "Perlin noise with analytic derivatives for ultra-smooth flow fields. Gradient computed alongside noise value in single evaluation, eliminating finite-difference jitter for perfectly parallel streamlines.",
     "tags": [
       "analytic-derivatives",
@@ -23860,7 +23912,7 @@
   {
     "id": "spec-distance-field-text",
     "name": "Distance Field Text",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-distance-field-text.wgsl",
+    "url": "shaders/spec-distance-field-text.wgsl",
     "description": "SDF-based procedural glyph overlay with audio-reactive domain warp, depth-aware shadows, temporal feedback trails, ACES tone mapping, and chromatic aberration. Generates abstract runes and symbols as signed distance fields with smooth scaling, glowing edges, and chromatic cycling.",
     "tags": [
       "SDF",
@@ -23929,7 +23981,7 @@
   {
     "id": "spec-quaternion-julia",
     "name": "Quaternion Julia",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-quaternion-julia.wgsl",
+    "url": "shaders/spec-quaternion-julia.wgsl",
     "description": "4D quaternion Julia set raymarched in real-time. The 4th dimension animates over time creating organic morphing fractal forms with orbit-trap coloring and physically-based lighting.",
     "tags": [
       "quaternion",
@@ -23989,7 +24041,7 @@
   {
     "id": "spore-galaxy",
     "name": "Spore Galaxy",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spore-galaxy.wgsl",
+    "url": "shaders/spore-galaxy.wgsl",
     "category": "generative",
     "description": "Organic spore particles disperse in galactic spiral arms with bass-driven arm swell and treble sparkle.",
     "tags": [
@@ -24051,7 +24103,7 @@
   {
     "id": "stellar-plasma",
     "name": "Stellar Plasma",
-    "url": "https://test.1ink.us/image_video_effects/shaders/stellar-plasma.wgsl",
+    "url": "shaders/stellar-plasma.wgsl",
     "description": "An endlessly morphing procedural cosmos powered by domain-warped fractional brownian motion. Creates swirling, liquid-like cosmic nebulae with interactive mouse gravity.",
     "tags": [
       "generative",
@@ -24120,7 +24172,7 @@
     "id": "supernova-core",
     "name": "Supernova Core",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/supernova-core.wgsl",
+    "url": "shaders/supernova-core.wgsl",
     "description": "Sedov-Taylor blast wave with radioactive decay luminosity (56Ni->56Co->56Fe). Rayleigh-Taylor instability fingers and neutrino-driven convection cells. Blackbody cooling sequence with iron emission lines and chromatic aberration. Audio drives shock expansion. Mouse creates asymmetric ejecta. Depth controls light echo perspective. Advanced alpha composition blends luminance keying, depth layering, and physical transmittance for cleaner 3-slot compositing.",
     "features": [
       "audio-reactive",
@@ -24186,7 +24238,7 @@
   {
     "id": "supernova-remnant",
     "name": "Supernova Remnant",
-    "url": "https://test.1ink.us/image_video_effects/shaders/supernova-remnant.wgsl",
+    "url": "shaders/supernova-remnant.wgsl",
     "description": "Expanding supernova shockwave with turbulent ejecta filaments. Bass drives the expansion front, mids create Rayleigh-Taylor instability fingers, treble adds radioactive decay sparkles. Mouse pulls the remnant center.",
     "tags": [
       "generative",
@@ -24245,7 +24297,7 @@
   {
     "id": "symbiotic-light-propagation-networks",
     "name": "Symbiotic Light Propagation Networks",
-    "url": "https://test.1ink.us/image_video_effects/shaders/symbiotic-light-propagation-networks.wgsl",
+    "url": "shaders/symbiotic-light-propagation-networks.wgsl",
     "category": "generative",
     "description": "Two organic species grow while transporting and transforming light through their network. They support each other symbiotically while competing for resources. Mouse seeds new growth while audio controls light color and transmission.",
     "features": [
@@ -24312,7 +24364,7 @@
   {
     "id": "topological-acoustic-knots",
     "name": "Topological Acoustic Knots",
-    "url": "https://test.1ink.us/image_video_effects/shaders/topological-acoustic-knots.wgsl",
+    "url": "shaders/topological-acoustic-knots.wgsl",
     "category": "generative",
     "description": "Nematic Q-tensor evolution with topological charge computation and trefoil-knot SDF constraint. Schlieren texture with defect-core coloring and HDR bloom on +1 defects. Bass creates defect pairs via Kibble-Zurek quench, mids drive annihilation dynamics, treble adds acoustic phonon waves. Mouse pins director with homeotropic anchoring. Ripples spawn defect loops.",
     "features": [
@@ -24381,7 +24433,7 @@
     "id": "tornado-vortex",
     "name": "Tornado Vortex",
     "category": "generative",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tornado-vortex.wgsl",
+    "url": "shaders/tornado-vortex.wgsl",
     "description": "Rankine vortex model with viscous core, radial inflow, and vertical updraft. Lagrangian debris advection with condensation funnel and subsurface scattering. Lightning flash illumination. Audio drives Fujita-scale intensity. Mouse acts as a probe flung by vorticity. Depth controls debris perspective.",
     "features": [
       "audio-reactive",
@@ -24442,7 +24494,7 @@
   {
     "id": "turing-veins",
     "name": "Turing Veins",
-    "url": "https://test.1ink.us/image_video_effects/shaders/generative-turing-veins.wgsl",
+    "url": "shaders/generative-turing-veins.wgsl",
     "description": "Generative multiscale reaction-diffusion Turing patterns forming organic vein/networks with bioluminescent glow. Procedurally evolves over time; depth increases complexity; mouse perturbs fields. Subtly distorts and overlays input image.",
     "params": [
       {
@@ -24503,7 +24555,7 @@
   {
     "id": "volumetric-cloud-nebula",
     "name": "Volumetric Cloud Nebula",
-    "url": "https://test.1ink.us/image_video_effects/shaders/volumetric-cloud-nebula.wgsl",
+    "url": "shaders/volumetric-cloud-nebula.wgsl",
     "description": "Raymarched volumetric clouds with nebula coloring. Features procedural cloud generation with FBM noise, dynamic color palettes, and animated camera movement through a cosmic nebula.",
     "tags": [
       "generative",
@@ -24565,7 +24617,7 @@
   {
     "id": "wolfram-data-demo",
     "name": "Wolfram Data Demo",
-    "url": "https://test.1ink.us/image_video_effects/shaders/wolfram-data-demo.wgsl",
+    "url": "shaders/wolfram-data-demo.wgsl",
     "description": "Demonstrates scientific constants and mathematical functions from Wolfram Alpha. Features phyllotaxis patterns, Airy disk diffraction, Fibonacci spirals, and atmospheric scattering using real physical data.",
     "tags": [
       "wolfram",

--- a/public/shader-lists/geometric.json
+++ b/public/shader-lists/geometric.json
@@ -2,7 +2,7 @@
   {
     "id": "adaptive-mosaic",
     "name": "Adaptive Mosaic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/adaptive-mosaic.wgsl",
+    "url": "shaders/adaptive-mosaic.wgsl",
     "description": "Depth-adaptive tile mosaic: near objects render as fine tiles, far objects as coarse blocks. SDF bevel on every tile edge, Voronoi crackle overlay at coarse sizes, mouse-focus zone, and audio-reactive tile-size pulse.",
     "features": [
       "mouse-driven",
@@ -59,7 +59,7 @@
   {
     "id": "ascii-glyph",
     "name": "ASCII Glyphs",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ascii-glyph.wgsl",
+    "url": "shaders/ascii-glyph.wgsl",
     "description": "SDF glyph morph with bass character swap and depth luminance map. Pixels are quantized into glyph cells; depth controls brightness tiering. Bass swaps glyph patterns on beats, treble adds chromatic highlights to dense characters.",
     "features": [
       "mouse-driven",
@@ -115,7 +115,7 @@
     "id": "crystal-mosaic",
     "name": "Crystal Mosaic",
     "category": "geometric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystal-mosaic.wgsl",
+    "url": "shaders/crystal-mosaic.wgsl",
     "description": "Image broken into triangular mosaic tiles that rotate based on mouse proximity. Enhanced with crystal Fresnel refraction lighting, caustics projection, rim lighting on tile edges, subsurface scattering glow, light attenuation, and chromatic aberration at tile boundaries.",
     "features": [
       "mouse-driven",
@@ -177,7 +177,7 @@
   {
     "id": "datamosh",
     "name": "Datamosh",
-    "url": "https://test.1ink.us/image_video_effects/shaders/datamosh.wgsl",
+    "url": "shaders/datamosh.wgsl",
     "description": "True video compression datamoshing with I/P-frame simulation, motion vector prediction, and authentic macroblock smearing artifacts.",
     "features": [
       "mouse-driven",
@@ -239,7 +239,7 @@
     "id": "digital-crease",
     "name": "Digital Crease",
     "category": "geometric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-crease.wgsl",
+    "url": "shaders/digital-crease.wgsl",
     "description": "Origami crease pattern simulation with mountain/valley assignment, Kawasaki-Justin flat-foldability approximation, depth-driven layer shadows, digital paper fiber texture, chromatic folding, HDR crease specular, and ACES tone mapping. Bass drives fold speed; mouse performs local folds; depth controls layer ordering.",
     "params": [
       {
@@ -294,7 +294,7 @@
   {
     "id": "flip-matrix",
     "name": "Flip Matrix",
-    "url": "https://test.1ink.us/image_video_effects/shaders/flip-matrix.wgsl",
+    "url": "shaders/flip-matrix.wgsl",
     "description": "Grid of tiles that flip vertically in pseudo-3D based on mouse proximity.",
     "features": [
       "mouse-driven"
@@ -341,7 +341,7 @@
   {
     "id": "hyperbolic-dreamweaver",
     "name": "Hyperbolic Dreamweaver",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyperbolic-dreamweaver.wgsl",
+    "url": "shaders/hyperbolic-dreamweaver.wgsl",
     "description": "Infinite non-Euclidean Poincaré disk tilings weaving the image through psychedelic Möbius transformations, depth-aware curvature, chromatic aberration, and glowing symmetry lines. Mouse centers the dream; ripples perturb the fabric.",
     "params": [
       {
@@ -402,7 +402,7 @@
   {
     "id": "interactive-origami",
     "name": "Interactive Origami",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-origami.wgsl",
+    "url": "shaders/interactive-origami.wgsl",
     "description": "Simulates folded paper with triangle-wave crease planes radiating from the mouse. Normal-map facet shading, depth-aware fold amplitude (far objects fold more), audio-reactive bass amplitude, and ripple-triggered expanding crease rings.",
     "features": [
       "mouse-driven",
@@ -459,7 +459,7 @@
   {
     "id": "kaleido-scope-grokcf1",
     "name": "Kaleido-Scope Prism grokcf1",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kaleido-scope-grokcf1.wgsl",
+    "url": "shaders/kaleido-scope-grokcf1.wgsl",
     "description": "Kaleidoscope with spring-damper mouse follow, attack/release audio envelope, and temporal feedback trails.",
     "features": [
       "mouse-driven",
@@ -508,7 +508,7 @@
     "id": "kaleido-scope",
     "name": "Kaleido-Scope",
     "category": "geometric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kaleido-scope.wgsl",
+    "url": "shaders/kaleido-scope.wgsl",
     "description": "Hyperbolic Poincaré-disk tessellation kaleidoscope with animated morphing between symmetry types, iridescent metallic boundaries, HDR specular vertices, and depth-driven stereoscopic chromatic aberration.",
     "features": [
       "mouse-driven",
@@ -557,7 +557,7 @@
   {
     "id": "kinetic-tiles",
     "name": "Kinetic Tiles",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kinetic_tiles.wgsl",
+    "url": "shaders/kinetic_tiles.wgsl",
     "description": "Grid of tiles that rotate and scale responsively to mouse proximity.",
     "features": [
       "mouse-driven",
@@ -607,7 +607,7 @@
   {
     "id": "neon-poly-grid",
     "name": "Neon Poly Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-poly-grid.wgsl",
+    "url": "shaders/neon-poly-grid.wgsl",
     "description": "A futuristic hexagonal grid that lights up when you touch it, leaving a fading trail.",
     "features": [
       "mouse-driven"
@@ -650,7 +650,7 @@
   {
     "id": "neon-quantum-lattice",
     "name": "Neon Quantum Lattice",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-quantum-lattice.wgsl",
+    "url": "shaders/neon-quantum-lattice.wgsl",
     "description": "Aperiodic Penrose-like quasi-crystal tiling with neon edge glow, metallic fill gradients, HDR vertex bloom, and quantum uncertainty zones.",
     "params": [
       {
@@ -700,7 +700,7 @@
   {
     "id": "spec-hypercube-projection",
     "name": "Hypercube Projection",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-hypercube-projection.wgsl",
+    "url": "shaders/spec-hypercube-projection.wgsl",
     "description": "Animated 4D tesseract projected into 2D using double rotation in XW and YZ planes. 32 edges are rendered with depth-based glow and input image texture-mapped onto faces.",
     "tags": [
       "hypercube",
@@ -755,7 +755,7 @@
   {
     "id": "time-lag-map",
     "name": "Time-Lag Map",
-    "url": "https://test.1ink.us/image_video_effects/shaders/time-lag-map.wgsl",
+    "url": "shaders/time-lag-map.wgsl",
     "description": "Per-pixel temporal delay creating echo, smear, and time-displacement effects.",
     "params": [
       {
@@ -801,7 +801,7 @@
   {
     "id": "voronoi-zoom-turbulence",
     "name": "Voronoi Zoom Turbulence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-zoom-turbulence.wgsl",
+    "url": "shaders/voronoi-zoom-turbulence.wgsl",
     "description": "Divides the screen into Voronoi cells where each cell applies a chaotic, time-varying zoom. Mouse proximity calms or agitates the turbulence.",
     "params": [
       {

--- a/public/shader-lists/hybrid.json
+++ b/public/shader-lists/hybrid.json
@@ -4,7 +4,7 @@
     "name": "Chromatic Circuit",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-chromatic-circuit.wgsl",
+    "url": "shaders/hyb-chromatic-circuit.wgsl",
     "description": "Opal-circuit style hex-grid trace edges, radial pulse glow, and chromatic aberration are layered over the input image while preserving alpha.",
     "features": [
       "hybrid",
@@ -89,7 +89,7 @@
     "name": "Hex Voronoi Distort",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-hex-voronoi-distort.wgsl",
+    "url": "shaders/hyb-hex-voronoi-distort.wgsl",
     "description": "Hexagonal grid mosaic distortion blended with animated 2D Voronoi cells. Samples the input image through distorted hex centers while preserving the original alpha channel.",
     "features": [
       "hybrid",
@@ -169,7 +169,7 @@
     "name": "Iridescent FBM Glow",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-iridescent-fbm-glow.wgsl",
+    "url": "shaders/hyb-iridescent-fbm-glow.wgsl",
     "description": "Domain-warped FBM drives a thin-film iridescent glow with audio reactivity, depth-aware fog, ACES tone mapping, IGN dither, chromatic aberration, Fresnel rim and OkLab mixing.",
     "features": [
       "upgraded-rgba",
@@ -253,7 +253,7 @@
     "name": "Kaleidoscope Pulse",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-kaleidoscope-pulse.wgsl",
+    "url": "shaders/hyb-kaleidoscope-pulse.wgsl",
     "description": "Mirrors the input image into FBM-domain-warped kaleidoscope segments, adds an ACES-tonemapped radial pulse, and writes semantic alpha encoding pulse energy and depth.",
     "features": [
       "hybrid",
@@ -335,7 +335,7 @@
     "name": "Neural Voronoi Feedback",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-neural-voronoi-feedback.wgsl",
+    "url": "shaders/hyb-neural-voronoi-feedback.wgsl",
     "description": "Voronoi neural cells, FBM-driven feedback drift, and glowing neural dust are blended over the input image while preserving alpha.",
     "features": [
       "hybrid",
@@ -420,7 +420,7 @@
     "name": "Spectral FBM Displace",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-spectral-fbm-displace.wgsl",
+    "url": "shaders/hyb-spectral-fbm-displace.wgsl",
     "description": "FBM domain warping displaces the input image, and the warp gradient drives a chromatic RGB smear tinted by a spectral wavelength palette.",
     "features": [
       "hybrid",
@@ -504,7 +504,7 @@
     "name": "Temporal FBM Ghost",
     "category": "hybrid",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyb-temporal-fbm-ghost.wgsl",
+    "url": "shaders/hyb-temporal-fbm-ghost.wgsl",
     "description": "Temporal RGB channel offsets, FBM domain-warp displacement, and a ghosting glow are blended over the input image while preserving alpha.",
     "features": [
       "hybrid",
@@ -589,7 +589,7 @@
   {
     "id": "hybrid-chromatic-liquid",
     "name": "Hybrid Chromatic Liquid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-chromatic-liquid.wgsl",
+    "url": "shaders/hybrid-chromatic-liquid.wgsl",
     "description": "Fluid-like distortion with RGB channel separation flowing along a noise-generated flow field. Audio reactivity pulses dot size and ink density with the music.",
     "features": [
       "mouse-driven",
@@ -660,7 +660,7 @@
   {
     "id": "hybrid-cyber-organic",
     "name": "Hybrid Cyber-Organic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-cyber-organic.wgsl",
+    "url": "shaders/hybrid-cyber-organic.wgsl",
     "description": "Digital circuit traces that grow organically with neon glow, combining hexagonal grid structures with cellular growth patterns",
     "features": [
       "hybrid",
@@ -723,7 +723,7 @@
   {
     "id": "hybrid-fractal-feedback",
     "name": "Hybrid Fractal Feedback",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-fractal-feedback.wgsl",
+    "url": "shaders/hybrid-fractal-feedback.wgsl",
     "description": "Julia set fractal with feedback trails and per-channel temporal delay creating RGB separation trails",
     "features": [
       "hybrid",
@@ -786,7 +786,7 @@
   {
     "id": "hybrid-magnetic-field",
     "name": "Hybrid Magnetic Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-magnetic-field.wgsl",
+    "url": "shaders/hybrid-magnetic-field.wgsl",
     "description": "Magnetic field line visualization with flowing particles and FBM-varied field distortion. Audio reactivity makes field lines pulse and glow with the beat.",
     "features": [
       "hybrid",
@@ -860,7 +860,7 @@
   {
     "id": "hybrid-noise-kaleidoscope",
     "name": "Hybrid Noise Kaleidoscope",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-noise-kaleidoscope.wgsl",
+    "url": "shaders/hybrid-noise-kaleidoscope.wgsl",
     "description": "Domain-warped FBM noise fed through kaleidoscope symmetry with dynamic hue shifting and RGB channel splits",
     "features": [
       "hybrid",
@@ -926,7 +926,7 @@
   {
     "id": "hybrid-particle-fluid",
     "name": "Hybrid Particle Fluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-particle-fluid.wgsl",
+    "url": "shaders/hybrid-particle-fluid.wgsl",
     "description": "Particles that move like fluid with glowing trails, combining particle advection with curl noise velocity field",
     "features": [
       "hybrid",
@@ -989,7 +989,7 @@
   {
     "id": "hybrid-reaction-diffusion-glass",
     "name": "Hybrid Reaction-Diffusion Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-reaction-diffusion-glass.wgsl",
+    "url": "shaders/hybrid-reaction-diffusion-glass.wgsl",
     "description": "Turing patterns (reaction-diffusion) refracted through depth-aware glass distortion",
     "features": [
       "hybrid",
@@ -1053,7 +1053,7 @@
   {
     "id": "hybrid-sdf-plasma",
     "name": "Hybrid SDF Plasma Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-sdf-plasma.wgsl",
+    "url": "shaders/hybrid-sdf-plasma.wgsl",
     "description": "Raymarched SDF scene with plasma noise displacement and dynamic palette-based coloring",
     "features": [
       "hybrid",
@@ -1117,7 +1117,7 @@
   {
     "id": "hybrid-spectral-sorting",
     "name": "Hybrid Spectral Sorting",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-spectral-sorting.wgsl",
+    "url": "shaders/hybrid-spectral-sorting.wgsl",
     "description": "Audio-reactive pixel sorting with frequency-based color shifts and displacement based on spectral analysis",
     "features": [
       "mouse-driven",
@@ -1188,7 +1188,7 @@
   {
     "id": "hybrid-voronoi-glass",
     "name": "Hybrid Voronoi Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hybrid-voronoi-glass.wgsl",
+    "url": "shaders/hybrid-voronoi-glass.wgsl",
     "description": "Voronoi diagram rendered as glass blocks with chromatic dispersion and physically-inspired refraction",
     "features": [
       "mouse-driven",
@@ -1256,7 +1256,7 @@
   {
     "id": "ripple-bloom",
     "name": "Ripple Bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ripple-bloom.wgsl",
+    "url": "shaders/ripple-bloom.wgsl",
     "category": "hybrid",
     "description": "Huygens wavelet ripple simulation with frequency dispersion, chromatic dispersion on crests, multi-pass Gaussian bloom, caustic refraction light patterns, rainbow dispersion at bright edges, 6-pointed starburst diffraction from bright points, film grain, radial chromatic aberration, color grading with lift/gamma/gain, anamorphic streaks, lens dirt overlay, and ACES tone mapping. Bass drives ripple frequency and anamorphic streaks, mids control bloom and caustics, treble adds dispersion and starburst. Mouse drops stones, depth controls water depth.",
     "tags": [

--- a/public/shader-lists/image.json
+++ b/public/shader-lists/image.json
@@ -3,7 +3,7 @@
     "id": "aerogel-smoke",
     "name": "Aerogel Smoke",
     "description": "Simulates the ethereal, frozen-smoke appearance of aerogel with volumetric lighting and Rayleigh scattering.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aerogel-smoke.wgsl",
+    "url": "shaders/aerogel-smoke.wgsl",
     "features": [
       "mouse-driven",
       "volumetric"
@@ -46,7 +46,7 @@
   {
     "id": "alucinate",
     "name": "Alucinate",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alucinate.wgsl",
+    "url": "shaders/alucinate.wgsl",
     "description": "Reaction-Diffusion Psychedelia with Gray-Scott Turing patterns, domain-warped FBM, kaleidoscopic IFS fractals, conformal mapping, and audio-reactive color science.",
     "features": [
       "upgraded-rgba",
@@ -108,7 +108,7 @@
   {
     "id": "analog-film-degrade",
     "name": "Analog Film Degrade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/analog-film-degrade.wgsl",
+    "url": "/shaders/analog-film-degrade.wgsl",
     "description": "Vintage film degradation with grain, dust, scratches, color fading, and vignette.",
     "tags": [
       "film",
@@ -164,7 +164,7 @@
   {
     "id": "bismuth-crystallizer",
     "name": "Bismuth Crystallizer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bismuth-crystallizer.wgsl",
+    "url": "shaders/bismuth-crystallizer.wgsl",
     "description": "Generates geometric hopper crystal patterns with physical light transmission. Simulates bismuth crystals with thin-film interference iridescence, metallic Fresnel reflection, and oxide layer transmission.",
     "params": [
       {
@@ -219,7 +219,7 @@
     "id": "chroma-threads",
     "name": "Chroma Threads",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-threads.wgsl",
+    "url": "shaders/chroma-threads.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -283,7 +283,7 @@
   {
     "id": "chrono-slit-scan",
     "name": "Chrono Slit Scan",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chrono-slit-scan.wgsl",
+    "url": "shaders/chrono-slit-scan.wgsl",
     "description": "Multi-slit temporal scan with 2-3 simultaneous animated slits, feathered edges, audio-reactive speed modulation, depth-aware width scaling, and LOD-optimized fbm warp with early-exit sampling.",
     "params": [
       {
@@ -340,7 +340,7 @@
     "id": "circular-pixelate",
     "name": "Circular Pixelate",
     "description": "Renders the image as a grid of circles. Mouse controls density and radius.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/circular-pixelate.wgsl",
+    "url": "shaders/circular-pixelate.wgsl",
     "params": [
       {
         "name": "Density",
@@ -388,7 +388,7 @@
   {
     "id": "color-blindness",
     "name": "Color Blindness Sim",
-    "url": "https://test.1ink.us/image_video_effects/shaders/color-blindness.wgsl",
+    "url": "shaders/color-blindness.wgsl",
     "description": "Simulates various forms of color blindness (Protanopia, Deuteranopia, Tritanopia) with split-screen comparison.",
     "params": [
       {
@@ -433,7 +433,7 @@
   {
     "id": "color-channel-weave",
     "name": "Color Channel Weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/color-channel-weave.wgsl",
+    "url": "shaders/color-channel-weave.wgsl",
     "category": "image",
     "description": "Samples RGB channels from offset positions simulating a woven fabric. Horizontal threads carry red; vertical threads carry blue; green is neutral. Audio shifts thread spacing and chromatic offset. Mouse tilts the warp direction.",
     "tags": [
@@ -489,7 +489,7 @@
   {
     "id": "concentric-spin",
     "name": "Concentric Spin",
-    "url": "https://test.1ink.us/image_video_effects/shaders/concentric-spin.wgsl",
+    "url": "shaders/concentric-spin.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -538,7 +538,7 @@
   {
     "id": "contour-flow",
     "name": "Contour Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/contour-flow.wgsl",
+    "url": "shaders/contour-flow.wgsl",
     "description": "Per-pixel curl flow with depth advection and bass turbulence. Sobel edge detection drives flow direction, curl noise adds organic swirl, and depth controls sharpness vs advection mix. Treble sparks on edge intersections.",
     "params": [
       {
@@ -592,7 +592,7 @@
     "id": "conv-anisotropic-diffusion",
     "name": "Anisotropic Diffusion",
     "description": "Perona-Malik anisotropic diffusion that smooths along edges but not across them. Creates oil-painting simplification into flat colored regions. Alpha stores per-pixel diffusion coefficient as a process map. Mouse acts as heat source accelerating diffusion.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-anisotropic-diffusion.wgsl",
+    "url": "shaders/conv-anisotropic-diffusion.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -650,7 +650,7 @@
     "id": "conv-bilateral-dream",
     "name": "Bilateral Dream",
     "description": "Edge-preserving bilateral smoothing with psychedelic color preservation. Uses RGBA32FLOAT alpha channel to store accumulated weight for deferred normalization. Mouse controls varying sharpness region.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-bilateral-dream.wgsl",
+    "url": "shaders/conv-bilateral-dream.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -708,7 +708,7 @@
     "id": "conv-bilateral-grid-splat",
     "name": "Bilateral Grid Splat",
     "description": "Fast approximate bilateral filter using 3D grid splatting (spatial x, y + intensity). Achieves edge-preserving smoothing at O(1) per pixel. RGBA32FLOAT stores HDR accumulated color and weight. Mouse creates high-resolution detail zone.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-bilateral-grid-splat.wgsl",
+    "url": "shaders/conv-bilateral-grid-splat.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -766,7 +766,7 @@
     "id": "conv-difference-of-gaussians-cascade",
     "name": "Difference of Gaussians Cascade",
     "description": "Multi-scale Difference-of-Gaussians at 4 scales with signed response storage. Creates neural-edge glow where edges at different scales colorize differently. RGBA32FLOAT stores signed bipolar responses in all channels. Mouse controls scale emphasis.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-difference-of-gaussians-cascade.wgsl",
+    "url": "shaders/conv-difference-of-gaussians-cascade.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -824,7 +824,7 @@
     "id": "conv-fractal-kernel",
     "name": "Fractal Kernel",
     "description": "Convolution kernel shaped by Mandelbrot set membership. Pixels inside the fractal are sampled, creating alien mathematically beautiful blur patterns. Alpha stores fractal iteration depth. Mouse warps the Mandelbrot center live.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-fractal-kernel.wgsl",
+    "url": "shaders/conv-fractal-kernel.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -882,7 +882,7 @@
     "id": "conv-frequency-domain-notch",
     "name": "Frequency Domain Notch",
     "description": "Spatial-domain approximation of frequency notch filtering using tuned sinusoidal convolution kernels. Removes moire patterns or creates frequency painting. Alpha stores spectral response magnitude. Mouse selects target frequency band.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-frequency-domain-notch.wgsl",
+    "url": "shaders/conv-frequency-domain-notch.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -940,7 +940,7 @@
     "id": "conv-gabor-texture-analyzer",
     "name": "Gabor Texture Analyzer",
     "description": "Gabor filter bank detecting oriented texture patterns at 0, 45, 90, and 135 degrees. RGBA32FLOAT stores signed bipolar responses in all four channels. Mouse rotates the filter bank for swirling texture segmentation.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-gabor-texture-analyzer.wgsl",
+    "url": "shaders/conv-gabor-texture-analyzer.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -998,7 +998,7 @@
     "id": "conv-guided-filter-depth",
     "name": "Guided Filter Depth",
     "description": "Guided filter using depth texture as guide for edge-aware filtering. Creates depth-of-field blur that perfectly respects object boundaries. Alpha stores filtering confidence coefficient. Mouse creates localized focus aperture.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-guided-filter-depth.wgsl",
+    "url": "shaders/conv-guided-filter-depth.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1056,7 +1056,7 @@
   {
     "id": "conv-guided-video-filter",
     "name": "Guided Video Filter",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-guided-video-filter.wgsl",
+    "url": "shaders/conv-guided-video-filter.wgsl",
     "category": "image",
     "description": "Guided image filter that uses the original crisp video frame as the guide image to restore sharp edges on heavily processed or convoluted content from the previous slot pass. Eliminates halo artifacts while preserving painterly, glitch, or artistic effects inside smooth regions. Mouse proximity creates a live sharpening lens.",
     "tags": [
@@ -1114,7 +1114,7 @@
     "id": "conv-morphological-erosion-dilation",
     "name": "Morphological Erosion Dilation",
     "description": "Mathematical morphology on images — erosion shrinks bright regions, dilation expands them. RGBA32FLOAT packs erosion (R), dilation (G), gradient (B), and top-hat (A) into one pass. Mouse controls directional structuring element.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-morphological-erosion-dilation.wgsl",
+    "url": "shaders/conv-morphological-erosion-dilation.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1172,7 +1172,7 @@
     "id": "conv-non-local-means",
     "name": "Non-Local Means",
     "description": "Gold-standard denoising that averages similar patches across the image. Cranked to artistic overdrive for hallucinatory double-exposure effects. Alpha stores self-similarity importance map. Mouse controls focus zone precision.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-non-local-means.wgsl",
+    "url": "shaders/conv-non-local-means.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1229,7 +1229,7 @@
   {
     "id": "conv-reaction-convolution",
     "name": "Reaction Convolution",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-reaction-convolution.wgsl",
+    "url": "shaders/conv-reaction-convolution.wgsl",
     "description": "Gray-Scott reaction-diffusion applied as a convolution filter on the input image. Uses image luminance to seed chemical concentrations and mouse interaction to inject patterns.",
     "tags": [
       "convolution",
@@ -1283,7 +1283,7 @@
     "id": "conv-spiral-blur",
     "name": "Spiral Blur",
     "description": "Logarithmic spiral convolution creating rotational motion blur along golden ratio spirals. RGBA32FLOAT stores HDR accumulated color and spiral coverage factor. Mouse controls spiral center and tightness for vortex-like effects.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-spiral-blur.wgsl",
+    "url": "shaders/conv-spiral-blur.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1342,7 +1342,7 @@
     "id": "conv-steerable-pyramid",
     "name": "Steerable Pyramid",
     "description": "Decomposes image into oriented sub-bands at 0, 45, 90, and 135 degrees using steerable filters. RGBA32FLOAT stores full-precision signed sub-band coefficients for lossless reconstruction or artistic boosting. Mouse steers the decomposition angle.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-steerable-pyramid.wgsl",
+    "url": "shaders/conv-steerable-pyramid.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1400,7 +1400,7 @@
     "id": "conv-stochastic-stipple",
     "name": "Stochastic Stipple",
     "description": "Blue-noise dithered weighted Voronoi stippling creating pointillist art from any image. Each dot represents a local neighborhood sized by average luminance. Alpha stores continuous stipple density for downstream dot-size variation. Mouse creates higher-resolution stipple zone.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-stochastic-stipple.wgsl",
+    "url": "shaders/conv-stochastic-stipple.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1459,7 +1459,7 @@
     "id": "conv-structure-tensor-flow",
     "name": "Structure Tensor Flow",
     "description": "Computes structure tensor, extracts eigenvectors for dominant texture orientation, and visualizes flow via Line Integral Convolution. RGBA32FLOAT packs eigenvector components, coherency, and LIC intensity. Mouse creates vortices in the flow field.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/conv-structure-tensor-flow.wgsl",
+    "url": "shaders/conv-structure-tensor-flow.wgsl",
     "features": [
       "advanced-convolution",
       "rgba32float-exploiting",
@@ -1516,7 +1516,7 @@
   {
     "id": "cross-conv-mouse-bilateral",
     "name": "Bilateral Paint",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cross-conv-mouse-bilateral.wgsl",
+    "url": "shaders/cross-conv-mouse-bilateral.wgsl",
     "description": "Crossover shader combining bilateral convolution with mouse-driven painting. The cursor acts as a brush that applies edge-preserving smoothing — stronger near the cursor, with click boosting the effect.",
     "tags": [
       "crossover",
@@ -1563,7 +1563,7 @@
   {
     "id": "crt-scanline-damage",
     "name": "CRT Scanline Damage",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crt-scanline-damage.wgsl",
+    "url": "shaders/crt-scanline-damage.wgsl",
     "description": "Damaged CRT monitor simulation with barrel distortion, RGB phosphor mask, scanlines, temporal phosphor decay via dataTextureC, audio-driven chromatic barrel separation, depth-aware distortion, and occasional vertical roll.",
     "tags": [
       "crt",
@@ -1625,7 +1625,7 @@
     "id": "crumpled-paper",
     "name": "Crumpled Paper",
     "description": "Simulates the look of crumpled paper with interactive smoothing.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crumpled-paper.wgsl",
+    "url": "shaders/crumpled-paper.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -1667,7 +1667,7 @@
   {
     "id": "crystalline-shatter",
     "name": "Crystalline Shatter",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystalline-shatter.wgsl",
+    "url": "shaders/crystalline-shatter.wgsl",
     "category": "image",
     "description": "Voronoi cell decomposition shatters the image into crystal facets, each refracting light independently with chromatic aberration. Bass pulses crack new cells; mouse proximity amplifies the shatter.",
     "tags": [
@@ -1723,7 +1723,7 @@
   {
     "id": "cyber-halftone-scanner",
     "name": "Cyber Halftone Scanner",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-halftone-scanner.wgsl",
+    "url": "shaders/cyber-halftone-scanner.wgsl",
     "description": "CMYK-style halftone pattern with a scanning glitch line.",
     "params": [
       {
@@ -1767,7 +1767,7 @@
   {
     "id": "digital-lens",
     "name": "Digital Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-lens.wgsl",
+    "url": "shaders/digital-lens.wgsl",
     "description": "Brown-Conrady lens distortion model with radial/tangential coefficients, per-channel chromatic aberration with depth-dependent separation, anamorphic squeeze, mouse gravity-well focus, attack/release bass envelope, temporal feedback trails, ACES tone mapping, film grain, and advanced RGBA compositing via depth-layered, luminance-key, and effect-intensity alpha.",
     "params": [
       {
@@ -1830,7 +1830,7 @@
     "name": "Directional Blur Wipe",
     "category": "image",
     "description": "Splits the screen with an audio-reactive directional blur. Mouse controls split position; chromatic offset scatters RGB per treble. Depth-scatter increases blur radius on distant objects.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/directional-blur-wipe.wgsl",
+    "url": "shaders/directional-blur-wipe.wgsl",
     "params": [
       {
         "name": "Split Pos",
@@ -1884,7 +1884,7 @@
   {
     "id": "ember-drift-dissolve",
     "name": "Ember Drift Dissolve",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ember-drift-dissolve.wgsl",
+    "url": "shaders/ember-drift-dissolve.wgsl",
     "description": "Bright areas of the image lift off as glowing embers and are carried upward by a living heat field. Creates haunting, beautiful disintegration especially on video. Treble controls spark density while bass thickens the rising glow.",
     "tags": [
       "ember",
@@ -1940,7 +1940,7 @@
   {
     "id": "fireworks-depth-parade",
     "name": "4th of July — Depth Parade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fireworks-depth-parade.wgsl",
+    "url": "shaders/fireworks-depth-parade.wgsl",
     "description": "Depth layers of your image launch fireworks in parade sequence — foreground detonates first, then midground, then background. Creates a cinematic 3D-ish celebration where near elements pop before far ones. Image colors tint each layer's shells. Bass amplifies foreground launches. Mouse triggers a depth-sorted barrage.",
     "tags": [
       "fireworks",
@@ -1997,7 +1997,7 @@
   {
     "id": "fireworks-edge-ignite",
     "name": "4th of July — Edge Ignite",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fireworks-edge-ignite.wgsl",
+    "url": "shaders/fireworks-edge-ignite.wgsl",
     "description": "Image contours and edges become ignition lines for a fireworks show. Bright boundaries spark and launch colored shells along the detected edges of your photo. The picture's outlines trace themselves in pyrotechnic light. Bass deepens edge bursts, treble adds crackle along contours. Mouse ignites edges at the cursor.",
     "tags": [
       "fireworks",
@@ -2053,7 +2053,7 @@
   {
     "id": "fireworks-patriotic-july4",
     "name": "4th of July — Patriotic Pyro",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fireworks-patriotic-july4.wgsl",
+    "url": "shaders/fireworks-patriotic-july4.wgsl",
     "description": "Happy July 4th! Your image fuels a red, white, and blue fireworks spectacular. Bright regions launch patriotic shells cycling through crimson, silver-white, and electric blue. Image hues blend with the classic American palette for a backyard celebration feel. Bass booms the big shells, treble crackles the finale. Mouse fires a patriotic barrage.",
     "tags": [
       "fireworks",
@@ -2109,7 +2109,7 @@
   {
     "id": "fireworks-portrait-burst",
     "name": "4th of July — Portrait Burst",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fireworks-portrait-burst.wgsl",
+    "url": "shaders/fireworks-portrait-burst.wgsl",
     "description": "Bright regions of your image become the cores of spectacular firework detonations. Faces, skylines, and luminous highlights erupt in bursts that inherit the source colors. The photo celebrates itself — portraits explode in their own palette. Bass triggers larger cores, treble adds sparkle. Mouse detonates at the cursor.",
     "tags": [
       "fireworks",
@@ -2165,7 +2165,7 @@
   {
     "id": "fractal-noise-dissolve",
     "name": "Fractal Noise Dissolve",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fractal-noise-dissolve.wgsl",
+    "url": "shaders/fractal-noise-dissolve.wgsl",
     "description": "Dissolves the image into fractal noise around the mouse.",
     "params": [
       {
@@ -2208,7 +2208,7 @@
   {
     "id": "frost-reveal",
     "name": "Frost Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/frost-reveal.wgsl",
+    "url": "shaders/frost-reveal.wgsl",
     "description": "Interactive frost reveal effect with crystalline patterns that form based on mouse interaction.",
     "features": [
       "mouse-driven",
@@ -2256,7 +2256,7 @@
   {
     "id": "frosted-glass-lens",
     "name": "Frosted Glass Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/frosted-glass-lens.wgsl",
+    "url": "shaders/frosted-glass-lens.wgsl",
     "description": "A frosted glass effect that reveals the clear image under the mouse cursor.",
     "params": [
       {
@@ -2300,7 +2300,7 @@
     "id": "gamma-ray-burst",
     "name": "Gamma Ray Burst",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gamma-ray-burst.wgsl",
+    "url": "shaders/gamma-ray-burst.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2350,7 +2350,7 @@
     "id": "glitch-reveal",
     "name": "Glitch Reveal",
     "description": "A chaotic digital noise field that is stabilized and clarified by the proximity of the cursor.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glitch-reveal.wgsl",
+    "url": "shaders/glitch-reveal.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -2391,7 +2391,7 @@
   },
   {
     "id": "glitch-ripple-drag",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glitch-ripple-drag.wgsl",
+    "url": "shaders/glitch-ripple-drag.wgsl",
     "description": "Mouse emits expanding ripples that permanently drag and glitch the video pixels.",
     "features": [
       "mouse-driven"
@@ -2440,7 +2440,7 @@
     "id": "graphic-novel",
     "name": "Graphic Novel",
     "description": "Transforms image into a comic book style with edge detection and halftone patterns.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/graphic_novel.wgsl",
+    "url": "shaders/graphic_novel.wgsl",
     "params": [
       {
         "id": "dotSize",
@@ -2482,7 +2482,7 @@
   {
     "id": "heat-haze-mirage",
     "name": "Heat Haze Mirage",
-    "url": "https://test.1ink.us/image_video_effects/shaders/heat-haze-mirage.wgsl",
+    "url": "shaders/heat-haze-mirage.wgsl",
     "category": "image",
     "description": "Vertical heat shimmer driven by a rising hot-air column. Time-varying noise is advected upward, displacing the UV sample with chromatic separation. Bass injects fresh heat bursts; mouse creates a heat source.",
     "tags": [
@@ -2539,7 +2539,7 @@
     "id": "hex-lens",
     "name": "Hex Lens Interactive",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hex-lens.wgsl",
+    "url": "shaders/hex-lens.wgsl",
     "description": "Honeycomb microlenses with hexagonal bokeh blur, wavelength-dependent chromatic dispersion, hexagonal aperture diffraction starbursts, FBM domain warping, and 6-fold/12-fold star patterns. Audio-reactive lens rotation and prismatic shimmer.",
     "params": [
       {
@@ -2600,7 +2600,7 @@
   {
     "id": "holographic-shatter",
     "name": "Holographic Shatter",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-shatter.wgsl",
+    "url": "shaders/holographic-shatter.wgsl",
     "description": "Fractures the image into digital shards with temporal shard velocity persistence, chromatic edge refraction per shard, audio-driven impact intensity, holographic interference patterns, and plasma palette tinting.",
     "features": [
       "mouse-driven",
@@ -2660,7 +2660,7 @@
   {
     "id": "honey-melt",
     "name": "Honey Melt",
-    "url": "https://test.1ink.us/image_video_effects/shaders/honey-melt.wgsl",
+    "url": "shaders/honey-melt.wgsl",
     "description": "A golden hexagonal grid that melts under the mouse.",
     "params": [
       {
@@ -2704,7 +2704,7 @@
     "id": "kintsugi-repair",
     "name": "Kintsugi Repair",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kintsugi-repair.wgsl",
+    "url": "shaders/kintsugi-repair.wgsl",
     "description": "Simulates the Japanese art of repairing broken pottery with gold (Kintsugi). Voronoi patterns create cracks with gold filling.",
     "params": [
       {
@@ -2751,7 +2751,7 @@
   {
     "id": "lenticular-holographic-shift",
     "name": "Lenticular Holographic Shift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lenticular-holographic-shift.wgsl",
+    "url": "shaders/lenticular-holographic-shift.wgsl",
     "description": "Simulates a lenticular/holographic print that dramatically shifts perspective, color, and moiré interference as you move the mouse or as audio beats. Stunning on portraits and detailed imagery.",
     "tags": [
       "lenticular",
@@ -2807,7 +2807,7 @@
   {
     "id": "liquid-chrome-ripple",
     "name": "Liquid Chrome Ripple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-chrome-ripple.wgsl",
+    "url": "shaders/liquid-chrome-ripple.wgsl",
     "description": "Metallic liquid effect that ripples with mouse movement.",
     "params": [
       {
@@ -2850,7 +2850,7 @@
   {
     "id": "luma-refraction",
     "name": "Luma Refraction",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-refraction.wgsl",
+    "url": "shaders/luma-refraction.wgsl",
     "description": "Ripples propagate through the image with speed determined by brightness. Features chromatic refraction offsets (R/G/B at different normals), temporal wave damping memory, audio-driven wave amplitude, and semantic alpha handling.",
     "params": [
       {
@@ -2907,7 +2907,7 @@
     "id": "magnetic-chroma",
     "name": "Magnetic Chroma",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-chroma.wgsl",
+    "url": "shaders/magnetic-chroma.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2959,7 +2959,7 @@
   {
     "id": "mercury-temporal-mirror",
     "name": "Mercury Temporal Mirror",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mercury-temporal-mirror.wgsl",
+    "url": "shaders/mercury-temporal-mirror.wgsl",
     "description": "The input image is reflected in a living liquid mercury surface whose ripples persist and evolve over time. Mouse presses create visceral impact dents that propagate realistically. Audio controls the viscosity and thickness of the metal.",
     "tags": [
       "mercury",
@@ -3017,7 +3017,7 @@
   {
     "id": "neon-pulse-dissolve",
     "name": "Neon Pulse Dissolve",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-pulse-dissolve.wgsl",
+    "url": "shaders/neon-pulse-dissolve.wgsl",
     "category": "image",
     "description": "Audio-reactive neon edge detection that pulses with bass and dissolves the image interior into luminous colour noise driven by mid and treble frequencies.",
     "tags": [
@@ -3070,7 +3070,7 @@
   },
   {
     "id": "neon-pulse-stream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-pulse-stream.wgsl",
+    "url": "shaders/neon-pulse-stream.wgsl",
     "description": "Video luminance directs a fluid flow of neon trails injected by the mouse.",
     "features": [
       "mouse-driven",
@@ -3124,7 +3124,7 @@
   {
     "id": "oil-slick-iridescence",
     "name": "Oil Slick Iridescence",
-    "url": "https://test.1ink.us/image_video_effects/shaders/oil-slick-iridescence.wgsl",
+    "url": "shaders/oil-slick-iridescence.wgsl",
     "category": "image",
     "description": "Thin-film optical interference simulation, like oil on water. A procedural flowing height map modulates film thickness, producing shifting rainbow iridescence. Bass warps the film; mouse creates ripples.",
     "tags": [
@@ -3181,7 +3181,7 @@
     "id": "optical-illusion-spin",
     "name": "Optical Illusion Spin",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/optical-illusion-spin.wgsl",
+    "url": "shaders/optical-illusion-spin.wgsl",
     "description": "Op-art illusion generator with Rotating Snakes, Fraser spiral, and moiré interference between counter-rotating patterns. Chromatic afterimage, HDR edges, ACES tone mapping, and dithering. Bass drives rotation, mouse distorts locally, depth controls scale perspective.",
     "params": [
       {
@@ -3234,7 +3234,7 @@
   {
     "id": "page-curl-interactive",
     "name": "Page Curl Interactive",
-    "url": "https://test.1ink.us/image_video_effects/shaders/page-curl-interactive.wgsl",
+    "url": "shaders/page-curl-interactive.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -3295,7 +3295,7 @@
     "id": "pin-art-3d",
     "name": "Pin Art 3D",
     "description": "Simulates a 3D pin art toy where image brightness controls pin height. Mouse pushes pins down.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pin-art-3d.wgsl",
+    "url": "shaders/pin-art-3d.wgsl",
     "params": [
       {
         "name": "Density",
@@ -3341,7 +3341,7 @@
   {
     "id": "pixel-scattering",
     "name": "Pixel Scattering",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-scattering.wgsl",
+    "url": "/shaders/pixel-scattering.wgsl",
     "category": "distortion",
     "description": "Velocity-field advection using curl noise and Fibonacci spiral patterns. Motion blur trails, chromatic separation along velocity vectors, and HDR accumulation. Bass triggers explosive scatter events.",
     "params": [
@@ -3394,7 +3394,7 @@
     "name": "Pixel Stretch Interactive",
     "category": "image",
     "description": "Anisotropic pixel stretching guided by image structure tensor, with chromatic smear along edge directions, HDR bloom on highlights, ACES tone mapping, and film grain. Bass drives stretch magnitude, mouse controls direction, depth creates parallax layering.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-stretch-interactive.wgsl",
+    "url": "shaders/pixel-stretch-interactive.wgsl",
     "params": [
       {
         "name": "Stretch Amount",
@@ -3447,7 +3447,7 @@
   {
     "id": "pixel-tornado",
     "name": "Pixel Tornado",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-tornado.wgsl",
+    "url": "shaders/pixel-tornado.wgsl",
     "category": "image",
     "description": "A pixel-level tornado vortex whose eye tracks the mouse. Bass energy widens the funnel; treble adds turbulent jitter. Click ripples send radial shockwaves through the frame.",
     "tags": [
@@ -3503,7 +3503,7 @@
     "id": "plastic-bricks",
     "name": "Plastic Bricks",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/plastic-bricks.wgsl",
+    "url": "shaders/plastic-bricks.wgsl",
     "description": "LEGO-style plastic bricks with microfacet BRDF, ambient occlusion in stud cavities, fingerprint smudges, and subsurface scattering. Bass drives assembly animation, mouse deconstructs bricks, depth controls stud perspective.",
     "params": [
       {
@@ -3556,7 +3556,7 @@
     "id": "polka-wave",
     "name": "Polka Wave",
     "description": "Halftone effect where dot size responds to image brightness and interactive ripples.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/polka-wave.wgsl",
+    "url": "shaders/polka-wave.wgsl",
     "params": [
       {
         "name": "Grid Density",
@@ -3604,7 +3604,7 @@
   {
     "id": "posterize-neon-edges",
     "name": "Posterize Neon Edges",
-    "url": "https://test.1ink.us/image_video_effects/shaders/posterize-neon-edges.wgsl",
+    "url": "/shaders/posterize-neon-edges.wgsl",
     "category": "image",
     "description": "Edge-aware posterization with FBM-noise organic boundaries, multi-band luminance quantization, HDR neon bloom with ACES tone mapping, and cyan/magenta split-tone. Audio-reactive and mouse-driven.",
     "tags": [
@@ -3665,7 +3665,7 @@
   {
     "id": "pyramid-bandprocess-pass2",
     "name": "Gaussian-Laplacian Pyramid (Pass 2: Band Processing)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pyramid-bandprocess-pass2.wgsl",
+    "url": "shaders/pyramid-bandprocess-pass2.wgsl",
     "description": "Pass 2 of 3: Extracts Laplacian (high-freq residual = original − prev-frame blur) and applies per-band creative effects: neon edge saturation (L0), audio-bass hue rotation (L1), slow LFO colour breathing (L2). Audio-reactive via plasmaBuffer.",
     "features": [
       "multi-pass-2",
@@ -3726,7 +3726,7 @@
   {
     "id": "pyramid-composite-pass3",
     "name": "Gaussian-Laplacian Pyramid (Pass 3: ROI Magnifying Glass)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pyramid-composite-pass3.wgsl",
+    "url": "shaders/pyramid-composite-pass3.wgsl",
     "description": "Pass 3 of 3: Final composite with ROI magnifying-glass effect. Inside the mouse-tracked circle (radius = zoom_params.w) all frequency bands are amplified 2.5×+, creating a psychedelic detail magnifier. Outside the circle, effects are subtle. A pulsing ring marks the ROI boundary.",
     "features": [
       "multi-pass-3",
@@ -3789,7 +3789,7 @@
   {
     "id": "pyramid-downsample-pass1",
     "name": "Gaussian-Laplacian Pyramid (Pass 1: Gaussian Blur)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pyramid-downsample-pass1.wgsl",
+    "url": "shaders/pyramid-downsample-pass1.wgsl",
     "description": "Pass 1 of 3: Separable Gaussian blur via 18×18 shared-memory tile. Stores the blurred image for the next frame's Laplacian decomposition. Chain with pyramid-bandprocess-pass2.",
     "features": [
       "multi-pass-1",
@@ -3848,7 +3848,7 @@
     "id": "retro-gameboy",
     "name": "Retro Game Boy",
     "description": "Simulates a classic handheld green dot-matrix display.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/retro-gameboy.wgsl",
+    "url": "shaders/retro-gameboy.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -3890,7 +3890,7 @@
   {
     "id": "rgb-ripple-distortion",
     "name": "RGB Ripple Distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-ripple-distortion.wgsl",
+    "url": "shaders/rgb-ripple-distortion.wgsl",
     "description": "A ripple effect that separates RGB channels based on distance from mouse.",
     "params": [
       {
@@ -3934,7 +3934,7 @@
     "id": "ring-slicer",
     "name": "Ring Slicer",
     "description": "Slices the image into rotating concentric rings centered on the mouse, with organic noise-wobbled seams, palette-driven edge glow, subtle audio-reactive spin, and a mouse-down grab-and-twist.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ring_slicer.wgsl",
+    "url": "shaders/ring_slicer.wgsl",
     "params": [
       {
         "id": "density",
@@ -3981,7 +3981,7 @@
     "id": "ripple-blocks",
     "name": "Ripple Blocks",
     "description": "Grid blocks that scale based on a wave pattern from the mouse.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ripple-blocks.wgsl",
+    "url": "shaders/ripple-blocks.wgsl",
     "params": [
       {
         "name": "Grid Size",
@@ -4029,7 +4029,7 @@
   {
     "id": "scanline-cyberpunk",
     "name": "Scanline Cyberpunk",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scanline-cyberpunk.wgsl",
+    "url": "shaders/scanline-cyberpunk.wgsl",
     "category": "image",
     "description": "CRT scanline grid with RGB phosphor triad mask layered over a cyberpunk cinematic colour grade (teal shadows, amber-magenta highlights). Bass drives glitch-roll bands; treble flickers brightness.",
     "tags": [
@@ -4085,7 +4085,7 @@
   {
     "id": "silk-flow-advection",
     "name": "Silk Flow Advection",
-    "url": "https://test.1ink.us/image_video_effects/shaders/silk-flow-advection.wgsl",
+    "url": "shaders/silk-flow-advection.wgsl",
     "description": "The colors and details of the input are gently carried along living, silky curl-noise flows. The mouse acts like a finger disturbing delicate fabric. Creates beautiful organic painterly motion on stills and video.",
     "tags": [
       "silk",
@@ -4143,7 +4143,7 @@
   {
     "id": "slime-drip",
     "name": "Slime Drip",
-    "url": "https://test.1ink.us/image_video_effects/shaders/slime-drip.wgsl",
+    "url": "shaders/slime-drip.wgsl",
     "description": "A gooey, dripping slime effect that can be wiped away.",
     "params": [
       {
@@ -4186,7 +4186,7 @@
   {
     "id": "spec-cooperative-edge-linking",
     "name": "Cooperative Edge Linking",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-cooperative-edge-linking.wgsl",
+    "url": "shaders/spec-cooperative-edge-linking.wgsl",
     "description": "Workgroup-cooperative edge detection and chain tracing. Uses shared memory union-find to link connected edges within each tile, assigning unique edge IDs for downstream segmentation and flow effects.",
     "tags": [
       "edge-detection",
@@ -4243,7 +4243,7 @@
   {
     "id": "spec-histogram-equalize",
     "name": "Histogram Equalize",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-histogram-equalize.wgsl",
+    "url": "shaders/spec-histogram-equalize.wgsl",
     "description": "Real-time CLAHE histogram equalization using workgroup cooperative histogram building. Computes local histogram per 8x8 tile and remaps intensities via CDF for dramatic adaptive contrast enhancement.",
     "tags": [
       "histogram",
@@ -4299,7 +4299,7 @@
     "id": "spectral-mesh",
     "name": "Spectral Mesh",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-mesh.wgsl",
+    "url": "shaders/spectral-mesh.wgsl",
     "description": "Adaptive Delaunay-style spectral mesh with image-gradient-driven density, chromatic wavelength vertex coloring, wireframe glow, HDR bloom, ACES tone mapping, and subsurface scattering. Bass drives subdivision, mouse attracts vertices, depth controls foreshortening.",
     "features": [
       "mouse-driven",
@@ -4360,7 +4360,7 @@
   {
     "id": "steampunk-gear-lens",
     "name": "Steampunk Gear Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/steampunk-gear-lens.wgsl",
+    "url": "shaders/steampunk-gear-lens.wgsl",
     "description": "A rotating mechanical gear lens with sepia filter and audio-reactive rotation.",
     "params": [
       {
@@ -4409,7 +4409,7 @@
   {
     "id": "tensor-flow-sculpting",
     "name": "Tensor Flow Sculpting",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tensor-flow-sculpting.wgsl",
+    "url": "shaders/tensor-flow-sculpting.wgsl",
     "description": "Depth is treated as a 4-D strain tensor that warps and sculpts the image like clay — bulk regions bend dramatically while high-frequency edge details stay crisp.",
     "tags": [
       "depth",
@@ -4471,7 +4471,7 @@
   {
     "id": "tesseract-fold",
     "name": "Tesseract Fold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tesseract-fold.wgsl",
+    "url": "shaders/tesseract-fold.wgsl",
     "description": "A 4D kaleidoscopic folding effect centered on the mouse. Features HDR tone mapping, iridescent color grading, atmospheric vignette, treble-driven edge glow, and bloom-weight alpha for chained rendering.",
     "params": [
       {
@@ -4526,7 +4526,7 @@
   {
     "id": "texture",
     "name": "Procedural Texture Analyzer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/texture.wgsl",
+    "url": "shaders/texture.wgsl",
     "description": "Multi-scale texture analyzer with Laplacian edge enhancement, unsharp mask, temporal smoothing, golden-ratio vignette, and audio-reactive sparkle/glitch.",
     "features": [
       "depth-aware",
@@ -4582,7 +4582,7 @@
   {
     "id": "tilt-shift",
     "name": "Tilt Shift Miniature",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tilt-shift.wgsl",
+    "url": "shaders/tilt-shift.wgsl",
     "description": "Scheimpflug principle tilt-shift with angular blur kernel and depth-aware circle-of-confusion. Bass drives tilt angle oscillation, mouse positions the focal plane, depth controls local blur radius. Features boosted saturation, vignette on blurred regions, ACES tone mapping, and chromatic aberration in out-of-focus areas.",
     "params": [
       {
@@ -4632,7 +4632,7 @@
     "id": "triangle-mosaic",
     "name": "Triangle Mosaic",
     "description": "Breaks the image into an equilateral triangle grid. Mouse controls scale and twist.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/triangle-mosaic.wgsl",
+    "url": "shaders/triangle-mosaic.wgsl",
     "params": [
       {
         "name": "Scale",
@@ -4678,7 +4678,7 @@
   {
     "id": "velvet-scatter-bloom",
     "name": "Velvet Scatter Bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/velvet-scatter-bloom.wgsl",
+    "url": "shaders/velvet-scatter-bloom.wgsl",
     "description": "Rich velvet-like subsurface scattering on darker regions of the input, with living audio-reactive bloom and a moving mouse light that reveals hidden color beneath the surface. Feels luxurious and organic on both stills and video.",
     "tags": [
       "velvet",
@@ -4736,7 +4736,7 @@
     "id": "vhs-chroma-bleed",
     "name": "VHS Chroma Bleed",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vhs-chroma-bleed.wgsl",
+    "url": "shaders/vhs-chroma-bleed.wgsl",
     "description": "VHS tape aesthetic with authentic tape degradation: time-varying chromatic aberration, tape tracking error with horizontal wobble and jitter, audio-reactive line dropouts, compression artifacts, analog warmth, saturation roll-off, noise bands, film grain, scanlines, CRT barrel distortion, and vignette. Chromatic bleed with depth-scatter. Bass drives line dropouts, treble adds micro-glitch.",
     "tags": [
       "vhs",
@@ -4805,7 +4805,7 @@
   {
     "id": "video-echo-chamber",
     "name": "Video Echo Chamber",
-    "url": "https://test.1ink.us/image_video_effects/shaders/video-echo-chamber.wgsl",
+    "url": "shaders/video-echo-chamber.wgsl",
     "description": "Temporal trails that persist longer near the mouse cursor, creating a ghostly echo effect.",
     "params": [
       {
@@ -4850,7 +4850,7 @@
     "id": "voxel-depth-sort",
     "name": "Voxel Depth Sort",
     "category": "image",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voxel-depth-sort.wgsl",
+    "url": "shaders/voxel-depth-sort.wgsl",
     "description": "Converts the image into a 3D grid of isometric floating blocks. Block height is determined by brightness and depth, with ambient occlusion, soft shadows, and mouse-rotated isometric projection.",
     "params": [
       {
@@ -4901,7 +4901,7 @@
   {
     "id": "watercolor-bloom",
     "name": "Watercolor Bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/watercolor-bloom.wgsl",
+    "url": "shaders/watercolor-bloom.wgsl",
     "category": "image",
     "description": "Soft feathered watercolor bloom with paper fibre texture, wet-edge darkening, and audio-reactive radius expansion. Temporal feedback lets wet paint slowly dry.",
     "tags": [
@@ -4956,7 +4956,7 @@
   },
   {
     "id": "wave-halftone",
-    "url": "https://test.1ink.us/image_video_effects/shaders/wave-halftone.wgsl",
+    "url": "shaders/wave-halftone.wgsl",
     "description": "Halftone dot pattern with a waving grid and mouse magnification lens.",
     "features": [
       "mouse-driven"

--- a/public/shader-lists/interactive-mouse.json
+++ b/public/shader-lists/interactive-mouse.json
@@ -2,7 +2,7 @@
   {
     "id": "anamorphic-flare",
     "name": "Anamorphic Flare",
-    "url": "https://test.1ink.us/image_video_effects/shaders/anamorphic-flare.wgsl",
+    "url": "shaders/anamorphic-flare.wgsl",
     "description": "Generates a cinematic horizontal lens flare centered on the mouse position.",
     "params": [
       {
@@ -45,7 +45,7 @@
   {
     "id": "ascii-decode",
     "name": "ASCII Decode",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ascii-decode.wgsl",
+    "url": "shaders/ascii-decode.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -88,7 +88,7 @@
   {
     "id": "ascii-lens",
     "name": "ASCII Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ascii-lens.wgsl",
+    "url": "shaders/ascii-lens.wgsl",
     "description": "Reveals the image as procedural ASCII characters within a lens radius around the mouse.",
     "params": [
       {
@@ -143,7 +143,7 @@
   {
     "id": "bio-touch",
     "name": "Bio-Luminescent Touch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bio-touch.wgsl",
+    "url": "shaders/bio-touch.wgsl",
     "description": "Reveals organic, glowing cellular structures beneath the image where you touch. Audio-reactive cell density and pulse speed respond to bass.",
     "params": [
       {
@@ -192,7 +192,7 @@
   {
     "id": "biomimetic-scales",
     "name": "Biomimetic Scales",
-    "url": "https://test.1ink.us/image_video_effects/shaders/biomimetic-scales.wgsl",
+    "url": "shaders/biomimetic-scales.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -235,7 +235,7 @@
     "id": "block-distort-interactive",
     "name": "Block Distort",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/block-distort-interactive.wgsl",
+    "url": "shaders/block-distort-interactive.wgsl",
     "icon": "grid",
     "description": "Cursor pressure shoves image blocks into a prismatic distortion field with beat-reactive grid highlights. Enhanced with volumetric glow from mouse position, rim lighting on grid edges, audio-reactive light pulses, and warm/cool 3-point fill lighting.",
     "features": [
@@ -292,7 +292,7 @@
   {
     "id": "blueprint-reveal",
     "name": "Blueprint Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/blueprint-reveal.wgsl",
+    "url": "shaders/blueprint-reveal.wgsl",
     "description": "Temporal ink dissolve with depth hatch density and audio surge. Sobel edge detection draws blueprint lines; previous reveal state bleeds outward like spreading ink. Depth modulates hatch fineness, bass creates ink ripple surges from the mouse.",
     "params": [
       {
@@ -343,7 +343,7 @@
   {
     "id": "brush-strokes",
     "name": "Brush Strokes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/brush-strokes.wgsl",
+    "url": "shaders/brush-strokes.wgsl",
     "description": "Catalog entry for Brush Strokes.",
     "tags": [
       "mouse-driven",
@@ -404,7 +404,7 @@
   {
     "id": "bubble-wrap",
     "name": "Bubble Wrap",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bubble-wrap.wgsl",
+    "url": "shaders/bubble-wrap.wgsl",
     "description": "Interactive bubble wrap that you can pop with your mouse. Popped bubbles stay popped!",
     "params": [
       {
@@ -448,7 +448,7 @@
   {
     "id": "charcoal-rub",
     "name": "Charcoal Rub",
-    "url": "https://test.1ink.us/image_video_effects/shaders/charcoal-rub.wgsl",
+    "url": "shaders/charcoal-rub.wgsl",
     "description": "Scratch-off effect like rubbing charcoal paper. Mouse reveals image beneath textured overlay.",
     "params": [
       {
@@ -493,7 +493,7 @@
   {
     "id": "chroma-depth-tunnel",
     "name": "Chroma Depth Tunnel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-depth-tunnel.wgsl",
+    "url": "shaders/chroma-depth-tunnel.wgsl",
     "description": "A concentric tunnel effect centered on the mouse, with chromatic aberration.",
     "params": [
       {
@@ -545,7 +545,7 @@
   {
     "id": "chroma-kinetic",
     "name": "Chroma Kinetic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-kinetic.wgsl",
+    "url": "shaders/chroma-kinetic.wgsl",
     "description": "Velocity chromatic aberration with directional smear and audio split. R channel leads, B lags based on motion direction; bass drives lead amount, mids drive smear glow. Directional motion trails sample along the velocity vector for cinematic motion blur.",
     "params": [
       {
@@ -601,7 +601,7 @@
   {
     "id": "chroma-lens",
     "name": "Chroma Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-lens.wgsl",
+    "url": "shaders/chroma-lens.wgsl",
     "description": "A magnifying lens effect that splits color channels (chromatic aberration) towards the edges.",
     "params": [
       {
@@ -646,7 +646,7 @@
   {
     "id": "chroma-shift-grid",
     "name": "Chroma Shift Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-shift-grid.wgsl",
+    "url": "shaders/chroma-shift-grid.wgsl",
     "description": "Grid-based multi-mode chromatic aberration with alpha-channel translucency blending. Uses single UV displacement + spectral tint via mix(), with Voronoi F2-F1 cell pattern variation. Alpha encodes grid distortion strength * cell activity.",
     "features": [
       "mouse-driven",
@@ -700,7 +700,7 @@
   {
     "id": "chromatic-mosaic-projector",
     "name": "Chromatic Mosaic Projector",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-mosaic-projector.wgsl",
+    "url": "shaders/chromatic-mosaic-projector.wgsl",
     "description": "Animated Voronoi cell mosaic with per-cell chromatic aberration, mouse gravity wells, audio-reactive cell pulsing, HDR ACES tone mapping, temporal trails, dynamic blackbody color temperature, and layered alpha compositing.",
     "params": [
       {
@@ -765,7 +765,7 @@
   {
     "id": "chromatic-shockwave",
     "name": "Chromatic Shockwave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-shockwave.wgsl",
+    "url": "shaders/chromatic-shockwave.wgsl",
     "description": "Continuous chromatic ripples emanating from the mouse.",
     "params": [
       {
@@ -813,7 +813,7 @@
     "id": "chronos-brush",
     "name": "Chronos Brush",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chronos-brush.wgsl",
+    "url": "shaders/chronos-brush.wgsl",
     "description": "Freeze time by painting over the video feed with chromatic brush tints that cycle per click. Audio boosts brush size and opacity; depth modulates paint intensity.",
     "params": [
       {
@@ -870,7 +870,7 @@
   {
     "id": "circuit-breaker",
     "name": "Circuit Breaker",
-    "url": "https://test.1ink.us/image_video_effects/shaders/circuit-breaker.wgsl",
+    "url": "shaders/circuit-breaker.wgsl",
     "description": "Transforms image into a circuit board. Mouse interaction overloads the circuits.",
     "features": [
       "mouse-driven"
@@ -914,7 +914,7 @@
     "id": "cmyk-halftone-interactive",
     "name": "CMYK Halftone Interactive",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cmyk-halftone-interactive.wgsl",
+    "url": "shaders/cmyk-halftone-interactive.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -959,7 +959,7 @@
   },
   {
     "id": "codebreaker-reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/codebreaker-reveal.wgsl",
+    "url": "shaders/codebreaker-reveal.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1004,7 +1004,7 @@
   {
     "id": "cross-mouse-spec-dispersion-lens",
     "name": "Prismatic Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cross-mouse-spec-dispersion-lens.wgsl",
+    "url": "shaders/cross-mouse-spec-dispersion-lens.wgsl",
     "description": "Crossover shader combining mouse-driven lens interaction with physical spectral dispersion. The cursor becomes a prismatic lens that refracts RGB channels differently using Cauchy's equation.",
     "tags": [
       "crossover",
@@ -1060,7 +1060,7 @@
   {
     "id": "cross-stitch",
     "name": "Cross Stitch Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cross-stitch.wgsl",
+    "url": "shaders/cross-stitch.wgsl",
     "description": "Quantizes the image into cross-stitch patterns. Mouse movement unravels or distorts the fabric.",
     "params": [
       {
@@ -1104,7 +1104,7 @@
   {
     "id": "crystal-freeze",
     "name": "Crystal Freeze",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystal-freeze.wgsl",
+    "url": "shaders/crystal-freeze.wgsl",
     "description": "Mouse freezes the image into growing ice crystals with physical light transmission. Features Voronoi-based crystal cells with Fresnel reflection, path absorption, and purity-based scattering.",
     "params": [
       {
@@ -1160,7 +1160,7 @@
   {
     "id": "crystal-illuminator",
     "name": "Crystal Illuminator",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystal-illuminator.wgsl",
+    "url": "shaders/crystal-illuminator.wgsl",
     "description": "Faceted glass/gemstone surface with physical light transmission. Features Voronoi-based facets with mouse-controlled lighting, Fresnel reflection, and purity-based scattering for realistic crystal appearance.",
     "features": [
       "mouse-driven",
@@ -1218,7 +1218,7 @@
   {
     "id": "crystal-refraction",
     "name": "Crystal Refraction",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crystal-refraction.wgsl",
+    "url": "shaders/crystal-refraction.wgsl",
     "description": "Interactive faceted crystal lens with physical light transmission. Features IOR-based chromatic dispersion, Fresnel reflection at edges, and variable crystal thickness affecting light path.",
     "params": [
       {
@@ -1280,7 +1280,7 @@
   {
     "id": "cursor-aura",
     "name": "Cursor Aura",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cursor-aura.wgsl",
+    "url": "shaders/cursor-aura.wgsl",
     "description": "Glowing aura around cursor with customizable colors, edge detection, and audio-reactive bass pulsing.",
     "params": [
       {
@@ -1328,7 +1328,7 @@
   {
     "id": "cyber-focus",
     "name": "Cyber Focus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-focus.wgsl",
+    "url": "shaders/cyber-focus.wgsl",
     "description": "High-tech focus mode where the area around the mouse is crisp, while the background suffers from digital interference and chromatic aberration.",
     "params": [
       {
@@ -1375,7 +1375,7 @@
     "id": "cyber-glitch-hologram",
     "name": "Cyber Glitch Hologram",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-glitch-hologram.wgsl",
+    "url": "shaders/cyber-glitch-hologram.wgsl",
     "description": "Block-based datamoshing with structure-tensor motion estimation, holographic cosine interference fringes, cyan/magenta color separation, chromatic aberration on glitch blocks, and ACES tone mapping.",
     "params": [
       {
@@ -1424,7 +1424,7 @@
   {
     "id": "cyber-hex-armor",
     "name": "Cyber Hex Armor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-hex-armor.wgsl",
+    "url": "shaders/cyber-hex-armor.wgsl",
     "description": "A hexagonal tech armor overlay that retracts when the mouse approaches.",
     "params": [
       {
@@ -1480,7 +1480,7 @@
   {
     "id": "cyber-lattice",
     "name": "Cyber Lattice",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-lattice.wgsl",
+    "url": "shaders/cyber-lattice.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1526,7 +1526,7 @@
     "id": "cyber-magnifier",
     "name": "Cyber Magnifier",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-magnifier.wgsl",
+    "url": "shaders/cyber-magnifier.wgsl",
     "description": "High-tech magnifying lens with chromatic aberration and HUD overlay.",
     "features": [
       "mouse-driven",
@@ -1579,7 +1579,7 @@
     "id": "cyber-organic",
     "name": "Cyber Organic Scanner",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-organic.wgsl",
+    "url": "shaders/cyber-organic.wgsl",
     "description": "Biotech scan lines reveal pulsing synthetic veins beneath the image, concentrated around the cursor. Enhanced with bioluminescent OkLab color mixing, blackbody warmth modulation, volumetric vein glow, split-tone grading, and ACES filmic tone mapping.",
     "params": [
       {
@@ -1636,7 +1636,7 @@
   {
     "id": "cyber-rain",
     "name": "Cyber Rain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-rain.wgsl",
+    "url": "shaders/cyber-rain.wgsl",
     "category": "interactive-mouse",
     "description": "Neon rain on wet glass with mouse wiper, audio-envelope intensity, temporal wetness accumulation, depth-aware rain occlusion, and chromatic-aberration glow.",
     "tags": [
@@ -1704,7 +1704,7 @@
   {
     "id": "cyber-ripples",
     "name": "Cyber Ripples",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-ripples.wgsl",
+    "url": "shaders/cyber-ripples.wgsl",
     "description": "Interactive cursor-driven ripples fused with domain-warped FBM turbulence, audio-driven cyber palette shifting, SDF ring masking, click shockwaves, bass envelope feedback trails, depth-aware compositing, and ACES tone mapping.",
     "params": [
       {
@@ -1763,7 +1763,7 @@
   },
   {
     "id": "cyber-slit-scan",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-slit-scan.wgsl",
+    "url": "shaders/cyber-slit-scan.wgsl",
     "features": [
       "mouse-driven",
       "webcam"
@@ -1812,7 +1812,7 @@
   {
     "id": "cyber-trace",
     "name": "Cyber Trace",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-trace.wgsl",
+    "url": "shaders/cyber-trace.wgsl",
     "description": "A glowing neon trail that follows your mouse cursor and reacts to clicks, overlaid on the video feed.",
     "features": [
       "mouse-driven"
@@ -1855,7 +1855,7 @@
   {
     "id": "data-slicer-interactive",
     "name": "Data Slicer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-slicer-interactive.wgsl",
+    "url": "shaders/data-slicer-interactive.wgsl",
     "description": "Glitchy horizontal slicing with FBM-warped torn edges, click-triggered slice bursts from ripple history, bass-modulated slice count, and semantic alpha at slice boundaries.",
     "params": [
       {
@@ -1943,7 +1943,7 @@
   {
     "id": "data-stream-corruption",
     "name": "Data Stream Corruption",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-stream-corruption.wgsl",
+    "url": "shaders/data-stream-corruption.wgsl",
     "description": "Vertical data streams fall like rain; your mouse leaves a trail of corrupted code blocks.",
     "params": [
       {
@@ -1988,7 +1988,7 @@
   {
     "id": "data-stream",
     "name": "Digital Stream",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-stream.wgsl",
+    "url": "shaders/data-stream.wgsl",
     "description": "Digital matrix-style data stream disrupted by mouse interaction. Audio-reactive bass pulses accelerate the flow.",
     "params": [
       {
@@ -2040,7 +2040,7 @@
   {
     "id": "digital-compression",
     "name": "Digital Compression",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-compression.wgsl",
+    "url": "shaders/digital-compression.wgsl",
     "description": "Simulates digital artifacts and compression blocks. Mouse controls the clear focus area.",
     "params": [
       {
@@ -2086,7 +2086,7 @@
   },
   {
     "id": "digital-haze",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-haze.wgsl",
+    "url": "shaders/digital-haze.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2143,7 +2143,7 @@
   {
     "id": "digital-mold",
     "name": "Digital Mold",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-mold.wgsl",
+    "url": "shaders/digital-mold.wgsl",
     "description": "Reaction-diffusion growth with spore noise and depth humidity. Gray-Scott simulation grows mold patterns from the mouse cursor; depth modulates growth speed. Bass injects spores, treble adds bright sporulation highlights.",
     "params": [
       {
@@ -2198,7 +2198,7 @@
     "id": "digital-reveal",
     "name": "Digital Rain Reveal",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-reveal.wgsl",
+    "url": "shaders/digital-reveal.wgsl",
     "description": "Hides the image behind chromatic digital rain; move the mouse to reveal content. Audio shifts rain colors (bass green, treble white). Depth makes near objects reveal faster.",
     "params": [
       {
@@ -2252,7 +2252,7 @@
   {
     "id": "directional-glitch",
     "name": "Directional Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/directional-glitch.wgsl",
+    "url": "shaders/directional-glitch.wgsl",
     "description": "SDF-masked Voronoi-ridge and FBM domain-warped glitch bands radiate from the mouse, driven by curl-noise displacement, audio-reactive cosine palette, chromatic aberration, depth-aware masking, and kaleidoscope temporal feedback.",
     "params": [
       {
@@ -2330,7 +2330,7 @@
   {
     "id": "double-exposure",
     "name": "Double Exposure Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/double-exposure.wgsl",
+    "url": "shaders/double-exposure.wgsl",
     "description": "Blends the image with a domain-warped, zoomed and rotated version of itself. Voronoi cellular ridges modulate the overlay intensity. Reacts to audio bass.",
     "features": [
       "mouse-driven",
@@ -2379,7 +2379,7 @@
   {
     "id": "dynamic-halftone",
     "name": "Dynamic Halftone",
-    "url": "https://test.1ink.us/image_video_effects/shaders/dynamic-halftone.wgsl",
+    "url": "shaders/dynamic-halftone.wgsl",
     "description": "Halftone pattern that reacts to mouse proximity with size and contrast changes. Audio-reactive radius expansion via bass input.",
     "params": [
       {
@@ -2430,7 +2430,7 @@
   {
     "id": "echo-ripple",
     "name": "Echo Ripple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/echo-ripple.wgsl",
+    "url": "shaders/echo-ripple.wgsl",
     "description": "Mouse movement and click history spawn expanding ripples that echo through time. Audio-reactive envelopes smooth bass pulses, depth-aware parallax separates foreground from background, and chromatic aberration plus ACES tone mapping give the feedback loop a modern, saturated look. Phase B adds LOD noise and a cached displacement field for cleaner echo accumulation.",
     "params": [
       {
@@ -2487,7 +2487,7 @@
     "id": "edge-glow-mouse",
     "name": "Edge Glow Mouse",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/edge-glow-mouse.wgsl",
+    "url": "shaders/edge-glow-mouse.wgsl",
     "description": "Unsharp-masked edges bloom into neon HDR halos with anisotropic diffusion, chromatic aberration, ACES tone mapping, and film grain. Bass drives glow radius, mouse creates local edge emphasis, depth controls falloff.",
     "params": [
       {
@@ -2539,7 +2539,7 @@
   {
     "id": "energy-shield",
     "name": "Energy Shield",
-    "url": "https://test.1ink.us/image_video_effects/shaders/energy-shield.wgsl",
+    "url": "shaders/energy-shield.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -2582,7 +2582,7 @@
   {
     "id": "entropy-grid",
     "name": "Entropy Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/entropy-grid.wgsl",
+    "url": "shaders/entropy-grid.wgsl",
     "description": "Scrambles the image into a chaotic grid using domain-warped FBM, Voronoi cellular ridges, and Clifford strange-attractor chaos. Mouse restores order (or creates chaos) with audio-reactive entropy.",
     "params": [
       {
@@ -2631,7 +2631,7 @@
   {
     "id": "fabric-zipper",
     "name": "Fabric Zipper",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fabric-zipper.wgsl",
+    "url": "shaders/fabric-zipper.wgsl",
     "description": "Unzip the canvas to reveal the underlying image. Drag the mouse vertically to control the zipper.",
     "params": [
       {
@@ -2686,7 +2686,7 @@
   {
     "id": "ferrofluid",
     "name": "Magnetic Ferrofluid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ferrofluid.wgsl",
+    "url": "shaders/ferrofluid.wgsl",
     "description": "Simulates magnetic ferrofluid spikes attracted to the mouse.",
     "params": [
       {
@@ -2729,7 +2729,7 @@
   {
     "id": "fiber-optic-weave",
     "name": "Fiber Optic Weave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/fiber-optic-weave.wgsl",
+    "url": "shaders/fiber-optic-weave.wgsl",
     "description": "Deconstructs image into glowing optical fibers that react to mouse movement.",
     "params": [
       {
@@ -2774,7 +2774,7 @@
   {
     "id": "flux-core",
     "name": "Flux Core",
-    "url": "https://test.1ink.us/image_video_effects/shaders/flux-core.wgsl",
+    "url": "shaders/flux-core.wgsl",
     "description": "Energy arcs emit from the cursor, connecting to bright areas in the image.",
     "features": [
       "mouse-driven",
@@ -2823,7 +2823,7 @@
   {
     "id": "focal-pixelate",
     "name": "Focal Pixelate",
-    "url": "https://test.1ink.us/image_video_effects/shaders/focal-pixelate.wgsl",
+    "url": "shaders/focal-pixelate.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2885,7 +2885,7 @@
   {
     "id": "foil-impression",
     "name": "Foil Impression",
-    "url": "https://test.1ink.us/image_video_effects/shaders/foil-impression.wgsl",
+    "url": "shaders/foil-impression.wgsl",
     "description": "Simulates a metallic foil surface. Pressing with the mouse flattens the foil to reveal the image relief and color.",
     "params": [
       {
@@ -2929,7 +2929,7 @@
     "id": "glass-bead-curtain",
     "name": "Glass Bead Curtain",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-bead-curtain.wgsl",
+    "url": "shaders/glass-bead-curtain.wgsl",
     "description": "Physical glass bead curtain with Fresnel refraction, chromatic caustics, subsurface scattering, and bead-collision physics. Bass drives wind sway, mouse pushes beads aside, depth controls perspective bead size.",
     "params": [
       {
@@ -2994,7 +2994,7 @@
     "id": "glass-shatter",
     "name": "Glass Shatter",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-shatter.wgsl",
+    "url": "shaders/glass-shatter.wgsl",
     "description": "Interactive shattered glass effect where shards are pushed by the mouse.",
     "params": [
       {
@@ -3041,7 +3041,7 @@
   },
   {
     "id": "glass-wall",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-wall.wgsl",
+    "url": "shaders/glass-wall.wgsl",
     "features": [
       "mouse-driven",
       "upgraded-rgba"
@@ -3090,7 +3090,7 @@
   {
     "id": "glitch-cathedral",
     "name": "Glitch Cathedral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glitch-cathedral.wgsl",
+    "url": "shaders/glitch-cathedral.wgsl",
     "description": "Stained-glass geometric patterns with glitch artifacts; mouse triggers channel separation and pixel sorting.",
     "params": [
       {
@@ -3136,7 +3136,7 @@
   {
     "id": "gravity-lens",
     "name": "Gravity Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/gravity-lens.wgsl",
+    "url": "shaders/gravity-lens.wgsl",
     "params": [
       {
         "id": "mass",
@@ -3178,7 +3178,7 @@
   {
     "id": "hex-mosaic",
     "name": "Hexagon Mosaic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hex-mosaic.wgsl",
+    "url": "shaders/hex-mosaic.wgsl",
     "description": "Hexagonal glass-tile mosaic that reveals the clear image around the mouse cursor. Beveled tiles with grout seams shimmer with audio-reactive glints, bass boosts saturation, clicks send light ripples across the tiles, and holding the mouse down magnifies the mosaic under the cursor.",
     "params": [
       {
@@ -3236,7 +3236,7 @@
     "id": "hex-pulse",
     "name": "Hex Pulse",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hex-pulse.wgsl",
+    "url": "shaders/hex-pulse.wgsl",
     "description": "Honeycomb hexagonal lattice with damped wave equation interference. Bioluminescent cell glow, chromatic dispersion at edges, and HDR bloom on constructive interference nodes. Mouse excites local cells; bass triggers cascades.",
     "params": [
       {
@@ -3287,7 +3287,7 @@
   {
     "id": "holographic-edge-ripple",
     "name": "Holographic Edge Ripple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-edge-ripple.wgsl",
+    "url": "shaders/holographic-edge-ripple.wgsl",
     "category": "interactive-mouse",
     "description": "SDF edge detection with Laplacian zero-crossings, damped wave equation ripples, holographic rainbow diffraction, and Fresnel iridescence with ACES tone mapping.",
     "params": [
@@ -3338,7 +3338,7 @@
     "id": "holographic-prism",
     "name": "Holographic Prism",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-prism.wgsl",
+    "url": "shaders/holographic-prism.wgsl",
     "description": "Triangular prism dispersion with Snell's law refraction, wavelength-accurate rainbow spectrum, holographic interference fringes and speckle. Bass rotates prism, mouse controls incident angle, depth drives parallax.",
     "params": [
       {
@@ -3392,7 +3392,7 @@
   {
     "id": "hyper-chromatic-delay",
     "name": "Hyper-Chromatic Delay",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyper-chromatic-delay.wgsl",
+    "url": "shaders/hyper-chromatic-delay.wgsl",
     "description": "Spectral Multi-Tap Echo with wavelength-dependent refraction, per-channel lens distortion, motion-aware temporal blur, and audio-reverb-inspired feedback echoes.",
     "params": [
       {
@@ -3447,7 +3447,7 @@
   {
     "id": "hypnotic-spiral",
     "name": "Hypnotic Spiral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hypnotic-spiral.wgsl",
+    "url": "shaders/hypnotic-spiral.wgsl",
     "description": "Breathing, rotating spirals with color cycling; mouse warps and twists the spiral geometry.",
     "params": [
       {
@@ -3495,7 +3495,7 @@
   {
     "id": "impasto-swirl",
     "name": "Impasto Swirl",
-    "url": "https://test.1ink.us/image_video_effects/shaders/impasto-swirl.wgsl",
+    "url": "shaders/impasto-swirl.wgsl",
     "description": "Simulates wet oil paint mixing. Mouse acts as a smudge tool that stirs the image.",
     "params": [
       {
@@ -3538,7 +3538,7 @@
   {
     "id": "infinite-fractal-feedback",
     "name": "Infinite Fractal Feedback",
-    "url": "https://test.1ink.us/image_video_effects/shaders/infinite-fractal-feedback.wgsl",
+    "url": "shaders/infinite-fractal-feedback.wgsl",
     "description": "Perpetual zoom tunnel with rotating mandala patterns. Mouse controls the zoom focal point and rotation speed.",
     "params": [
       {
@@ -3589,7 +3589,7 @@
   {
     "id": "infinite-spiral-zoom",
     "name": "Möbius–Droste Spiral",
-    "url": "https://test.1ink.us/image_video_effects/shaders/infinite-spiral-zoom.wgsl",
+    "url": "shaders/infinite-spiral-zoom.wgsl",
     "description": "Möbius transformation composed with log-polar mapping for Droste self-similar infinite zoom. Temporal Möbius drift, audio-driven zoom speed, depth-scaled chromatic aberration, and multi-fold symmetry.",
     "params": [
       {
@@ -3649,7 +3649,7 @@
   {
     "id": "infinite-video-feedback",
     "name": "Infinite Video Feedback",
-    "url": "https://test.1ink.us/image_video_effects/shaders/infinite-video-feedback.wgsl",
+    "url": "shaders/infinite-video-feedback.wgsl",
     "description": "Create a feedback loop with the previous frame, applying zoom and rotation centered on the mouse.",
     "params": [
       {
@@ -3696,7 +3696,7 @@
   {
     "id": "ink-bleed",
     "name": "Ink Bleed",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ink-bleed.wgsl",
+    "url": "shaders/ink-bleed.wgsl",
     "description": "Click to drop spreading ink that permanently stains the video feed.",
     "params": [
       {
@@ -3740,7 +3740,7 @@
   {
     "id": "interactive-emboss",
     "name": "Interactive Emboss",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-emboss.wgsl",
+    "url": "shaders/interactive-emboss.wgsl",
     "description": "Emboss effect where the light source follows the mouse cursor.",
     "params": [
       {
@@ -3794,7 +3794,7 @@
     "id": "interactive-film-burn",
     "name": "Film Burn",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-film-burn.wgsl",
+    "url": "shaders/interactive-film-burn.wgsl",
     "description": "Simulates burning film reel with organic edges and grain, centered on the cursor.",
     "params": [
       {
@@ -3843,7 +3843,7 @@
   {
     "id": "interactive-fisheye",
     "name": "Fluid Lens Dynamics",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-fisheye.wgsl",
+    "url": "shaders/interactive-fisheye.wgsl",
     "description": "Velocity-sensitive fluid lens with spring-mass response, viscosity-controlled damping, impulse-driven splash ripples, and depth-aware refractive magnification.",
     "params": [
       {
@@ -3899,7 +3899,7 @@
   {
     "id": "interactive-frost",
     "name": "Interactive Frost",
-    "url": "https://test.1ink.us/image_video_effects/shaders/frost-reveal.wgsl",
+    "url": "shaders/frost-reveal.wgsl",
     "description": "Realistic frost grows over the image; use your mouse (warmth) to melt it away.",
     "params": [
       {
@@ -3943,7 +3943,7 @@
   {
     "id": "interactive-glitch-brush",
     "name": "Glitch Brush",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-glitch-brush.wgsl",
+    "url": "shaders/interactive-glitch-brush.wgsl",
     "description": "Paint digital glitches onto the screen with audio-reactive intensity.",
     "params": [
       {
@@ -3996,7 +3996,7 @@
   {
     "id": "interactive-glitch-cubes",
     "name": "Interactive Glitch Cubes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-glitch-cubes.wgsl",
+    "url": "shaders/interactive-glitch-cubes.wgsl",
     "description": "Image mapped onto a grid of extruded cubes with audio-reactive extrusion, chromatic edge glow, temporal cube memory for settling physics, and depth-aware alpha.",
     "params": [
       {
@@ -4053,7 +4053,7 @@
   {
     "id": "interactive-glitch",
     "name": "Interactive Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-glitch.wgsl",
+    "url": "shaders/interactive-glitch.wgsl",
     "description": "Digital glitch artifacts that intensify around the mouse cursor.",
     "params": [
       {
@@ -4100,7 +4100,7 @@
   {
     "id": "interactive-halftone-spin",
     "name": "Interactive Halftone Spin",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-halftone-spin.wgsl",
+    "url": "shaders/interactive-halftone-spin.wgsl",
     "description": "CMYK halftone pattern where the grid rotation is driven by mouse proximity.",
     "params": [
       {
@@ -4144,7 +4144,7 @@
   {
     "id": "interactive-kuwahara",
     "name": "Oil Painting (Kuwahara)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-kuwahara.wgsl",
+    "url": "shaders/interactive-kuwahara.wgsl",
     "description": "Applies an oil painting effect using a Kuwahara filter. Mouse distance controls the detail level (focus area).",
     "params": [
       {
@@ -4190,7 +4190,7 @@
   {
     "id": "interactive-magnetic-ripple",
     "name": "Magnetic Ripple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-magnetic-ripple.wgsl",
+    "url": "shaders/interactive-magnetic-ripple.wgsl",
     "description": "Phase B audio-reactive magnetic ripple. Bass-pulsed ripple frequency and field strength, mids-morphing hue-cycled glow, treble sparkle on field lines, plus curl-noise field lines, click-burst shockwaves, 50 ripple-point accumulation, FBM domain warping, depth-aware compositing, temporal motion trails, chromatic split, and semantic glow-alpha.",
     "params": [
       {
@@ -4283,7 +4283,7 @@
   {
     "id": "interactive-pixel-wind",
     "name": "Pixel Wind",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-pixel-wind.wgsl",
+    "url": "shaders/interactive-pixel-wind.wgsl",
     "description": "Wind effect driven by cursor direction.",
     "params": [
       {
@@ -4328,7 +4328,7 @@
     "id": "interactive-ripple",
     "name": "Interactive Ripple",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-ripple.wgsl",
+    "url": "shaders/interactive-ripple.wgsl",
     "description": "2D wave equation solver with dispersion and Huygens wavelet superposition. Chromatic dispersion on ripple crests, caustic highlights in constructive interference zones, HDR bloom, subsurface scattering, and boundary reflection damping.",
     "params": [
       {
@@ -4380,7 +4380,7 @@
   {
     "id": "interactive-voronoi-lens",
     "name": "Interactive Voronoi Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-voronoi-lens.wgsl",
+    "url": "shaders/interactive-voronoi-lens.wgsl",
     "category": "interactive-mouse",
     "description": "Voronoi cells act as audio-reactive lenses with mouse-driven focus, temporal trail accumulation, depth-aware edge fog, and neon cell-boundary accents.",
     "tags": [
@@ -4447,7 +4447,7 @@
   {
     "id": "interactive-voronoi-web",
     "name": "Voronoi Web",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-voronoi-web.wgsl",
+    "url": "shaders/interactive-voronoi-web.wgsl",
     "description": "Dynamic voronoi web connected to the cursor.",
     "params": [
       {
@@ -4490,7 +4490,7 @@
   },
   {
     "id": "kaleido-portal-interactive",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kaleido-portal-interactive.wgsl",
+    "url": "shaders/kaleido-portal-interactive.wgsl",
     "icon": "circle",
     "description": "A circular portal that reveals a kaleidoscopic view of the video, controlled by the mouse.",
     "features": [
@@ -4535,7 +4535,7 @@
   {
     "id": "kimi-chromatic-warp",
     "name": "Kimi Chromatic Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_chromatic_warp.wgsl",
+    "url": "shaders/kimi_chromatic_warp.wgsl",
     "description": "RGB channel separation and prismatic distortion effects that intensify near the cursor with swirling motion.",
     "features": [
       "mouse-driven",
@@ -4588,7 +4588,7 @@
   {
     "id": "kimi-ripple-touch",
     "name": "Kimi Ripple Touch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_ripple_touch.wgsl",
+    "url": "shaders/kimi_ripple_touch.wgsl",
     "description": "Interactive water ripple effect at mouse position with expanding waves, chromatic aberration, and bass-driven audio reactivity.",
     "features": [
       "mouse-driven",
@@ -4643,7 +4643,7 @@
   {
     "id": "kimi-spotlight",
     "name": "Kimi Spotlight",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_spotlight.wgsl",
+    "url": "shaders/kimi_spotlight.wgsl",
     "description": "Flashlight effect that reveals full color under the beam while surroundings are desaturated and darkened. Audio-reactive spotlight size pulses with bass.",
     "features": [
       "mouse-driven",
@@ -4698,7 +4698,7 @@
   {
     "id": "kinetic-dispersion",
     "name": "Kinetic Dispersion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kinetic-dispersion.wgsl",
+    "url": "shaders/kinetic-dispersion.wgsl",
     "description": "Mouse-velocity dispersion effect with RGB split, block scattering, and audio-reactive intensity.",
     "features": [
       "mouse-driven",
@@ -4751,7 +4751,7 @@
     "id": "knitted-fabric",
     "name": "Knitted Fabric",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/knitted-fabric.wgsl",
+    "url": "shaders/knitted-fabric.wgsl",
     "description": "Simulates a knitted wool texture. Mouse interaction pulls and stretches the fabric.",
     "params": [
       {
@@ -4799,7 +4799,7 @@
   {
     "id": "laser-burn",
     "name": "Laser Burn",
-    "url": "https://test.1ink.us/image_video_effects/shaders/laser-burn.wgsl",
+    "url": "shaders/laser-burn.wgsl",
     "description": "Temporal burn accumulation with ember glow and audio spark showers. Mouse beam chars the surface persistently; embers fade slower than heat for lingering glow. Treble creates flying spark particles near the beam, bass deepens the char.",
     "params": [
       {
@@ -4852,7 +4852,7 @@
   {
     "id": "light-leaks",
     "name": "Light Leaks",
-    "url": "https://test.1ink.us/image_video_effects/shaders/light-leaks.wgsl",
+    "url": "shaders/light-leaks.wgsl",
     "description": "Simulates film light leaks. Move the mouse to change the light source angle.",
     "params": [
       {
@@ -4896,7 +4896,7 @@
   {
     "id": "lighthouse-reveal",
     "name": "Lighthouse Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lighthouse-reveal.wgsl",
+    "url": "shaders/lighthouse-reveal.wgsl",
     "description": "A rotating beam of light that reveals the image, emanating from the mouse position.",
     "features": [
       "mouse-driven",
@@ -4946,7 +4946,7 @@
   {
     "id": "liquid-lens",
     "name": "Liquid Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-lens.wgsl",
+    "url": "shaders/liquid-lens.wgsl",
     "category": "interactive-mouse",
     "description": "Spherical aberration simulation with Snell's law refraction at curved interfaces, 7-sample chromatic dispersion, caustic highlights, Fresnel reflections, and ACES tone mapping.",
     "params": [
@@ -4995,7 +4995,7 @@
   },
   {
     "id": "liquid-time-warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-time-warp.wgsl",
+    "url": "shaders/liquid-time-warp.wgsl",
     "features": [
       "mouse-driven",
       "webcam"
@@ -5044,7 +5044,7 @@
   {
     "id": "liquid-touch",
     "name": "Liquid Touch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-touch.wgsl",
+    "url": "shaders/liquid-touch.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -5086,7 +5086,7 @@
   {
     "id": "liquid-volumetric-zoom",
     "name": "Liquid Volumetric Zoom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-volumetric-zoom.wgsl",
+    "url": "shaders/liquid-volumetric-zoom.wgsl",
     "description": "Unified 3D fluid zoom that merges parallax, vortex dynamics, plasma flow and chromatic aberration into a single volumetric zoom.",
     "params": [
       {
@@ -5134,7 +5134,7 @@
   {
     "id": "liquid-warp",
     "name": "Liquid Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-warp.wgsl",
+    "url": "shaders/liquid-warp.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -5176,7 +5176,7 @@
   },
   {
     "id": "luma-echo-warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-echo-warp.wgsl",
+    "url": "shaders/luma-echo-warp.wgsl",
     "description": "Temporal echo accumulation with depth-parallax attenuation and curl-noise swirl warping around the mouse. Bass drives echo amplitude and chromatic trail separation, treble adds twinkling sparkle to high-luma regions, and previous frames bleed through via dataTextureC with a luma-locked palette shimmer.",
     "features": [
       "mouse-driven",
@@ -5233,7 +5233,7 @@
     "id": "luma-force",
     "name": "Luma Force",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-force.wgsl",
+    "url": "shaders/luma-force.wgsl",
     "description": "Physics-based particle advection driven by luma gradients: bright regions repel, dark attracts. Curl noise for divergence-free flow, mouse vortex, spectral chromatic aberration, and HDR velocity glow.",
     "params": [
       {
@@ -5283,7 +5283,7 @@
   {
     "id": "luma-magnetism",
     "name": "Luma Magnetism",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-magnetism.wgsl",
+    "url": "shaders/luma-magnetism.wgsl",
     "category": "interactive-mouse",
     "description": "Magnetic field line simulation with Runge-Kutta integration. Bright pixels act as north poles, dark as south. Renders glowing iron-filing filaments with HDR bloom and ACES tone mapping.",
     "params": [
@@ -5333,7 +5333,7 @@
   {
     "id": "luma-slice-interactive",
     "name": "Luma Slice Interactive",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-slice-interactive.wgsl",
+    "url": "shaders/luma-slice-interactive.wgsl",
     "description": "Slices the image horizontally, displacing strips based on their luminance and mouse position. Audio-reactive intensity via bass, mids-shimmered RGB fringes tinted by a cosine palette, organic fBM wobble, and a mouse-down surge ripple, finished with vignette and grain.",
     "params": [
       {
@@ -5386,7 +5386,7 @@
   {
     "id": "luma-topography",
     "name": "Luma Topography",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-topography.wgsl",
+    "url": "shaders/luma-topography.wgsl",
     "description": "Visualizes the image as a 3D terrain map where brightness determines height. The mouse controls a dynamic light source.",
     "params": [
       {
@@ -5432,7 +5432,7 @@
   {
     "id": "magma-fissure",
     "name": "Magma Fissure",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magma-fissure.wgsl",
+    "url": "shaders/magma-fissure.wgsl",
     "description": "Burn glowing fissures into the image with the mouse.",
     "params": [
       {
@@ -5474,7 +5474,7 @@
   },
   {
     "id": "magnetic-edge",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-edge.wgsl",
+    "url": "shaders/magnetic-edge.wgsl",
     "icon": "edgesensor_high",
     "features": [
       "mouse-driven",
@@ -5524,7 +5524,7 @@
   {
     "id": "magnetic-interference",
     "name": "Magnetic Interference",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-interference.wgsl",
+    "url": "shaders/magnetic-interference.wgsl",
     "description": "Simulates magnetic distortion using unified displacement fields and alpha translucency blending. Features ripple shockwave interference, gravity-well mouse attraction, canonical bass envelope, beat-pulsed magnetic field, mids-driven swirl and chromatic rotation, treble sparkle overlay, audio-amplified ripples, temporal feedback smearing, depth-aware compositing, chromatic aberration, and mouse-velocity trail drag.",
     "params": [
       {
@@ -5579,7 +5579,7 @@
   {
     "id": "magnetic-luma-sort",
     "name": "Magnetic Luma Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-luma-sort.wgsl",
+    "url": "shaders/magnetic-luma-sort.wgsl",
     "description": "Pixels are magnetically pulled by the cursor based on brightness, creating trails.",
     "params": [
       {
@@ -5623,7 +5623,7 @@
     "id": "magnetic-pixels",
     "name": "Magnetic Pixels",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-pixels.wgsl",
+    "url": "shaders/magnetic-pixels.wgsl",
     "description": "Pixels behave as iron filings in a magnetic dipole field. Mouse positions the dipole; bass oscillates field strength. Metallic sheen, chromatic aberration, and HDR bloom on field concentrations.",
     "params": [
       {
@@ -5674,7 +5674,7 @@
   {
     "id": "magnetic-rgb",
     "name": "Magnetic RGB",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-rgb.wgsl",
+    "url": "shaders/magnetic-rgb.wgsl",
     "params": [
       {
         "id": "strength",
@@ -5715,7 +5715,7 @@
   },
   {
     "id": "magnetic-ring",
-    "url": "https://test.1ink.us/image_video_effects/shaders/magnetic-ring.wgsl",
+    "url": "shaders/magnetic-ring.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -5771,7 +5771,7 @@
     "id": "matrix-curtain",
     "name": "Matrix Curtain",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/matrix-curtain.wgsl",
+    "url": "shaders/matrix-curtain.wgsl",
     "description": "Conway's Game of Life on a falling phosphor character grid with Perlin-noise column velocities, CRT glow, ghosting trails, and ACES tone mapping. Bass drives spawn rate, mouse scrubs horizontal shift and rain speed, depth creates parallax.",
     "params": [
       {
@@ -5822,7 +5822,7 @@
   {
     "id": "mirror-drag",
     "name": "Mirror Drag",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mirror-drag.wgsl",
+    "url": "shaders/mirror-drag.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -5875,7 +5875,7 @@
     "id": "moire-interference",
     "label": "Moiré Interference",
     "name": "Moiré Interference",
-    "url": "https://test.1ink.us/image_video_effects/shaders/moire-interference.wgsl",
+    "url": "shaders/moire-interference.wgsl",
     "icon": "wifi",
     "description": "Generates dynamic interference patterns between the center and the mouse position.",
     "features": [
@@ -5921,7 +5921,7 @@
   {
     "id": "molten-glass",
     "name": "Molten Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/molten-glass.wgsl",
+    "url": "shaders/molten-glass.wgsl",
     "features": [
       "mouse-driven",
       "upgraded-rgba",
@@ -5967,7 +5967,7 @@
   {
     "id": "motion-heatmap",
     "name": "Motion Heatmap",
-    "url": "https://test.1ink.us/image_video_effects/shaders/motion-heatmap.wgsl",
+    "url": "shaders/motion-heatmap.wgsl",
     "description": "Visualizes video motion and mouse interaction as a heatmap.",
     "params": [
       {
@@ -6010,7 +6010,7 @@
   {
     "id": "motion-revealer",
     "name": "Motion Revealer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/motion-revealer.wgsl",
+    "url": "shaders/motion-revealer.wgsl",
     "category": "interactive-mouse",
     "description": "Optical flow estimation via structure tensor reveals only moving regions. Motion trails with spectral chromatic aberration, HDR glow on fast objects, ACES tone mapping, and motion blur. Bass drives motion sensitivity, mouse creates a motion mask, depth controls trail length perspective.",
     "params": [
@@ -6069,7 +6069,7 @@
   {
     "id": "mouse-chromatic-explosion",
     "name": "Chromatic Explosion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-chromatic-explosion.wgsl",
+    "url": "shaders/mouse-chromatic-explosion.wgsl",
     "features": [
       "mouse-driven",
       "chromatic-aberration",
@@ -6117,7 +6117,7 @@
   {
     "id": "mouse-electromagnetic-aurora",
     "name": "Electromagnetic Aurora",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-electromagnetic-aurora.wgsl",
+    "url": "shaders/mouse-electromagnetic-aurora.wgsl",
     "features": [
       "mouse-driven",
       "multi-pass-1"
@@ -6164,7 +6164,7 @@
   {
     "id": "mouse-fluid-coupling",
     "name": "Fluid Coupling",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-fluid-coupling.wgsl",
+    "url": "shaders/mouse-fluid-coupling.wgsl",
     "features": [
       "mouse-driven",
       "temporal"
@@ -6211,7 +6211,7 @@
   {
     "id": "mouse-gravity",
     "name": "Interactive Gravity",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-gravity.wgsl",
+    "url": "shaders/mouse-gravity.wgsl",
     "description": "Gravitational distortion field that follows the mouse cursor.",
     "params": [
       {
@@ -6258,7 +6258,7 @@
   {
     "id": "mouse-hyperbolic-navigator",
     "name": "Hyperbolic Navigator",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-hyperbolic-navigator.wgsl",
+    "url": "shaders/mouse-hyperbolic-navigator.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6305,7 +6305,7 @@
   {
     "id": "mouse-ink-bleed",
     "name": "Mouse Ink Bleed",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-ink-bleed.wgsl",
+    "url": "shaders/mouse-ink-bleed.wgsl",
     "category": "interactive-mouse",
     "description": "Organic ink that bleeds and diffuses outward from the mouse position with domain-warped FBM turbulence, temporal trails, audio envelope reactivity, and depth-aware compositing.",
     "tags": [
@@ -6375,7 +6375,7 @@
   {
     "id": "mouse-julia-morph",
     "name": "Julia Morph",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-julia-morph.wgsl",
+    "url": "shaders/mouse-julia-morph.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6421,7 +6421,7 @@
   {
     "id": "mouse-kaleidoscope-tunnel",
     "name": "Kaleidoscope Tunnel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-kaleidoscope-tunnel.wgsl",
+    "url": "shaders/mouse-kaleidoscope-tunnel.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6467,7 +6467,7 @@
   {
     "id": "mouse-magnetic-pixel-sand",
     "name": "Magnetic Pixel Sand",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-magnetic-pixel-sand.wgsl",
+    "url": "shaders/mouse-magnetic-pixel-sand.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6513,7 +6513,7 @@
   {
     "id": "mouse-mandelbrot-zoom-portal",
     "name": "Mandelbrot Zoom Portal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-mandelbrot-zoom-portal.wgsl",
+    "url": "shaders/mouse-mandelbrot-zoom-portal.wgsl",
     "features": [
       "mouse-driven",
       "raymarched"
@@ -6560,7 +6560,7 @@
   {
     "id": "mouse-neural-dreamscape",
     "name": "Neural Dreamscape",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-neural-dreamscape.wgsl",
+    "url": "shaders/mouse-neural-dreamscape.wgsl",
     "features": [
       "mouse-driven",
       "temporal"
@@ -6608,7 +6608,7 @@
   {
     "id": "mouse-paint-splatter",
     "name": "Paint Splatter",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-paint-splatter.wgsl",
+    "url": "shaders/mouse-paint-splatter.wgsl",
     "features": [
       "mouse-driven",
       "temporal"
@@ -6655,7 +6655,7 @@
   {
     "id": "mouse-polarized-light-field",
     "name": "Polarized Light Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-polarized-light-field.wgsl",
+    "url": "shaders/mouse-polarized-light-field.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6702,7 +6702,7 @@
   {
     "id": "mouse-synesthetic-sound-paint",
     "name": "Synesthetic Sound Paint",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-synesthetic-sound-paint.wgsl",
+    "url": "shaders/mouse-synesthetic-sound-paint.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -6751,7 +6751,7 @@
   {
     "id": "mouse-time-crystal",
     "name": "Time Crystal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-time-crystal.wgsl",
+    "url": "shaders/mouse-time-crystal.wgsl",
     "features": [
       "mouse-driven",
       "temporal"
@@ -6799,7 +6799,7 @@
   {
     "id": "mouse-voronoi-mosaic",
     "name": "Voronoi Mosaic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-voronoi-mosaic.wgsl",
+    "url": "shaders/mouse-voronoi-mosaic.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6845,7 +6845,7 @@
   {
     "id": "mouse-wormhole-lens",
     "name": "Wormhole Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/mouse-wormhole-lens.wgsl",
+    "url": "shaders/mouse-wormhole-lens.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -6891,7 +6891,7 @@
   {
     "id": "nano-repair",
     "name": "Nano-Tech Repair",
-    "url": "https://test.1ink.us/image_video_effects/shaders/nano-repair.wgsl",
+    "url": "shaders/nano-repair.wgsl",
     "description": "The image is corrupted by digital rot. Use the mouse to deploy nano-bots that repair the image.",
     "params": [
       {
@@ -6935,7 +6935,7 @@
   {
     "id": "neon-contour-drag",
     "name": "Neon Wake",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-contour-drag.wgsl",
+    "url": "shaders/neon-contour-drag.wgsl",
     "description": "Detects edges and applies a neon glow that is warped by the mouse cursor like a magnetic field.",
     "params": [
       {
@@ -6985,7 +6985,7 @@
   {
     "id": "neon-cursor-trace",
     "name": "Neon Cursor Trace",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-cursor-trace.wgsl",
+    "url": "shaders/neon-cursor-trace.wgsl",
     "description": "Spring-mass cursor physics with persistent phosphor trails, gravity-well mouse attraction, click-burst particle spawning, depth-aware compositing, and ACES tone-mapped neon glow.",
     "params": [
       {
@@ -7047,7 +7047,7 @@
   {
     "id": "neon-echo",
     "name": "Neon Echo",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-echo.wgsl",
+    "url": "shaders/neon-echo.wgsl",
     "description": "Per-channel CRT phosphor persistence with blackbody-aged echoes, cursor drift, and scanline halation.",
     "params": [
       {
@@ -7097,7 +7097,7 @@
     "id": "neon-edge-radar",
     "name": "Neon Edge Radar",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-edge-radar.wgsl",
+    "url": "shaders/neon-edge-radar.wgsl",
     "description": "Mouse-centered radar sweep with depth-aware edge detection, audio-reactive neon emission, ACES tone mapping, IGN dither, Fresnel rim, volumetric fog, hue-preserve clamp and blackbody hotspots.",
     "workgroup_size": [
       16,
@@ -7166,7 +7166,7 @@
   {
     "id": "neon-flashlight",
     "name": "Neon Flashlight",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-flashlight.wgsl",
+    "url": "shaders/neon-flashlight.wgsl",
     "description": "Dark environment illuminated by a neon-edge detecting flashlight.",
     "params": [
       {
@@ -7215,7 +7215,7 @@
   {
     "id": "neon-fluid-warp",
     "name": "Neon Fluid Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-fluid-warp.wgsl",
+    "url": "shaders/neon-fluid-warp.wgsl",
     "description": "Distorts the image like a fluid around the mouse, adding neon edges.",
     "params": [
       {
@@ -7263,7 +7263,7 @@
   {
     "id": "neon-pulse",
     "name": "Neon Pulse Distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-pulse.wgsl",
+    "url": "shaders/neon-pulse.wgsl",
     "description": "Distorts the image with a pulsating neon wave emanating from the cursor.",
     "params": [
       {
@@ -7314,7 +7314,7 @@
   {
     "id": "neon-ripple-split",
     "name": "Neon Ripple Split",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-ripple-split.wgsl",
+    "url": "shaders/neon-ripple-split.wgsl",
     "description": "A reactive ripple effect using unified displacement fields and alpha translucency blending. Features spectral tint via mix(), mouse gravity wells, ripple integration, audio-reactive bass envelope, and temporal feedback.",
     "params": [
       {
@@ -7363,7 +7363,7 @@
   {
     "id": "neon-strings",
     "name": "Neon Strings — Blackbody Wire",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-strings.wgsl",
+    "url": "shaders/neon-strings.wgsl",
     "description": "Plucked-string vibration with Planck blackbody thermal emission. Temperature proportional to squared displacement amplitude (kinetic energy density), Stefan-Boltzmann glow (T⁴) per string segment, Newton cooling from antinodes to clamped ends. Audio bass adds vibrato; treble drives plasma shimmer.",
     "params": [
       {
@@ -7414,7 +7414,7 @@
   {
     "id": "neon-warp",
     "name": "Neon Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-warp.wgsl",
+    "url": "shaders/neon-warp.wgsl",
     "description": "Thermal mirage refraction driven by diffusing heat sources, ripples, and blackbody plasma glow.",
     "params": [
       {
@@ -7464,7 +7464,7 @@
     "id": "neural-nexus",
     "name": "Neural Nexus",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neural-nexus.wgsl",
+    "url": "shaders/neural-nexus.wgsl",
     "description": "Biological neural network simulation with pulsing electrical signals; mouse sends shockwaves through synapses.",
     "params": [
       {
@@ -7514,7 +7514,7 @@
   {
     "id": "night-vision-scope",
     "name": "Night Vision Scope",
-    "url": "https://test.1ink.us/image_video_effects/shaders/night-vision-scope.wgsl",
+    "url": "shaders/night-vision-scope.wgsl",
     "description": "Simulates a night vision intensifier tube with a high-clarity scope area following the mouse.",
     "params": [
       {
@@ -7561,7 +7561,7 @@
   {
     "id": "optical-feedback",
     "name": "Optical Feedback Loop",
-    "url": "https://test.1ink.us/image_video_effects/shaders/optical-feedback.wgsl",
+    "url": "shaders/optical-feedback.wgsl",
     "category": "interactive-mouse",
     "description": "Infinite video feedback loop centered on the mouse cursor with audio-pumped zoom, domain-warped drift, hue shifting, depth-aware fade, and temporal accumulation.",
     "tags": [
@@ -7630,7 +7630,7 @@
     "id": "origami-fold",
     "name": "Origami Fold",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/origami-fold.wgsl",
+    "url": "shaders/origami-fold.wgsl",
     "description": "Upgraded paper folding with mountain/valley crease patterns, dihedral angle constraints, Kawasaki-Justin flat-foldable vertices, paper fiber texture, shadow casting, HDR specular highlights on creases, ACES tone mapping, and chromatic edge darkening. Bass drives fold animation speed, mouse performs folds (mountain vs valley by click parity), depth controls paper layer ordering.",
     "params": [
       {
@@ -7692,7 +7692,7 @@
   {
     "id": "oscilloscope-overlay",
     "name": "Oscilloscope Overlay",
-    "url": "https://test.1ink.us/image_video_effects/shaders/oscilloscope-overlay.wgsl",
+    "url": "shaders/oscilloscope-overlay.wgsl",
     "description": "Overlays a real-time luminance waveform of the image scanline at the mouse cursor's vertical position, now with a smoothed bass envelope, treble sparkle, audio-reactive color temperature, HDR tone mapping, and IGN dithering.",
     "params": [
       {
@@ -7747,7 +7747,7 @@
   {
     "id": "paper-burn",
     "name": "Paper Burn",
-    "url": "https://test.1ink.us/image_video_effects/shaders/paper-burn.wgsl",
+    "url": "shaders/paper-burn.wgsl",
     "description": "Interactive paper burn effect that spreads from mouse cursor with realistic charring and ash.",
     "features": [
       "mouse-driven",
@@ -7795,7 +7795,7 @@
   {
     "id": "paper-cutout",
     "name": "Paper Cutout",
-    "url": "https://test.1ink.us/image_video_effects/shaders/paper-cutout.wgsl",
+    "url": "shaders/paper-cutout.wgsl",
     "description": "Quantizes the image into paper layers with drop shadows controlled by the mouse.",
     "params": [
       {
@@ -7841,7 +7841,7 @@
   {
     "id": "parallax-glow-compositor",
     "name": "Parallax Glow Compositor (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/parallax-glow-compositor.wgsl",
+    "url": "shaders/parallax-glow-compositor.wgsl",
     "description": "Compositor that applies chromatic aberration, volumetric glow, and depth-aware compositing for volumetric zooms.",
     "params": [
       {
@@ -7887,7 +7887,7 @@
   {
     "id": "particle-disperse",
     "name": "Particle Disperse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/particle-disperse.wgsl",
+    "url": "shaders/particle-disperse.wgsl",
     "description": "Mouse blows particles away with wind physics. Particles return to original position with spring forces.",
     "params": [
       {
@@ -7932,7 +7932,7 @@
   {
     "id": "particle-swarm",
     "name": "Particle Swarm",
-    "url": "https://test.1ink.us/image_video_effects/shaders/particle-swarm.wgsl",
+    "url": "shaders/particle-swarm.wgsl",
     "description": "Pixels behave like a swarm of particles attracted to the mouse, with spring physics returning them to their origin.",
     "params": [
       {
@@ -7979,7 +7979,7 @@
     "label": "Phosphor Magnifier",
     "name": "Phosphor Magnifier",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phosphor-magnifier.wgsl",
+    "url": "shaders/phosphor-magnifier.wgsl",
     "icon": "search",
     "description": "P22 phosphor decay CRT magnifier with chromatic aberration, barrel distortion, shadow mask, scanline beats, HDR bloom, ACES tone mapping, and afterimage trails. Bass drives excitation, mouse positions lens, depth controls magnification power.",
     "features": [
@@ -8029,7 +8029,7 @@
   {
     "id": "pixel-drag-smear",
     "name": "Pixel Drag Smear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-drag-smear.wgsl",
+    "url": "shaders/pixel-drag-smear.wgsl",
     "description": "Smudge and drag pixels like wet paint, creating persistent trails.",
     "params": [
       {
@@ -8073,7 +8073,7 @@
   },
   {
     "id": "pixel-explode",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-explode.wgsl",
+    "url": "shaders/pixel-explode.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -8122,7 +8122,7 @@
   {
     "id": "pixel-focus",
     "name": "Pixel Focus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-focus.wgsl",
+    "url": "shaders/pixel-focus.wgsl",
     "description": "Applies a mosaic effect everywhere except for a clear focus area around the mouse. Audio-reactive density adds rhythmic pulse to pixelation.",
     "params": [
       {
@@ -8171,7 +8171,7 @@
   },
   {
     "id": "pixel-repel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-repel.wgsl",
+    "url": "shaders/pixel-repel.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -8220,7 +8220,7 @@
   {
     "id": "pixel-reveal",
     "name": "Pixel Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-reveal.wgsl",
+    "url": "shaders/pixel-reveal.wgsl",
     "category": "interactive-mouse",
     "description": "Pixel sorting with threshold-based reveal and temporal noise accumulation. Revealed pixels decay back to hidden over time. Glitch chromatic separation on edges, scanline bands, film grain, and depth-controlled pixel perspective.",
     "params": [
@@ -8272,7 +8272,7 @@
   {
     "id": "pixel-sort-explorer",
     "name": "Pixel Sort Explorer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-sort-explorer.wgsl",
+    "url": "shaders/pixel-sort-explorer.wgsl",
     "description": "Sorts pixels into interval-segmented luma streaks inside a mouse-driven spotlight, with organic line wobble, a traveling scan read-out, and audio-reactive lens breathing.",
     "params": [
       {
@@ -8317,7 +8317,7 @@
   {
     "id": "pixel-sort-radial",
     "name": "Radial Pixel Stretch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-sort-radial.wgsl",
+    "url": "shaders/pixel-sort-radial.wgsl",
     "description": "Radially stretches pixels from the mouse position based on luminance.",
     "params": [
       {
@@ -8362,7 +8362,7 @@
   {
     "id": "pixel-stretch-cross",
     "name": "Pixel Stretch Cross",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-stretch-cross.wgsl",
+    "url": "shaders/pixel-stretch-cross.wgsl",
     "description": "Multi-direction pixel stretch using Fibonacci disk sampling, mouse gravity well, depth-aware attenuation, bass-envelope magnitude, click shockwaves, temporal trails, and layered alpha compositing with depth fading, luminance keying, and accumulative feedback.",
     "features": [
       "mouse-driven",
@@ -8453,7 +8453,7 @@
   {
     "id": "pixel-wind-chimes",
     "name": "Pixel Wind Chimes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-wind-chimes.wgsl",
+    "url": "shaders/pixel-wind-chimes.wgsl",
     "description": "Slices the image into hanging vertical strips that swing like wind chimes when pushed by the mouse.",
     "params": [
       {
@@ -8500,7 +8500,7 @@
   {
     "id": "polar-warp-interactive",
     "name": "Polar Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/polar-warp-interactive.wgsl",
+    "url": "shaders/polar-warp-interactive.wgsl",
     "description": "Maps the image to polar coordinates centered on the mouse with bass-envelope warp strength, velocity-driven spiral twist, click-triggered ripple bursts, chromatic aberration, temporal feedback trails, ACES tone mapping, and depth-aware fading.",
     "features": [
       "mouse-driven",
@@ -8559,7 +8559,7 @@
   {
     "id": "poly-art",
     "name": "Poly Art",
-    "url": "https://test.1ink.us/image_video_effects/shaders/poly-art.wgsl",
+    "url": "shaders/poly-art.wgsl",
     "description": "Transforms the image into a low-poly Voronoi mosaic. Mouse interaction distorts the grid density.",
     "params": [
       {
@@ -8602,7 +8602,7 @@
   {
     "id": "prismatic-3d-compositor",
     "name": "Prismatic 3D Compositor (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/prismatic-3d-compositor.wgsl",
+    "url": "shaders/prismatic-3d-compositor.wgsl",
     "description": "Adds parallax shifting, volumetric glow, chromatic aberration and final composite with depth-aware blending.",
     "params": [
       {
@@ -8651,7 +8651,7 @@
   {
     "id": "prismatic-feedback-loop",
     "name": "Prismatic Feedback Loop (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/prismatic-feedback-loop.wgsl",
+    "url": "shaders/prismatic-feedback-loop.wgsl",
     "description": "Consumes displacement from Pass 1 to create chromatic aberration, temporal feedback, and glowing halos.",
     "params": [
       {
@@ -8700,7 +8700,7 @@
   {
     "id": "psychedelic-noise-flow",
     "name": "Psychedelic Noise Flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/psychedelic-noise-flow.wgsl",
+    "url": "shaders/psychedelic-noise-flow.wgsl",
     "description": "Applies a liquid-like noise flow where RGB channels are separated by phase, creating colorful swirls. Mouse controls flow speed and direction.",
     "params": [
       {
@@ -8745,7 +8745,7 @@
   {
     "id": "quad-mirror",
     "name": "Quad Mirror",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quad-mirror.wgsl",
+    "url": "shaders/quad-mirror.wgsl",
     "description": "4-way kaleidoscope mirror with FBM domain warp at seam boundaries, animated rotation, audio-reactive seam shimmer, chromatic aberration, ACES tone mapping, temporal feedback trails, and layered semantic alpha compositing.",
     "params": [
       {
@@ -8806,7 +8806,7 @@
   {
     "id": "quantized-ripples",
     "name": "Haptic Ripple Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantized-ripples.wgsl",
+    "url": "shaders/quantized-ripples.wgsl",
     "description": "Piezo-inspired ripple interference field with velocity-sensitive impulse strength, blended damping models, rough touch-texture modulation, and quantized color bands.",
     "params": [
       {
@@ -8855,7 +8855,7 @@
   {
     "id": "quantum-cursor",
     "name": "Quantum Cursor",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-cursor.wgsl",
+    "url": "shaders/quantum-cursor.wgsl",
     "description": "Quantized reality field around the cursor with chromatic distortion and audio-reactive pulse.",
     "params": [
       {
@@ -8904,7 +8904,7 @@
   {
     "id": "quantum-flux",
     "name": "Quantum Flux",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-flux.wgsl",
+    "url": "shaders/quantum-flux.wgsl",
     "description": "Simulates quantum instability and probability waves emanating from the mouse cursor, causing jitter and color drift.",
     "params": [
       {
@@ -8949,7 +8949,7 @@
   },
   {
     "id": "quantum-prism",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-prism.wgsl",
+    "url": "shaders/quantum-prism.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -8996,7 +8996,7 @@
   {
     "id": "quantum-ripples",
     "name": "Quantum Ripples",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-ripples.wgsl",
+    "url": "shaders/quantum-ripples.wgsl",
     "description": "Mouse-driven quantum interference waves with domain-warped FBM, divergence-free curl turbulence, Voronoi cellular displacement, SDF portal masking, audio-driven palette, temporal feedback, depth-aware chromatic aberration and audio reactivity.",
     "params": [
       {
@@ -9055,7 +9055,7 @@
   {
     "id": "quantum-superposition",
     "name": "Quantum Superposition",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-superposition.wgsl",
+    "url": "shaders/quantum-superposition.wgsl",
     "description": "Image vibrates between states, stabilizing when observed (mouse hover).",
     "params": [
       {
@@ -9139,7 +9139,7 @@
         "max": 1
       }
     ],
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-tunnel-interactive.wgsl",
+    "url": "shaders/quantum-tunnel-interactive.wgsl",
     "description": "Interactive radial distortion with chromatic aberration, pulsing effects, and audio-reactive glow.",
     "tags": [
       "filter",
@@ -9151,7 +9151,7 @@
   {
     "id": "radial-hex-lens",
     "name": "Radial Hex Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/radial-hex-lens.wgsl",
+    "url": "shaders/radial-hex-lens.wgsl",
     "description": "Interactive hexagonal mosaic lens with radial magnification, FBM organic warp, depth-aware fog, and semantic alpha for slot-chain compositing.",
     "features": [
       "mouse-driven",
@@ -9213,7 +9213,7 @@
     "id": "radial-slit-scan",
     "name": "Radial Slit Scan",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/radial-slit-scan.wgsl",
+    "url": "shaders/radial-slit-scan.wgsl",
     "description": "A time-displacement effect that radiates from the cursor, now enhanced with volumetric glow, cosine palette color cycling, chromatic aberration, split-tone grading, and ACES filmic tone mapping.",
     "features": [
       "mouse-driven",
@@ -9270,7 +9270,7 @@
   {
     "id": "rain-lens-wipe",
     "name": "Rain Lens Wipe",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rain-lens-wipe.wgsl",
+    "url": "shaders/rain-lens-wipe.wgsl",
     "description": "Simulates raindrops on a lens. Use the mouse to wipe them away.",
     "params": [
       {
@@ -9313,7 +9313,7 @@
   {
     "id": "rainbow-vector-field",
     "name": "Rainbow Vector Field (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rainbow-vector-field.wgsl",
+    "url": "shaders/rainbow-vector-field.wgsl",
     "description": "Generates a base rainbow pattern and computes a displacement field (stored to depth) for a follow-up prismatic feedback pass.",
     "params": [
       {
@@ -9360,7 +9360,7 @@
   {
     "id": "raindrop-ripples",
     "name": "Raindrop Ripples",
-    "url": "https://test.1ink.us/image_video_effects/shaders/raindrop-ripples.wgsl",
+    "url": "shaders/raindrop-ripples.wgsl",
     "description": "Raindrops fall creating ripples, but the mouse cursor acts as a shield.",
     "params": [
       {
@@ -9404,7 +9404,7 @@
   {
     "id": "reactive-glass-grid",
     "name": "Reactive Glass Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/reactive-glass-grid.wgsl",
+    "url": "shaders/reactive-glass-grid.wgsl",
     "description": "A grid of refractive glass tiles that light up and distort based on mouse proximity.",
     "params": [
       {
@@ -9447,7 +9447,7 @@
   {
     "id": "reality-tear",
     "name": "Reality Tear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/reality-tear.wgsl",
+    "url": "shaders/reality-tear.wgsl",
     "description": "Rips a hole in the image to reveal a static void underneath.",
     "features": [
       "mouse-driven",
@@ -9493,7 +9493,7 @@
     "id": "refraction-shards",
     "name": "Refraction Shards",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/refraction-shards.wgsl",
+    "url": "shaders/refraction-shards.wgsl",
     "description": "Voronoi crystal shards refract and prism-split the source image, with extra sparkle near the cursor.",
     "params": [
       {
@@ -9542,7 +9542,7 @@
   {
     "id": "refractive-bubbles",
     "name": "Refractive Bubbles",
-    "url": "https://test.1ink.us/image_video_effects/shaders/refractive-bubbles.wgsl",
+    "url": "shaders/refractive-bubbles.wgsl",
     "description": "Floating bubbles around the cursor that distort the background like glass.",
     "params": [
       {
@@ -9587,7 +9587,7 @@
   {
     "id": "rgb-delay-brush",
     "name": "RGB Delay Brush",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-delay-brush.wgsl",
+    "url": "shaders/rgb-delay-brush.wgsl",
     "description": "Reveals past frames in RGB channels. Painting with the mouse creates colorful time-delayed trails.",
     "params": [
       {
@@ -9642,7 +9642,7 @@
   {
     "id": "rgb-fluid",
     "name": "RGB Fluidity",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-fluid.wgsl",
+    "url": "shaders/rgb-fluid.wgsl",
     "description": "Image behaves like a fluid, stirred by the mouse cursor.",
     "params": [
       {
@@ -9689,7 +9689,7 @@
   {
     "id": "rgb-iso-lines",
     "name": "RGB Iso Lines",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-iso-lines.wgsl",
+    "url": "shaders/rgb-iso-lines.wgsl",
     "description": "Visualizes the R, G, and B channels as separated contour maps. Mouse controls the parallax separation.",
     "params": [
       {
@@ -9747,7 +9747,7 @@
   {
     "id": "rgb-ripple-waves",
     "name": "RGB Ripple Waves",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-ripple-waves.wgsl",
+    "url": "shaders/rgb-ripple-waves.wgsl",
     "description": "Separates RGB channels into distinct ripple waves emanating from the mouse cursor.",
     "features": [
       "mouse-driven",
@@ -9796,7 +9796,7 @@
   {
     "id": "rgb-shift-brush",
     "name": "RGB Shift Brush",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-shift-brush.wgsl",
+    "url": "shaders/rgb-shift-brush.wgsl",
     "description": "Paint with RGB channel separation trails using the mouse.",
     "params": [
       {
@@ -9840,7 +9840,7 @@
   {
     "id": "rgb-split-glitch",
     "name": "RGB Split Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-split-glitch.wgsl",
+    "url": "shaders/rgb-split-glitch.wgsl",
     "description": "Splits RGB channels based on mouse proximity.",
     "params": [
       {
@@ -9885,7 +9885,7 @@
   {
     "id": "scan-slice",
     "name": "Scan Slice",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scan-slice.wgsl",
+    "url": "shaders/scan-slice.wgsl",
     "description": "Mouse X selects a vertical slice; Mouse Y offsets it with chromatic aberration. Audio-reactive edge glow pulses to bass.",
     "params": [
       {
@@ -9933,7 +9933,7 @@
   {
     "id": "scanline-sorting",
     "name": "Scanline Sorting",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scanline-sorting.wgsl",
+    "url": "shaders/scanline-sorting.wgsl",
     "description": "Sorts pixels by luminance within a moving scanline band using a tile-wide early-exit and a shared-memory bitonic sort over local 16-pixel segments. Reacts to audio bass for intensified sorting, applies ACES tone mapping, and preserves depth and semantic alpha.",
     "params": [
       {
@@ -9990,7 +9990,7 @@
   {
     "id": "scanline-tear",
     "name": "Scanline Tear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scanline-tear.wgsl",
+    "url": "shaders/scanline-tear.wgsl",
     "description": "Authentic analog video interlacing simulation with field-based temporal offset, HSync/VSync modeling, and VHS-style tracking errors.",
     "params": [
       {
@@ -10050,7 +10050,7 @@
   {
     "id": "scanline-wave",
     "name": "Scanline Wave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scanline-wave.wgsl",
+    "url": "shaders/scanline-wave.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -10114,7 +10114,7 @@
   {
     "id": "selective-color",
     "name": "Voronoi Multi-Focal Selective",
-    "url": "https://test.1ink.us/image_video_effects/shaders/selective-color.wgsl",
+    "url": "shaders/selective-color.wgsl",
     "description": "Voronoi multi-focal selective desaturation with chromatic aberration, fractal noise masking, polar sectors, SDF shapes, ripple propagation, and depth-aware edge detection.",
     "params": [
       {
@@ -10162,7 +10162,7 @@
   {
     "id": "sequin-flip",
     "name": "Sequin Flip",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sequin-flip.wgsl",
+    "url": "shaders/sequin-flip.wgsl",
     "description": "Simulates reversible sequins that flip to reveal a metallic back when brushed by the mouse.",
     "params": [
       {
@@ -10205,7 +10205,7 @@
   {
     "id": "signal-tuner",
     "name": "Signal Tuner",
-    "url": "https://test.1ink.us/image_video_effects/shaders/signal-tuner.wgsl",
+    "url": "shaders/signal-tuner.wgsl",
     "description": "TV-style signal interference with smoothed audio envelope, spring-damped mouse follow, and temporal feedback trails.",
     "params": [
       {
@@ -10252,7 +10252,7 @@
     "id": "sketch-reveal",
     "name": "Sketch Reveal",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sketch-reveal.wgsl",
+    "url": "shaders/sketch-reveal.wgsl",
     "description": "Gradient-directed pencil and charcoal cross-hatching with graphite sheen, paper tooth texture, smudge effects, and chromatic edge darkening. Bass drives reveal progression, mouse acts as the pencil, depth controls stroke size perspective.",
     "params": [
       {
@@ -10304,7 +10304,7 @@
   {
     "id": "sliding-tile-glitch",
     "name": "Sliding Tile Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sliding-tile-glitch.wgsl",
+    "url": "shaders/sliding-tile-glitch.wgsl",
     "description": "Grid tiles slide and glitch when touched by the mouse.",
     "params": [
       {
@@ -10347,7 +10347,7 @@
   {
     "id": "slinky-distort",
     "name": "Slinky Distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/slinky-distort.wgsl",
+    "url": "shaders/slinky-distort.wgsl",
     "description": "Slices the image into horizontal bands that shift back and forth like a slinky.",
     "params": [
       {
@@ -10394,7 +10394,7 @@
     "id": "solarize-warp",
     "name": "Solarize Warp",
     "category": "interactive-mouse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/solarize-warp.wgsl",
+    "url": "shaders/solarize-warp.wgsl",
     "description": "Sabattier solarization with domain-warped fBm displacement, Mackie edge lines, split-tone shadows/highlights, ACES tone mapping, and film grain. Bass drives threshold oscillation, mouse warps field, depth controls parallax.",
     "params": [
       {
@@ -10443,7 +10443,7 @@
   {
     "id": "sonar-pulse",
     "name": "Sonar Pulse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sonar-pulse.wgsl",
+    "url": "shaders/sonar-pulse.wgsl",
     "description": "Radial sonar waves emitting from the cursor that distort and scan the image. Now with audio reactivity.",
     "params": [
       {
@@ -10495,7 +10495,7 @@
   {
     "id": "sonar-reveal",
     "name": "Sonar Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sonar-reveal.wgsl",
+    "url": "shaders/sonar-reveal.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -10544,7 +10544,7 @@
   {
     "id": "sonic-distortion",
     "name": "Sonic Distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sonic-distortion.wgsl",
+    "url": "shaders/sonic-distortion.wgsl",
     "description": "Superellipse-masked sonic distortion with Lissajous wave interference, FBM domain warping, rose curve modulation, and alpha-ghosted echo trails.",
     "params": [
       {
@@ -10593,7 +10593,7 @@
   {
     "id": "spectral-brush",
     "name": "Spectral Brush",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-brush.wgsl",
+    "url": "shaders/spectral-brush.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -10648,7 +10648,7 @@
   {
     "id": "spectral-distortion",
     "name": "Spectral Distortion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-distortion.wgsl",
+    "url": "shaders/spectral-distortion.wgsl",
     "description": "RGB channels split and warp based on noise, mouse proximity, and bass-driven audio reactivity.",
     "params": [
       {
@@ -10698,7 +10698,7 @@
   {
     "id": "spectral-smear",
     "name": "Spectral Smear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-smear.wgsl",
+    "url": "shaders/spectral-smear.wgsl",
     "description": "Paints flowing spectral trails that follow the mouse, with organic noise-warped smearing and a rainbow fringe around the brush.",
     "params": [
       {
@@ -10745,7 +10745,7 @@
   {
     "id": "spectral-waves",
     "name": "Luma Ripple",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-waves.wgsl",
+    "url": "shaders/spectral-waves.wgsl",
     "description": "Luminance-reactive waves ripple out from the mouse cursor, displacing the image with chromatic aberration. Audio bass boosts wave amplitude.",
     "params": [
       {
@@ -10798,7 +10798,7 @@
   {
     "id": "sphere-projection",
     "name": "Sphere Projection",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sphere-projection.wgsl",
+    "url": "shaders/sphere-projection.wgsl",
     "description": "Projects the image onto a 3D sphere that can be rotated with the mouse.",
     "features": [
       "mouse-driven",
@@ -10854,7 +10854,7 @@
   {
     "id": "split-dimension",
     "name": "Split Dimension",
-    "url": "https://test.1ink.us/image_video_effects/shaders/split-dimension.wgsl",
+    "url": "shaders/split-dimension.wgsl",
     "description": "Splits the screen into two dimensions. One side is normal, the other is a glitched negative. The split follows the mouse.",
     "features": [
       "mouse-driven",
@@ -10900,7 +10900,7 @@
   {
     "id": "stereoscopic-3d",
     "name": "Stereoscopic 3D",
-    "url": "https://test.1ink.us/image_video_effects/shaders/stereoscopic-3d.wgsl",
+    "url": "shaders/stereoscopic-3d.wgsl",
     "description": "Interactive anaglyph 3D effect. Mouse X/Y controls convergence bias and focal plane with spring-damped smoothing. Audio bass drives a smoothed separation pulse and glitch amplitude. Depth-aware pass-through and temporal state feedback create ghost trails and slot-chain-ready output.",
     "params": [
       {
@@ -10955,7 +10955,7 @@
   {
     "id": "stipple-engraving",
     "name": "Stipple Engraving",
-    "url": "https://test.1ink.us/image_video_effects/shaders/stipple-engraving.wgsl",
+    "url": "shaders/stipple-engraving.wgsl",
     "description": "Converts the image into a vintage stipple engraving. Mouse proximity acts as a spotlight, revealing details by increasing luminance.",
     "features": [
       "mouse-driven"
@@ -10998,7 +10998,7 @@
   {
     "id": "strip-scan-glitch",
     "name": "Strip Scan Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/strip-scan-glitch.wgsl",
+    "url": "shaders/strip-scan-glitch.wgsl",
     "description": "Slices the image into vertical strips that drift and jitter, controlled by mouse position.",
     "params": [
       {
@@ -11044,7 +11044,7 @@
   {
     "id": "swirling-void",
     "name": "Swirling Void",
-    "url": "https://test.1ink.us/image_video_effects/shaders/swirling-void.wgsl",
+    "url": "shaders/swirling-void.wgsl",
     "description": "A powerful vortex that twists the image around the mouse cursor, now with a photorealistic accretion disk via blackbody temperature, OkLab color mixing, and ACES filmic tonemapping.",
     "params": [
       {
@@ -11093,7 +11093,7 @@
   {
     "id": "synthwave-grid-warp",
     "name": "Synthwave Grid Warp",
-    "url": "https://test.1ink.us/image_video_effects/shaders/synthwave-grid-warp.wgsl",
+    "url": "shaders/synthwave-grid-warp.wgsl",
     "description": "3D perspective-projected synthwave floor with atmospheric fog, sun, and mountain silhouettes.",
     "features": [
       "mouse-driven",
@@ -11148,7 +11148,7 @@
   {
     "id": "temporal-rift",
     "name": "Temporal Rift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-rift.wgsl",
+    "url": "shaders/temporal-rift.wgsl",
     "description": "Creates temporal echoes and time-smearing trails where the mouse moves.",
     "params": [
       {
@@ -11191,7 +11191,7 @@
   {
     "id": "temporal-slit-paint",
     "name": "Temporal Slit Paint",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-slit-paint.wgsl",
+    "url": "shaders/temporal-slit-paint.wgsl",
     "description": "Parametric brush painting with shape selection, velocity-aware smearing, and diffusion-based color bleeding onto a temporal canvas.",
     "features": [
       "mouse-driven"
@@ -11244,7 +11244,7 @@
   {
     "id": "thermal-touch",
     "name": "Thermal Touch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/thermal-touch.wgsl",
+    "url": "shaders/thermal-touch.wgsl",
     "category": "interactive-mouse",
     "description": "Heat diffusion simulation with Gaussian blur approximation, blackbody radiation color mapping, persistent mouse heat trails, and HDR glow with ACES tone mapping.",
     "params": [
@@ -11294,7 +11294,7 @@
   {
     "id": "tile-twist",
     "name": "Tile Twist",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tile-twist.wgsl",
+    "url": "shaders/tile-twist.wgsl",
     "description": "Grid tiles twist and rotate based on mouse proximity and an envelope-smoothed bass pulse, with mids-driven hue shifts, treble sparkle, FBM domain warping, and SDF edge masking.",
     "params": [
       {
@@ -11347,7 +11347,7 @@
   {
     "id": "vaporwave-horizon",
     "name": "Vaporwave Horizon",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vaporwave-horizon.wgsl",
+    "url": "shaders/vaporwave-horizon.wgsl",
     "description": "Transforms the image into a retro-futuristic landscape with a mouse-controlled horizon and grid.",
     "params": [
       {
@@ -11394,7 +11394,7 @@
   {
     "id": "velocity-field-paint",
     "name": "Velocity Field — Vorticity Confinement",
-    "url": "https://test.1ink.us/image_video_effects/shaders/velocity-field-paint.wgsl",
+    "url": "shaders/velocity-field-paint.wgsl",
     "description": "Mouse-driven velocity field with vorticity confinement (Fedkiw et al. 2001). Computes ω=∂v_y/∂x−∂v_x/∂y from 4-neighbour finite differences, applies F=ε·(η̂×ω̂) confinement force to restore turbulent detail. Enstrophy (ω²) colour coding: cyan=CCW, magenta=CW. Audio bass drives force, treble drives confinement strength.",
     "features": [
       "mouse-driven",
@@ -11445,7 +11445,7 @@
   {
     "id": "velvet-vortex",
     "name": "Velvet Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/velvet-vortex.wgsl",
+    "url": "shaders/velvet-vortex.wgsl",
     "description": "A spiraling, velvety distortion that swirls video content around the mouse cursor.",
     "params": [
       {
@@ -11493,7 +11493,7 @@
   {
     "id": "venetian-blinds",
     "name": "Venetian Blinds",
-    "url": "https://test.1ink.us/image_video_effects/shaders/venetian-blinds.wgsl",
+    "url": "shaders/venetian-blinds.wgsl",
     "description": "Interactive venetian blinds effect. Mouse Y controls the openness of the slats.",
     "params": [
       {
@@ -11538,7 +11538,7 @@
   {
     "id": "vertical-slice-wave",
     "name": "Vertical Slice Wave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vertical-slice-wave.wgsl",
+    "url": "shaders/vertical-slice-wave.wgsl",
     "description": "Splits the image into vertical strips that oscillate with spring-damped mouse follow, attack/release audio envelope, and temporal feedback trails. Mouse X/Y control frequency/amplitude with smooth lag. Audio bass drives wave amplitude.",
     "params": [
       {
@@ -11587,7 +11587,7 @@
   {
     "id": "vhs-jog",
     "name": "VHS Jog Wheel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vhs-jog.wgsl",
+    "url": "shaders/vhs-jog.wgsl",
     "description": "Simulate VHS tracking and jogging. Mouse X controls distortion (jog), Mouse Y controls tracking.",
     "params": [
       {
@@ -11634,7 +11634,7 @@
   {
     "id": "vhs-tracking-mouse",
     "name": "VHS Tracking",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vhs-tracking-mouse.wgsl",
+    "url": "shaders/vhs-tracking-mouse.wgsl",
     "description": "A vertical tracking bar distortion controlled by mouse height with audio-reactive intensity.",
     "params": [
       {
@@ -11686,7 +11686,7 @@
   {
     "id": "virtual-lens",
     "name": "Virtual Lens",
-    "url": "https://test.1ink.us/image_video_effects/shaders/virtual-lens.wgsl",
+    "url": "shaders/virtual-lens.wgsl",
     "description": "A virtual magnifying glass with alpha translucency blending. Single magnification displacement plus spectral tint via mix. Alpha driven by lens edge falloff and Fresnel reflectance with depth-aware attenuation.",
     "params": [
       {
@@ -11732,7 +11732,7 @@
   {
     "id": "volumetric-depth-zoom",
     "name": "Volumetric Depth Zoom (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/volumetric-depth-zoom.wgsl",
+    "url": "shaders/volumetric-depth-zoom.wgsl",
     "description": "Raymarched volumetric zoom using multiple depth slices, DOF, parallax and edge specular lighting.",
     "params": [
       {
@@ -11781,7 +11781,7 @@
   {
     "id": "volumetric-god-rays",
     "name": "Volumetric God Rays",
-    "url": "https://test.1ink.us/image_video_effects/shaders/volumetric-god-rays.wgsl",
+    "url": "shaders/volumetric-god-rays.wgsl",
     "description": "Ray-marched volumetric lighting with Mie scattering phase function, dust particle scatter, chromatic dispersion at shaft edges, ACES tone mapping, HDR bloom, and atmospheric haze. Bass drives dust density, mouse positions the light source, depth controls shaft occlusion and extinction.",
     "params": [
       {
@@ -11831,7 +11831,7 @@
   {
     "id": "volumetric-rainbow-clouds",
     "name": "Volumetric Rainbow Clouds (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/volumetric-rainbow-clouds.wgsl",
+    "url": "shaders/volumetric-rainbow-clouds.wgsl",
     "description": "Generates 3D noise clouds with normals, lighting, and depth-aware rainbow coloring for a volumetric prismatic effect.",
     "params": [
       {
@@ -11877,7 +11877,7 @@
   {
     "id": "voronoi-glass",
     "name": "Voronoi Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-glass.wgsl",
+    "url": "shaders/voronoi-glass.wgsl",
     "description": "Refractive glass cells based on Voronoi patterns that shift with the mouse.",
     "params": [
       {
@@ -11927,7 +11927,7 @@
   {
     "id": "voronoi-light",
     "name": "Voronoi Light",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-light.wgsl",
+    "url": "shaders/voronoi-light.wgsl",
     "description": "Voronoi cells light up and react when the mouse is near.",
     "params": [
       {
@@ -12005,7 +12005,7 @@
         "max": 1
       }
     ],
-    "url": "https://test.1ink.us/image_video_effects/shaders/voronoi-shatter.wgsl",
+    "url": "shaders/voronoi-shatter.wgsl",
     "description": "Breaks the image into crystalline shards that react to mouse movement.",
     "tags": [
       "filter",
@@ -12015,7 +12015,7 @@
   {
     "id": "vortex-drag",
     "name": "Vortex Drag",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vortex-drag.wgsl",
+    "url": "shaders/vortex-drag.wgsl",
     "description": "Twisting vortex distortion that follows the mouse cursor.",
     "params": [
       {
@@ -12064,7 +12064,7 @@
   {
     "id": "x-ray-reveal",
     "name": "X-Ray Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/x-ray-reveal.wgsl",
+    "url": "shaders/x-ray-reveal.wgsl",
     "description": "Interactive X-Ray lens that reveals an inverted, edge-enhanced internal structure.",
     "params": [
       {

--- a/public/shader-lists/lighting-effects.json
+++ b/public/shader-lists/lighting-effects.json
@@ -2,7 +2,7 @@
   {
     "id": "alpha-aurora-bands",
     "name": "Alpha Aurora Bands",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-aurora-bands.wgsl",
+    "url": "shaders/alpha-aurora-bands.wgsl",
     "description": "Physically-motivated aurora borealis simulation with emission-line spectral decomposition. RGB stores oxygen green, oxygen red, and nitrogen blue emission intensities. Alpha tracks altitude layer index. Mouse controls solar wind direction; ripples trigger magnetic reconnection substorms.",
     "tags": [
       "aurora",
@@ -60,7 +60,7 @@
   {
     "id": "aurora-rift-2-pass1",
     "name": "Aurora Rift 2 (Pass 1: Enhanced Volumetric)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-2-pass1.wgsl",
+    "url": "shaders/aurora-rift-2-pass1.wgsl",
     "description": "Enhanced volumetric aurora with improved flow dynamics. First pass of 2-pass system.",
     "features": [
       "multi-pass-1",
@@ -117,7 +117,7 @@
   {
     "id": "aurora-rift-2-pass2",
     "name": "Aurora Rift 2 (Pass 2: Enhanced Scattering)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-2-pass2.wgsl",
+    "url": "shaders/aurora-rift-2-pass2.wgsl",
     "description": "Enhanced atmospheric scattering with richer color grading. Second pass of 2-pass system.",
     "features": [
       "multi-pass-2",
@@ -174,7 +174,7 @@
   {
     "id": "aurora-rift-pass1",
     "name": "Aurora Rift (Pass 1: Volumetric)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-pass1.wgsl",
+    "url": "shaders/aurora-rift-pass1.wgsl",
     "description": "Raymarches volumetric aurora with curl-driven flow. First pass of 2-pass system.",
     "features": [
       "multi-pass-1",
@@ -231,7 +231,7 @@
   {
     "id": "aurora-rift-pass2",
     "name": "Aurora Rift (Pass 2: Atmospheric Scattering)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora-rift-pass2.wgsl",
+    "url": "shaders/aurora-rift-pass2.wgsl",
     "description": "Atmospheric scattering, color grading, and tone mapping. Second pass of 2-pass system.",
     "features": [
       "multi-pass-2",
@@ -288,7 +288,7 @@
   {
     "id": "aurora_borealis",
     "name": "Aurora Borealis",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aurora_borealis.wgsl",
+    "url": "shaders/aurora_borealis.wgsl",
     "description": "Northern lights with flowing ribbon curves, curl noise turbulence, altitude-based coloring (green to red), and starfield background",
     "tags": [
       "aurora",
@@ -344,7 +344,7 @@
     "id": "cinematic-flare",
     "name": "Cinematic Flare",
     "category": "lighting-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cinematic-flare.wgsl",
+    "url": "shaders/cinematic-flare.wgsl",
     "description": "Physically-based lens flare with Cooke triplet ghost reflections, 6-blade diffraction starburst, scatter halo, anamorphic streaks, rainbow chromatic aberration, ACES tone mapping, and film grain. Mouse positions light source.",
     "features": [
       "audio-reactive",
@@ -400,7 +400,7 @@
   {
     "id": "divine-light-gpt52",
     "name": "Divine Light Cathedral gpt52",
-    "url": "https://test.1ink.us/image_video_effects/shaders/divine-light-gpt52.wgsl",
+    "url": "shaders/divine-light-gpt52.wgsl",
     "description": "Expanded volumetric rays with dust motes and warm cinematic bloom.",
     "params": [
       {
@@ -450,7 +450,7 @@
   {
     "id": "divine-light",
     "name": "Divine Light",
-    "url": "https://test.1ink.us/image_video_effects/shaders/divine-light.wgsl",
+    "url": "shaders/divine-light.wgsl",
     "description": "Volumetric god rays emanating from cursor position. Creates cinematic light beam effects.",
     "params": [
       {
@@ -497,7 +497,7 @@
   {
     "id": "dynamic-lens-flares",
     "name": "Dynamic Lens Flares",
-    "url": "https://test.1ink.us/image_video_effects/shaders/dynamic-lens-flares.wgsl",
+    "url": "shaders/dynamic-lens-flares.wgsl",
     "description": "Cinematic lens flare following cursor. Generates ghost elements and chromatic artifacts.",
     "params": [
       {
@@ -542,7 +542,7 @@
   {
     "id": "lens-flare-brush",
     "name": "Lens Flare Brush",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lens-flare-brush.wgsl",
+    "url": "shaders/lens-flare-brush.wgsl",
     "description": "Generates anamorphic lens flares from bright pixels near the mouse.",
     "params": [
       {
@@ -591,7 +591,7 @@
   {
     "id": "matrix_digital_rain",
     "name": "Matrix Digital Rain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/matrix_digital_rain.wgsl",
+    "url": "shaders/matrix_digital_rain.wgsl",
     "description": "Matrix digital rain with cascading characters, decoding effect, trail fades, and glow. Alpha tracks character brightness.",
     "tags": [
       "matrix",
@@ -647,7 +647,7 @@
   {
     "id": "neon-light",
     "name": "Neon Light",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-light.wgsl",
+    "url": "shaders/neon-light.wgsl",
     "description": "Blackbody edge emission with Fresnel-bright depth normals, thermal fog, and mouse-heated hotspots.",
     "params": [
       {
@@ -698,7 +698,7 @@
   {
     "id": "neon-pulse-edge",
     "name": "Neon Pulse Edge",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-pulse-edge.wgsl",
+    "url": "shaders/neon-pulse-edge.wgsl",
     "description": "3×3 Sobel edge detection with multi-layer bloom (tight core + wide halo + diffuse), direction-based hue cycling, depth-aware glow intensity, and audio-reactive pulsing.",
     "features": [
       "mouse-driven",
@@ -753,7 +753,7 @@
   {
     "id": "sim-volumetric-fake-em",
     "name": "Volumetric Fake + EM Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-volumetric-fake-em.wgsl",
+    "url": "shaders/sim-volumetric-fake-em.wgsl",
     "description": "God rays with mouse electromagnetic field distortion. Electric field bends light rays; magnetic field causes chromatic RGB separation. Click ripples spawn secondary light charges.",
     "features": [
       "simulation",
@@ -827,7 +827,7 @@
   {
     "id": "temporal_echo",
     "name": "Temporal Echo",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal_echo.wgsl",
+    "url": "shaders/temporal_echo.wgsl",
     "description": "Multi-frame echo accumulation with hue-rotating trails, chromatic aberration on older echoes, depth-layered decay, and audio-reactive beat flash.",
     "tags": [
       "temporal",
@@ -881,7 +881,7 @@
   {
     "id": "underwater_caustics",
     "name": "Underwater Caustics",
-    "url": "https://test.1ink.us/image_video_effects/shaders/underwater_caustics.wgsl",
+    "url": "shaders/underwater_caustics.wgsl",
     "description": "Realistic underwater caustics with Gerstner wave surface simulation, refracted light patterns, god rays, and depth-based alpha",
     "tags": [
       "water",

--- a/public/shader-lists/liquid-effects.json
+++ b/public/shader-lists/liquid-effects.json
@@ -2,7 +2,7 @@
   {
     "id": "glass-wipes",
     "name": "Rainy Window",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glass-wipes.wgsl",
+    "url": "shaders/glass-wipes.wgsl",
     "description": "Simulates rain on a window that distorts the view. Use the mouse to wipe the glass clean.",
     "features": [
       "mouse-driven"
@@ -45,7 +45,7 @@
   {
     "id": "ink-marbling",
     "name": "Ink Marbling",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ink-marbling.wgsl",
+    "url": "shaders/ink-marbling.wgsl",
     "description": "Distorts the image with fluid, ink-like domain warping.",
     "features": [
       "mouse-driven"
@@ -92,7 +92,7 @@
   {
     "id": "kimi-liquid-glass",
     "name": "Kimi Liquid Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/kimi_liquid_glass.wgsl",
+    "url": "shaders/kimi_liquid_glass.wgsl",
     "description": "Realistic liquid surface with caustics, chromatic refraction, and specular highlights.",
     "features": [
       "mouse-driven",
@@ -148,7 +148,7 @@
   {
     "id": "liquid-displacement",
     "name": "Liquid Displacement",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-displacement.wgsl",
+    "url": "shaders/liquid-displacement.wgsl",
     "description": "Navier-Stokes fluid simulation for realistic water-like displacement. Features swirling eddies, vortices, and volume-conserving flow with pressure projection.",
     "params": [
       {
@@ -204,7 +204,7 @@
   {
     "id": "liquid-fast",
     "name": "Liquid Fast",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-fast.wgsl",
+    "url": "shaders/liquid-fast.wgsl",
     "description": "Fast analytical liquid ripples with low-sample motion blur, depth-aware flow, audio acceleration, and spectral edge highlights.",
     "tags": [
       "filter",
@@ -300,7 +300,7 @@
   {
     "id": "liquid-glitch",
     "name": "Liquid Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-glitch.wgsl",
+    "url": "shaders/liquid-glitch.wgsl",
     "description": "Block-quantized liquid smearing with audio-reactive signal corruption, chromatic splitting, click bursts, and temporal datamosh trails.",
     "tags": [
       "filter",
@@ -397,7 +397,7 @@
   {
     "id": "liquid-jelly",
     "name": "Liquid Jelly",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-jelly.wgsl",
+    "url": "shaders/liquid-jelly.wgsl",
     "description": "Spring-damped jelly deformation with subsurface scattering, audio-responsive elasticity, depth masking, and temporal wobble trails.",
     "features": [
       "upgraded-rgba",
@@ -495,7 +495,7 @@
   {
     "id": "liquid-metal",
     "name": "Liquid Metal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-metal.wgsl",
+    "url": "shaders/liquid-metal.wgsl",
     "description": "PBR mercury surface with FBM height field, Schlick-Fresnel reflectance, chromatic RGB dispersion, depth-aware pooling, and audio-reactive surface pulsing.",
     "features": [
       "mouse-driven",
@@ -552,7 +552,7 @@
   {
     "id": "liquid-mirror",
     "name": "Liquid Mirror",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-mirror.wgsl",
+    "url": "shaders/liquid-mirror.wgsl",
     "description": "Metallic liquid surface that reflects the image and ripples under the mouse.",
     "params": [
       {
@@ -595,7 +595,7 @@
   {
     "id": "liquid-oil",
     "name": "Liquid Oil",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-oil.wgsl",
+    "url": "shaders/liquid-oil.wgsl",
     "description": "",
     "tags": [
       "filter",
@@ -650,7 +650,7 @@
   {
     "id": "liquid-optimized-pass1",
     "name": "Liquid Optimized (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-optimized-pass1.wgsl",
+    "url": "shaders/liquid-optimized-pass1.wgsl",
     "description": "Physics simulation pass: capillary wave dynamics, Laplace pressure, ripple propagation, and ambient micro-ripples. Outputs height field state to dataTextureA.",
     "tags": [
       "liquid",
@@ -706,7 +706,7 @@
   {
     "id": "liquid-optimized-pass2",
     "name": "Liquid Optimized (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-optimized-pass2.wgsl",
+    "url": "shaders/liquid-optimized-pass2.wgsl",
     "description": "Fluid rendering pass: Fresnel reflection, Beer-Lambert absorption, specular highlights, and alpha blending. Reads physics state from dataTextureC.",
     "tags": [
       "liquid",
@@ -761,7 +761,7 @@
   {
     "id": "liquid-optimized",
     "name": "Liquid Surface Tension (Optimized)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-optimized.wgsl",
+    "url": "shaders/liquid-optimized.wgsl",
     "description": "Surface tension liquid simulation with shared memory optimization. Uses workgroup-local caching to reduce texture fetches by 80% for 8-10x performance improvement. Audio reactivity drives ambient wave amplitude and virtual ripple sources.",
     "tags": [
       "liquid",
@@ -815,7 +815,7 @@
   {
     "id": "liquid-pass1",
     "name": "Liquid (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-pass1.wgsl",
+    "url": "shaders/liquid-pass1.wgsl",
     "description": "Capillary wave physics pass: surface tension simulation with Laplacian and biharmonic operators, gravity waves, ripple sources, and ambient micro-ripples. Outputs persistent height field to dataTextureA.",
     "tags": [
       "liquid",
@@ -870,7 +870,7 @@
   {
     "id": "liquid-pass2",
     "name": "Liquid (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-pass2.wgsl",
+    "url": "shaders/liquid-pass2.wgsl",
     "description": "Fluid rendering pass: surface normal calculation, Snell's law refraction, Fresnel reflection, Beer-Lambert wavelength-dependent absorption, specular highlights, and physics-based alpha blending.",
     "tags": [
       "liquid",
@@ -925,7 +925,7 @@
   {
     "id": "liquid-perspective",
     "name": "Liquid Perspective",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-perspective.wgsl",
+    "url": "shaders/liquid-perspective.wgsl",
     "description": "Depth-aware liquid perspective warp with silhouette-safe parallax, canonical mouse interaction, audio-reactive ripples, and bioluminescent edges.",
     "params": [
       {
@@ -1021,7 +1021,7 @@
   {
     "id": "liquid-rainbow-prismatic",
     "name": "Liquid Rainbow Prismatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-rainbow-prismatic.wgsl",
+    "url": "shaders/liquid-rainbow-prismatic.wgsl",
     "description": "Liquid Rainbow Prismatic",
     "tags": [
       "liquid-rainbow",
@@ -1076,7 +1076,7 @@
   {
     "id": "liquid-rainbow",
     "name": "Liquid Rainbow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-rainbow.wgsl",
+    "url": "shaders/liquid-rainbow.wgsl",
     "description": "Thin-film liquid refraction with spectral ripple crests, Fresnel edge color, audio-reactive dispersion, and depth-aware compositing.",
     "tags": [
       "filter",
@@ -1172,7 +1172,7 @@
   {
     "id": "liquid-rgb",
     "name": "Liquid RGB",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-rgb.wgsl",
+    "url": "shaders/liquid-rgb.wgsl",
     "description": "Viscous RGB refraction with wavelength-dependent absorption, audio-reactive caustic fringes, and depth-sensitive channel separation.",
     "tags": [
       "filter",
@@ -1268,7 +1268,7 @@
   {
     "id": "liquid-smear",
     "name": "Liquid Smear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-smear.wgsl",
+    "url": "shaders/liquid-smear.wgsl",
     "description": "Smudge pixels like wet paint with your mouse.",
     "params": [
       {
@@ -1312,7 +1312,7 @@
   {
     "id": "liquid-tensor-vortex",
     "name": "Liquid Tensor Vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-tensor-vortex.wgsl",
+    "url": "shaders/liquid-tensor-vortex.wgsl",
     "description": "A 3D tensor field that melts and reforms like liquid metal under mouse vorticity, with bass-driven surface tension and transmission alpha that lets the background breathe through the folds.",
     "tags": [
       "liquid",
@@ -1367,7 +1367,7 @@
   {
     "id": "liquid-v1",
     "name": "Liquid (Ambient)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-v1.wgsl",
+    "url": "shaders/liquid-v1.wgsl",
     "description": "",
     "tags": [
       "filter",
@@ -1411,7 +1411,7 @@
   {
     "id": "liquid-viscous-grokcf1",
     "name": "Liquid Viscous Nebula grokcf1",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-viscous-grokcf1.wgsl",
+    "url": "shaders/liquid-viscous-grokcf1.wgsl",
     "description": "Cosmic viscous flow with multi-octave nebula warping, emissive veins, depth parallax, audio reactivity, and persistent trails.",
     "tags": [
       "filter",
@@ -1508,7 +1508,7 @@
   {
     "id": "liquid-viscous-simple",
     "name": "Liquid Viscous (Simple)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-viscous-simple.wgsl",
+    "url": "shaders/liquid-viscous-simple.wgsl",
     "description": "Viscous laminar flow with cohesive smoothing, audio-reactive click vortices, depth-aware motion, and subtle spectral film.",
     "tags": [
       "filter",
@@ -1604,7 +1604,7 @@
   {
     "id": "liquid-viscous",
     "name": "Liquid Viscous",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-viscous.wgsl",
+    "url": "shaders/liquid-viscous.wgsl",
     "description": "",
     "tags": [
       "filter",
@@ -1659,7 +1659,7 @@
   {
     "id": "liquid-zoom",
     "name": "Liquid Zoom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid-zoom.wgsl",
+    "url": "shaders/liquid-zoom.wgsl",
     "description": "",
     "features": [
       "mouse-driven"
@@ -1706,7 +1706,7 @@
   {
     "id": "liquid",
     "name": "Liquid (Interactive)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/liquid.wgsl",
+    "url": "shaders/liquid.wgsl",
     "description": "",
     "tags": [
       "filter",
@@ -1762,7 +1762,7 @@
   },
   {
     "id": "luma-melt-interactive",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-melt-interactive.wgsl",
+    "url": "shaders/luma-melt-interactive.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1814,7 +1814,7 @@
     "id": "luma-velocity-melt",
     "name": "Luma Velocity Melt",
     "category": "liquid-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-velocity-melt.wgsl",
+    "url": "shaders/luma-velocity-melt.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1870,7 +1870,7 @@
     "name": "Rain Ripples",
     "category": "liquid-effects",
     "type": "compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rain-ripples.wgsl",
+    "url": "shaders/rain-ripples.wgsl",
     "description": "Interactive water ripples and raindrops with FBM micro-ripples, depth-aware fog, displacement-driven chromatic aberration, specular highlights, and ACES tone mapping.",
     "features": [
       "mouse-driven",
@@ -1941,7 +1941,7 @@
   {
     "id": "viscous-drag",
     "name": "Viscous Drag",
-    "url": "https://test.1ink.us/image_video_effects/shaders/viscous-drag.wgsl",
+    "url": "shaders/viscous-drag.wgsl",
     "description": "The screen becomes a thick, viscous fluid that ripples and deforms under your touch.",
     "features": [
       "mouse-driven"

--- a/public/shader-lists/post-processing.json
+++ b/public/shader-lists/post-processing.json
@@ -2,7 +2,7 @@
   {
     "id": "audio-reactive-pyramid",
     "name": "Audio Reactive Pyramid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/audio-reactive-pyramid.wgsl",
+    "url": "shaders/audio-reactive-pyramid.wgsl",
     "category": "post-processing",
     "description": "Three-level Laplacian-style sharpening pyramid whose band intensities are driven by matching FFT frequency bands: coarse detail by bass bins (0–12), mid detail by mid bins (13–50), fine detail by treble bins (51–127). Compatible with the ford442/flac_player FFT wire format (128 bins in extraBuffer[5..132]).",
     "tags": [
@@ -56,7 +56,7 @@
   {
     "id": "audio-reactive-rgb-dispersion",
     "name": "Audio Reactive RGB Dispersion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/audio-reactive-rgb-dispersion.wgsl",
+    "url": "shaders/audio-reactive-rgb-dispersion.wgsl",
     "category": "post-processing",
     "description": "Chromatic (RGB) dispersion effect whose offset magnitudes and direction are driven by the spectral centroid of the live 128-bin FFT array. Bass-heavy music produces tight warm dispersion; treble-heavy music produces wide cool dispersion. Compatible with ford442/flac_player FFT wire format (128 bins in extraBuffer[5..132]).",
     "tags": [
@@ -110,7 +110,7 @@
   {
     "id": "audio-reactive-temporal-decay",
     "name": "Audio Reactive Temporal Decay",
-    "url": "https://test.1ink.us/image_video_effects/shaders/audio-reactive-temporal-decay.wgsl",
+    "url": "shaders/audio-reactive-temporal-decay.wgsl",
     "category": "post-processing",
     "description": "Feedback trail effect whose per-pixel decay rate is modulated by the energy of a selectable FFT frequency bin range, now enhanced with spectral visualization overlay, chromatic aberration on trails, multi-pass bloom on bright areas, anamorphic streaks, film grain, scanlines, color grading with lift/gamma/gain, and vignette. Low-band energy → long ghostly trails; high-band energy → fast fade with spectral color highlights.",
     "tags": [
@@ -173,7 +173,7 @@
   {
     "id": "chrono-luma-slit-scan",
     "name": "Chrono Luma Slit Scan",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chrono-luma-slit-scan.wgsl",
+    "url": "shaders/chrono-luma-slit-scan.wgsl",
     "category": "post-processing",
     "description": "Luminance-driven 3D-texture slit scan: each pixel's brightness determines which frame in the history ring it samples. Bright pixels snap to the present; dark pixels reveal the deep past. Moving subjects leave temporal halos as their bright edges exist in the now while dark backgrounds drift through time.",
     "tags": [
@@ -231,7 +231,7 @@
   {
     "id": "long-exposure",
     "name": "Long Exposure Light Painting",
-    "url": "https://test.1ink.us/image_video_effects/shaders/long-exposure.wgsl",
+    "url": "shaders/long-exposure.wgsl",
     "description": "Simulates an open camera shutter accumulating light over time. Bright regions of each frame persist and blend into a glowing exposure buffer stored in dataTextureC; darker regions fade slowly, leaving luminous light-painting trails. Mouse click resets the exposure. Bass brightens incoming frames for punchier accumulation; mids control bloom halo radius; treble adds sparkle to the brightest traces.",
     "tags": [
       "long-exposure",
@@ -291,7 +291,7 @@
   {
     "id": "luma-pixel-sort",
     "name": "Luma Pixel Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-pixel-sort.wgsl",
+    "url": "shaders/luma-pixel-sort.wgsl",
     "description": "Fibonacci disk neighborhood pixel sorting with depth-aware blending, audio-reactive threshold modulation, and luminance-keyed alpha.",
     "features": [
       "upgraded-rgba",
@@ -380,7 +380,7 @@
   {
     "id": "optical-flow-tracer",
     "name": "Optical Flow Tracer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/optical-flow-tracer.wgsl",
+    "url": "shaders/optical-flow-tracer.wgsl",
     "category": "post-processing",
     "description": "Lucas-Kanade optical flow tracer: computes per-pixel motion vectors between the current frame and the previous history frame, then warps after-images along those trajectories. Moving objects leave physically-accurate ghost trails that follow actual motion paths rather than fading in place.",
     "tags": [
@@ -439,7 +439,7 @@
   {
     "id": "pixel-depth-sort",
     "name": "Pixel Depth Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-depth-sort.wgsl",
+    "url": "shaders/pixel-depth-sort.wgsl",
     "description": "Directional pixel sorting by depth with a 25-comparator sorting network, mouse-following sort angle, depth-weighted color selection, distance-based LOD, chromatic aberration at boundaries, bass-driven sort length, depth-layered alpha, temporal feedback, and ACES tone mapping.",
     "features": [
       "upgraded-rgba",
@@ -536,7 +536,7 @@
   {
     "id": "pp-bloom",
     "name": "PP Bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pp-bloom.wgsl",
+    "url": "shaders/pp-bloom.wgsl",
     "description": "High-quality HDR bloom with multi-tap Gaussian blur, anamorphic stretch, and lens dirt effects",
     "tags": [
       "post-process",
@@ -578,7 +578,7 @@
   {
     "id": "pp-chromatic",
     "name": "PP Chromatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pp-chromatic.wgsl",
+    "url": "shaders/pp-chromatic.wgsl",
     "description": "Chromatic aberration with RGB channel separation, barrel/pincushion distortion, and vignette",
     "tags": [
       "post-process",
@@ -620,7 +620,7 @@
   {
     "id": "pp-sharpen",
     "name": "PP Sharpen",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pp-sharpen.wgsl",
+    "url": "shaders/pp-sharpen.wgsl",
     "description": "Unsharp mask sharpening with edge detection, halo control, and multiple enhancement modes",
     "tags": [
       "post-process",
@@ -662,7 +662,7 @@
   {
     "id": "pp-ssao",
     "name": "PP SSAO",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pp-ssao.wgsl",
+    "url": "shaders/pp-ssao.wgsl",
     "description": "Screen-space ambient occlusion for added depth, with color bleeding from occluding surfaces",
     "tags": [
       "post-process",
@@ -704,7 +704,7 @@
   {
     "id": "pp-tone-map",
     "name": "PP Tone Map",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pp-tone-map.wgsl",
+    "url": "shaders/pp-tone-map.wgsl",
     "description": "HDR to LDR tone mapping with ACES, Uncharted 2, Reinhard, and AgX algorithms. Includes exposure, contrast, and saturation controls.",
     "tags": [
       "post-process",
@@ -746,7 +746,7 @@
   {
     "id": "pp-vignette",
     "name": "PP Vignette",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pp-vignette.wgsl",
+    "url": "shaders/pp-vignette.wgsl",
     "description": "Film vignette with grain, sepia/warm/cool color grading, and retro scanline effects",
     "tags": [
       "post-process",
@@ -789,7 +789,7 @@
   {
     "id": "radial-blur",
     "name": "Radial Blur",
-    "url": "https://test.1ink.us/image_video_effects/shaders/radial-blur.wgsl",
+    "url": "shaders/radial-blur.wgsl",
     "description": "Depth-aware radial blur with bokeh shape selection, chromatic aberration, Gaussian kernel weighting, and vignette.",
     "params": [
       {
@@ -845,7 +845,7 @@
   {
     "id": "soft-vignette-bloom",
     "name": "Soft Vignette Bloom",
-    "url": "https://test.1ink.us/image_video_effects/shaders/soft-vignette-bloom.wgsl",
+    "url": "shaders/soft-vignette-bloom.wgsl",
     "category": "post-processing",
     "description": "Cinematic post-processing with multi-scale Gaussian bloom pyramid, anamorphic highlight streaks, and superellipse vignette. Enhanced with lens flare ghost images, 8-pointed starburst diffraction spikes, chromatic aberration at edges, bokeh depth-of-field with hexagonal aperture, and enhanced light falloff with realistic attenuation.",
     "tags": [
@@ -918,7 +918,7 @@
   {
     "id": "spatio-temporal-3d-conv",
     "name": "Spatio-Temporal 3D Convolution",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spatio-temporal-3d-conv.wgsl",
+    "url": "shaders/spatio-temporal-3d-conv.wgsl",
     "category": "post-processing",
     "description": "3×3×T spatio-temporal convolution using the history ring buffer. A Gaussian spatial kernel is applied at each of T past frames and blended with temporal weights. Param 3 selects the operation mode: Temporal Noise Reduction (averages frames to kill flicker), Motion Blur (exponential frame accumulation), or Temporal Sharpening (subtracts the temporal mean to amplify transient changes).",
     "tags": [
@@ -982,7 +982,7 @@
   {
     "id": "temporal-decay-multiresolution",
     "name": "Temporal Decay Multiresolution",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-decay-multiresolution.wgsl",
+    "url": "shaders/temporal-decay-multiresolution.wgsl",
     "description": "Four-timescale temporal decomposition. R=fast (ages 1–2), G=medium (ages 4–5), B=slow (age 7), A=ultra-slow (full average). Per-channel independent decay rates create psychedelic rainbow splits where motion speed maps to color. Stacks cleanly behind sim-decay-system-rgba.",
     "tags": [
       "temporal",
@@ -1039,7 +1039,7 @@
   {
     "id": "temporal-feedback-zoom-tracer",
     "name": "Temporal Feedback Zoom Tracer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-feedback-zoom-tracer.wgsl",
+    "url": "shaders/temporal-feedback-zoom-tracer.wgsl",
     "description": "Reads the most recent history frame through a slight affine warp (zoom + rotation) then blends with the current frame. The compounding warp generates infinite self-generating psychedelic zoom tunnels from any video content.",
     "tags": [
       "temporal",
@@ -1096,7 +1096,7 @@
   {
     "id": "temporal-frequency-decomposition",
     "name": "Temporal Frequency Decomposition",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-frequency-decomposition.wgsl",
+    "url": "shaders/temporal-frequency-decomposition.wgsl",
     "description": "Discrete temporal Fourier analysis across the 8-frame history ring. Static pixels cancel to near-zero; pixels flickering or oscillating near the target frequency glow brightly. Reveals hidden temporal rhythms in video content.",
     "tags": [
       "temporal",
@@ -1153,7 +1153,7 @@
   {
     "id": "temporal-halation-freeze",
     "name": "Temporal Halation Freeze",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-halation-freeze.wgsl",
+    "url": "shaders/temporal-halation-freeze.wgsl",
     "description": "Long-exposure halation and ghost echoes using a 7-tap hex-bokeh bloom, audio envelope, ACES tone mapping, depth-aware fog, and semantic alpha for dreamy time-blurred composites.",
     "tags": [
       "halation",
@@ -1223,7 +1223,7 @@
   {
     "id": "temporal-layered-time-stamps",
     "name": "Temporal Layered Time-Stamps",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-layered-time-stamps.wgsl",
+    "url": "shaders/temporal-layered-time-stamps.wgsl",
     "description": "Psychedelic temporal echo: blends 4–8 past frames from the history ring buffer (binding 13) with per-layer hue rotation and spiral UV distortion",
     "tags": [
       "temporal",
@@ -1275,7 +1275,7 @@
   {
     "id": "temporal-phosphor-burn-motion-adaptive",
     "name": "Temporal Phosphor Burn (Motion Adaptive)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-phosphor-burn-motion-adaptive.wgsl",
+    "url": "shaders/temporal-phosphor-burn-motion-adaptive.wgsl",
     "description": "Motion-adaptive CRT phosphor burn. Fast-moving pixels get slow decay (long bright trails); still areas clear quickly. Green/amber warm tint follows the motion glow for vivid CRT ambiance.",
     "tags": [
       "temporal",
@@ -1333,7 +1333,7 @@
   {
     "id": "temporal-phosphor-burn",
     "name": "Temporal Phosphor Burn",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-phosphor-burn.wgsl",
+    "url": "shaders/temporal-phosphor-burn.wgsl",
     "description": "CRT phosphor persistence: per-channel exponential decay (R=fast, B=slow) creates green/amber afterglow. max(current, decayed_history) luminance floor keeps bright pixels glowing long after the source moves on.",
     "tags": [
       "temporal",
@@ -1390,7 +1390,7 @@
   {
     "id": "temporal-rgb-ghost",
     "name": "Temporal RGB Ghost",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-rgb-ghost.wgsl",
+    "url": "shaders/temporal-rgb-ghost.wgsl",
     "description": "Per-channel temporal displacement: R=current, G=N frames ago, B=M frames ago. Moving objects leave vivid rainbow comet tails as each color channel trails a different distance behind. Static areas appear normal.",
     "tags": [
       "temporal",
@@ -1447,7 +1447,7 @@
   {
     "id": "temporal-slit-scan",
     "name": "Temporal Slit Scan",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-slit-scan.wgsl",
+    "url": "shaders/temporal-slit-scan.wgsl",
     "description": "Classic slit-scan time-smear: each column (or row) samples a different point in the 8-frame history ring. One edge shows the current frame, the opposite edge shows 7 frames ago. Creates the flowing painterly time-smear of Radiohead's Street Spirit video on any motion.",
     "tags": [
       "temporal",
@@ -1504,7 +1504,7 @@
   {
     "id": "tone-histogram-apply",
     "name": "Tone Histogram (Pass 2: Apply)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tone-histogram-apply.wgsl",
+    "url": "shaders/tone-histogram-apply.wgsl",
     "description": "Reads histogram buckets, computes auto-exposure and tone curve, and applies histogram-driven grading.",
     "features": [
       "multi-pass-2",
@@ -1563,7 +1563,7 @@
     "id": "tone-histogram",
     "name": "Tone Histogram v2",
     "category": "post-processing",
-    "url": "https://test.1ink.us/image_video_effects/shaders/tone-histogram.wgsl",
+    "url": "shaders/tone-histogram.wgsl",
     "description": "Single-pass local adaptive histogram equalization with film-like tonal curves, split-tone shadows/highlights, grain texture, and depth-driven haze removal. Bass stretches histogram dynamically.",
     "features": [
       "audio-reactive",

--- a/public/shader-lists/retro-glitch.json
+++ b/public/shader-lists/retro-glitch.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "ascii-flow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ascii-flow.wgsl",
+    "url": "shaders/ascii-flow.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -50,7 +50,7 @@
     "id": "bayer-dither-interactive",
     "name": "Bayer Dither Interactive",
     "category": "retro-glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bayer-dither-interactive.wgsl",
+    "url": "shaders/bayer-dither-interactive.wgsl",
     "description": "Ordered 8x8 Bayer dither with blue-noise modulation, gather-style error diffusion, retro 1-bit/4-bit/8-bit palette switching, CRT phosphor dot pitch, and chromatic aberration on dither edges.",
     "features": [
       "mouse-driven",
@@ -112,7 +112,7 @@
   {
     "id": "byte-mosh",
     "name": "Byte-Mosh Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/byte-mosh.wgsl",
+    "url": "shaders/byte-mosh.wgsl",
     "description": "Bitwise XOR, AND, shift, and rotate operations creating digital corruption effects.",
     "params": [
       {
@@ -158,7 +158,7 @@
   {
     "id": "crt-magnet",
     "name": "CRT Magnet",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crt-magnet.wgsl",
+    "url": "shaders/crt-magnet.wgsl",
     "description": "Phase-B hybrid CRT monitor degaussing magnetic distortion near the mouse. Fuses crt-magnet distortion with temporal feedback echo, audio-driven cosine palette, domain-warped FBM, and a smooth SDF mask. Uses canonical fbm/curl noise, unified audio-envelope and spring-damped mouse state, branchless aperture grille, hex-bloom, beam-purity RGB separation, and ACES tone mapping with semantic alpha blending.",
     "params": [
       {
@@ -218,7 +218,7 @@
   {
     "id": "crt-phosphor-decay",
     "name": "CRT Phosphor Decay",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crt-phosphor-decay.wgsl",
+    "url": "shaders/crt-phosphor-decay.wgsl",
     "description": "Simulates CRT phosphor persistence with per-channel RGB decay rates, scanline masking, sub-pixel triad rendering, and halation bloom. Audio-reactive brightness flash and scanline flutter. Touch cursor adds static.",
     "features": [
       "mouse-driven",
@@ -276,7 +276,7 @@
   {
     "id": "crt-tv",
     "name": "CRT TV - Phosphor Physics",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crt-tv.wgsl",
+    "url": "shaders/crt-tv.wgsl",
     "description": "Authentic CRT phosphor physics simulation with aperture grille shadow mask, per-channel phosphor decay (R>G>B persistence rates), halation glow from glass scattering, barrel distortion, and realistic scanlines",
     "tags": [
       "crt",
@@ -329,7 +329,7 @@
   {
     "id": "cyber-rain-interactive",
     "name": "Cyber Rain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-rain-interactive.wgsl",
+    "url": "shaders/cyber-rain-interactive.wgsl",
     "description": "Matrix-style digital rain that reacts to image luminance and mouse.",
     "features": [
       "mouse-driven"
@@ -373,7 +373,7 @@
   {
     "id": "cyber-terminal-ascii",
     "name": "Cyber Terminal ASCII",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-terminal-ascii.wgsl",
+    "url": "shaders/cyber-terminal-ascii.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -427,7 +427,7 @@
   {
     "id": "data-moshing-diffusion",
     "name": "Data Moshing Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-moshing-diffusion.wgsl",
+    "url": "shaders/data-moshing-diffusion.wgsl",
     "category": "advanced-hybrid",
     "description": "Data moshing with anisotropic diffusion, chromatic per-channel diffusion offsets, audio-reactive smear strength, temporal smear persistence, and mouse swirl injection.",
     "tags": [
@@ -486,7 +486,7 @@
   {
     "id": "data-moshing",
     "name": "Data Moshing",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-moshing.wgsl",
+    "url": "shaders/data-moshing.wgsl",
     "category": "retro-glitch",
     "description": "Advanced data-moshing glitch effect with structure-tensor optical flow estimation and motion-compensated smearing. Simulates MPEG macro-blocking, DCT ringing, chroma subsampling errors, and VHS head-switching bands. Bass triggers corruption events, mouse scrubs temporal buffer, and depth controls compression quality.",
     "tags": [
@@ -548,7 +548,7 @@
   {
     "id": "datamosh-brush",
     "name": "Datamosh Brush",
-    "url": "https://test.1ink.us/image_video_effects/shaders/datamosh-brush.wgsl",
+    "url": "shaders/datamosh-brush.wgsl",
     "description": "Interactive datamosh effect. Mouse drags and corrupts pixels like P-frame compression artifacts.",
     "params": [
       {
@@ -596,7 +596,7 @@
   {
     "id": "digital-decay",
     "name": "Digital Decay",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-decay.wgsl",
+    "url": "shaders/digital-decay.wgsl",
     "description": "Simulates data corruption: block displacement, sub-pixel jitter, chromatic aberration, bit-flip channel noise, scanline static, and ghost-frame persistence — all scaling with audio bass and depth.",
     "features": [
       "audio-reactive",
@@ -652,7 +652,7 @@
   {
     "id": "digital-glitch-pass1",
     "name": "Digital Glitch (Pass 1)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-glitch-pass1.wgsl",
+    "url": "shaders/digital-glitch-pass1.wgsl",
     "description": "Glitch field generation: block displacement, scanline tearing, bitwise corruption seeds, and per-pixel corruption masks. Outputs glitch field to dataTextureA.",
     "tags": [
       "glitch",
@@ -708,7 +708,7 @@
   {
     "id": "digital-glitch-pass2",
     "name": "Digital Glitch (Pass 2)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-glitch-pass2.wgsl",
+    "url": "shaders/digital-glitch-pass2.wgsl",
     "description": "Error propagation and compositing pass: neighbor error spreading, digital decay with bit-depth reduction, chromatic aberration, scanline artifacts, and block inversion. Reads glitch field from dataTextureC.",
     "tags": [
       "glitch",
@@ -762,7 +762,7 @@
   {
     "id": "digital-glitch",
     "name": "Digital Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-glitch.wgsl",
+    "url": "shaders/digital-glitch.wgsl",
     "description": "",
     "params": [
       {
@@ -819,7 +819,7 @@
   {
     "id": "digital-waves",
     "name": "Digital Waves",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-waves.wgsl",
+    "url": "shaders/digital-waves.wgsl",
     "description": "Digital wave interference patterns.",
     "tags": [
       "filter",
@@ -864,7 +864,7 @@
     "id": "film-gate-weave",
     "name": "Film Gate Weave",
     "category": "retro-glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/film-gate-weave.wgsl",
+    "url": "shaders/film-gate-weave.wgsl",
     "description": "Accurate 35mm film gate weave simulation with perforation hole registration jitter, gate flutter from intermittent motion, and film scratch generation with temporal persistence. Film grain with dye cloud structure, gate hair accumulation, splice tape artifacts, ACES tone mapping, and chromatic aberration from lens breathing.",
     "features": [
       "temporal-frame-jitter",
@@ -928,7 +928,7 @@
   {
     "id": "halftone",
     "name": "Retro Halftone",
-    "url": "https://test.1ink.us/image_video_effects/shaders/halftone.wgsl",
+    "url": "shaders/halftone.wgsl",
     "description": "Classic newspaper halftone dot pattern with adjustable scale, contrast, and color mode. Audio-reactive bass pulse modulates dot intensity.",
     "params": [
       {
@@ -984,7 +984,7 @@
     "id": "holographic-glitch",
     "name": "Holographic Glitch",
     "category": "retro-glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-glitch.wgsl",
+    "url": "shaders/holographic-glitch.wgsl",
     "description": "Sci-fi holographic projection with block glitch, chromatic aberration, depth-aware scanlines, temporal trails, ACES tone mapping, IGN dither, Fresnel rim, split-tone, film grain and hue-preserve clamp.",
     "workgroup_size": [
       16,
@@ -1057,7 +1057,7 @@
     "id": "holographic-projection-failure",
     "name": "Holo-Projection Failure v2",
     "category": "retro-glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-projection-failure.wgsl",
+    "url": "shaders/holographic-projection-failure.wgsl",
     "description": "Holographic projection failure simulation with phase wrapping errors, bit-depth truncation, scanline desync, and block corruption. Bass triggers cascading failure modes; mouse repairs the signal locally. Depth controls projection plane distance.",
     "params": [
       {
@@ -1112,7 +1112,7 @@
   {
     "id": "neon-edges",
     "name": "Neon Edges",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-edges.wgsl",
+    "url": "shaders/neon-edges.wgsl",
     "description": "Multi-scale Mach-band edge enhancement colorized by blackbody temperature and depth-aware spotlighting.",
     "params": [
       {
@@ -1172,7 +1172,7 @@
   {
     "id": "phosphor-decay",
     "name": "Phosphor Decay",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phosphor-decay.wgsl",
+    "url": "shaders/phosphor-decay.wgsl",
     "description": "CRT phosphor persistence with per-channel linear-feedback decay, OkLab-blended trails, audio-reactive bloom, branchless shadow mask, scan-line blanking, depth haze, blackbody temperature grading, and IGN-dithered premultiplied output.",
     "params": [
       {
@@ -1229,7 +1229,7 @@
   {
     "id": "pixel-rain",
     "name": "Pixel Rain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-rain.wgsl",
+    "url": "shaders/pixel-rain.wgsl",
     "features": [
       "mouse-driven",
       "upgraded-rgba",
@@ -1278,7 +1278,7 @@
   {
     "id": "pixelation-drift",
     "name": "Pixelation Drift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixelation-drift.wgsl",
+    "url": "shaders/pixelation-drift.wgsl",
     "description": "Dynamic pixelated mosaic with audio-reactive pixel sizing, chromatic RGB pixel separation, depth-aware sizing, organic noise drift, and temporal persistence.",
     "params": [
       {
@@ -1337,7 +1337,7 @@
   {
     "id": "rgb-glitch-displacement",
     "name": "RGB Glitch Displacement",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-glitch-displacement.wgsl",
+    "url": "shaders/rgb-glitch-displacement.wgsl",
     "description": "Digital glitch effect with RGB channel displacement, block glitches, scanlines, pixel sorting, and datamosh effects. Mouse-reactive wave displacement and chromatic aberration. Audio reactivity pulses glitch intensity and adds beat-synchronized flashes.",
     "tags": [
       "glitch",
@@ -1387,7 +1387,7 @@
   {
     "id": "rgb-glitch-trail",
     "name": "RGB Glitch Trail",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-glitch-trail.wgsl",
+    "url": "shaders/rgb-glitch-trail.wgsl",
     "description": "Mouse leaves chromatic aberration trails with alpha-channel translucency blending. Uses domain-warped FBM for organic displacement and computes alpha from glitch intensity * temporal persistence.",
     "params": [
       {
@@ -1434,7 +1434,7 @@
   {
     "id": "scan-distort",
     "name": "Scan Distort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scan-distort.wgsl",
+    "url": "shaders/scan-distort.wgsl",
     "description": "CRT-style scanline distortion with unified displacement fields and alpha translucency blending. Features temporal feedback accumulation, bass-driven audio envelope, mouse-reactive glitch bursts, and block-edge quantization artifacts.",
     "features": [
       "mouse-driven",
@@ -1495,7 +1495,7 @@
   {
     "id": "scanline-drift",
     "name": "Scanline Drift",
-    "url": "https://test.1ink.us/image_video_effects/shaders/scanline-drift.wgsl",
+    "url": "shaders/scanline-drift.wgsl",
     "description": "Horizontal segments of the image drift left and right, simulating a bad video signal or tracking error.",
     "params": [
       {
@@ -1541,7 +1541,7 @@
   {
     "id": "signal-noise",
     "name": "Signal Noise",
-    "url": "https://test.1ink.us/image_video_effects/shaders/signal-noise.wgsl",
+    "url": "shaders/signal-noise.wgsl",
     "description": "Multi-octave analog noise with VHS head-switching bands, DCT block artifacts, datamoshing smear, and directional chromatic aberration with YUV chroma noise.",
     "features": [
       "temporal"
@@ -1591,7 +1591,7 @@
   {
     "id": "spectral-glitch-sort",
     "name": "Spectral Glitch Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-glitch-sort.wgsl",
+    "url": "shaders/spectral-glitch-sort.wgsl",
     "features": [
       "mouse-driven",
       "chromatic-aberration",
@@ -1638,7 +1638,7 @@
   {
     "id": "spectrum-bleed",
     "name": "Spectrum Bleed",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectrum-bleed.wgsl",
+    "url": "shaders/spectrum-bleed.wgsl",
     "description": "Color channel separation and bleeding effects.",
     "tags": [
       "filter",
@@ -1685,7 +1685,7 @@
   {
     "id": "vhs-tracking",
     "name": "VHS Tracking Error",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vhs-tracking.wgsl",
+    "url": "shaders/vhs-tracking.wgsl",
     "features": [
       "mouse-driven",
       "upgraded-rgba",
@@ -1732,7 +1732,7 @@
     "id": "vinyl-scratch",
     "name": "Vinyl Scratch",
     "category": "retro-glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/vinyl-scratch.wgsl",
+    "url": "shaders/vinyl-scratch.wgsl",
     "description": "Vintage vinyl record scratch with chromatic wobble, animated dust particles, groove lighting with directional reflections, groove sparkle highlights, analog warmth, saturation roll-off, film grain with temporal coherence, radial chromatic aberration, vignette, and lens dirt. Bass drives rotation speed, mids warp the record, treble adds groove sparkle and dust. Depth scales groove intensity.",
     "params": [
       {
@@ -1793,7 +1793,7 @@
   {
     "id": "waveform-glitch",
     "name": "Waveform Glitch",
-    "url": "https://test.1ink.us/image_video_effects/shaders/waveform-glitch.wgsl",
+    "url": "shaders/waveform-glitch.wgsl",
     "description": "VHS waveform glitch driven by a Clifford strange attractor, domain-warped FBM, divergence-free curl flow, Voronoi F2-F1 ridge corruption, YUV chroma noise, CRT shadow mask, temporal feedback persistence, SDF glitch masks, audio-driven cosine palette, and bass-envelope smoothing. Alpha encodes waveform displacement magnitude * block corruption intensity * SDF-mask proximity.",
     "features": [
       "temporal",
@@ -1870,7 +1870,7 @@
   {
     "id": "xerox-degrade",
     "name": "Xerox Degrade",
-    "url": "https://test.1ink.us/image_video_effects/shaders/xerox-degrade.wgsl",
+    "url": "shaders/xerox-degrade.wgsl",
     "description": "Simulates the degradation of repeated photocopying with grain, high contrast, and smear.",
     "params": [
       {

--- a/public/shader-lists/simulation.json
+++ b/public/shader-lists/simulation.json
@@ -2,7 +2,7 @@
   {
     "id": "aero-chromatics",
     "name": "Aero Chromatics",
-    "url": "https://test.1ink.us/image_video_effects/shaders/aero-chromatics.wgsl",
+    "url": "shaders/aero-chromatics.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -49,7 +49,7 @@
   {
     "id": "alpha-crystal-growth-phase",
     "name": "Alpha Crystal Growth Phase",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-crystal-growth-phase.wgsl",
+    "url": "shaders/alpha-crystal-growth-phase.wgsl",
     "description": "Phase-field model of crystal growth with RGBA-packed state. Phase (solid/liquid), temperature, crystal orientation, and impurity concentration evolve together. Creates dendritic crystal patterns with orientation-dependent color. Mouse seeds new crystals; ripples trigger nucleation.",
     "tags": [
       "crystal",
@@ -108,7 +108,7 @@
   {
     "id": "alpha-em-field-simulation",
     "name": "Alpha EM Field Simulation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-em-field-simulation.wgsl",
+    "url": "shaders/alpha-em-field-simulation.wgsl",
     "description": "Electromagnetic field simulation using RGBA32FLOAT as four data channels: R=E-field X, G=E-field Y, B=magnetic potential, A=charge density. Mouse and ripples inject alternating positive/negative charges. Wave equation propagation with damping.",
     "tags": [
       "electromagnetic",
@@ -166,7 +166,7 @@
   {
     "id": "alpha-erosion-terrain",
     "name": "Alpha Erosion Terrain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-erosion-terrain.wgsl",
+    "url": "shaders/alpha-erosion-terrain.wgsl",
     "description": "Hydraulic erosion simulation with RGBA-packed terrain state. Height from image luminance is eroded by flowing water that picks up sediment and deposits it in flat areas. Mouse creates rainstorms; ripples trigger flash floods. Alpha tracks cumulative erosion history.",
     "tags": [
       "erosion",
@@ -225,7 +225,7 @@
   {
     "id": "alpha-fire-temperature",
     "name": "Alpha Fire Temperature",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-fire-temperature.wgsl",
+    "url": "shaders/alpha-fire-temperature.wgsl",
     "description": "Fire simulation with RGBA-packed state: fuel, temperature, smoke density, and combustion age. Temperature drives blackbody radiation color. Fuel burns, generates smoke, and heat rises via convection. Mouse injects fuel; ripples create sparks.",
     "tags": [
       "fire",
@@ -284,7 +284,7 @@
   {
     "id": "alpha-fluid-simulation-paint",
     "name": "Alpha Fluid Simulation Paint",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-fluid-simulation-paint.wgsl",
+    "url": "shaders/alpha-fluid-simulation-paint.wgsl",
     "description": "Full 2D incompressible fluid simulation packed into a single RGBA32FLOAT texture. R=velocity.x, G=velocity.y, B=pressure, A=dye density. Mouse creates vortices and injects dye. Requires f32 for signed velocity and pressure fields.",
     "tags": [
       "fluid",
@@ -343,7 +343,7 @@
   {
     "id": "alpha-multi-state-ecosystem",
     "name": "Alpha Multi-State Ecosystem",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-multi-state-ecosystem.wgsl",
+    "url": "shaders/alpha-multi-state-ecosystem.wgsl",
     "description": "Continuous multi-species ecosystem simulation packed into RGBA32FLOAT. Two species compete for shared resources while producing toxins. Species diffuse, grow, compete, and die. Mouse nurtures by adding resources.",
     "tags": [
       "ecosystem",
@@ -401,7 +401,7 @@
   {
     "id": "alpha-reaction-diffusion-rgba",
     "name": "Alpha Reaction Diffusion RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-reaction-diffusion-rgba.wgsl",
+    "url": "shaders/alpha-reaction-diffusion-rgba.wgsl",
     "description": "Four-species reaction-diffusion simulation packed into RGBA32FLOAT. A feeds B, C feeds D, with cross-inhibition between pairs. Creates complex multi-color patterns impossible in 2-species systems.",
     "tags": [
       "reaction-diffusion",
@@ -459,7 +459,7 @@
   {
     "id": "bitonic-sort",
     "name": "Bitonic Pixel Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/bitonic-sort.wgsl",
+    "url": "shaders/bitonic-sort.wgsl",
     "description": "Workgroup bitonic pixel sort with polar kaleidoscope symmetry, Voronoi ridge sort keys, domain-warped FBM, Halton quasi-random jitter, depth-aware weighting, ACES tone mapping, chromatic aberration, bass-reactive mixing, and temporal feedback.",
     "features": [
       "upgraded-rgba",
@@ -560,7 +560,7 @@
   {
     "id": "cellular-automata-rgba",
     "name": "Cellular Automata RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cellular-automata-rgba.wgsl",
+    "url": "shaders/cellular-automata-rgba.wgsl",
     "description": "2D ecosystem cellular automaton with four interacting species packed into RGBA. Plants grow from nutrients, herbivores eat plants, predators eat herbivores, and all dead matter cycles back to soil nutrients. Continuous densities enable stable predator-prey oscillations.",
     "tags": [
       "simulation",
@@ -619,7 +619,7 @@
   {
     "id": "chromatic-reaction-diffusion-rgba",
     "name": "Chromatic Reaction Diffusion RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-reaction-diffusion-rgba.wgsl",
+    "url": "shaders/chromatic-reaction-diffusion-rgba.wgsl",
     "description": "Four-species reaction-diffusion with chromatic cross-coupling. Activators A/C and inhibitors B/D form warm/cool tone pairs that suppress each other at boundaries, creating iridescent fringe patterns. RGBA packs full simulation state.",
     "tags": [
       "reaction-diffusion",
@@ -679,7 +679,7 @@
     "id": "cymatic-sand",
     "name": "Cymatic Sand",
     "description": "Multi-harmonic Chladni plate simulation. Sand accumulates on nodal lines with temporal persistence, audio-driven harmonic superposition, and SDF-based rounded grain rendering.",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cymatic-sand.wgsl",
+    "url": "shaders/cymatic-sand.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -736,7 +736,7 @@
   {
     "id": "digital-moss",
     "name": "Digital Moss",
-    "url": "https://test.1ink.us/image_video_effects/shaders/digital-moss.wgsl",
+    "url": "shaders/digital-moss.wgsl",
     "description": "Digital moss grows on dark areas. Use the mouse to clean it.",
     "features": [
       "mouse-driven"
@@ -784,7 +784,7 @@
     "id": "ferrofluid-spikes",
     "name": "Ferrofluid Spikes",
     "category": "simulation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ferrofluid-spikes.wgsl",
+    "url": "shaders/ferrofluid-spikes.wgsl",
     "description": "Mouse-driven ferrofluid simulation. The cursor acts as a magnet, pulling up metallic spikes from a dark liquid surface. Enhanced with full 3-point studio lighting (key/fill/rim), GGX PBR specular, Fresnel-Schlick reflections, anisotropic metallic sheen, ambient occlusion, and subsurface scattering glow.",
     "features": [
       "mouse-driven",
@@ -847,7 +847,7 @@
   {
     "id": "flow-sort",
     "name": "Streamline Pixel Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/flow-sort.wgsl",
+    "url": "shaders/flow-sort.wgsl",
     "description": "Pixel sorting along vector field lines derived from luminance gradients.",
     "params": [
       {
@@ -893,7 +893,7 @@
   {
     "id": "galaxy-compute",
     "name": "Galaxy Compute",
-    "url": "https://test.1ink.us/image_video_effects/shaders/galaxy-compute.wgsl",
+    "url": "shaders/galaxy-compute.wgsl",
     "description": "Volumetric spiral galaxy with logarithmic spiral SDF, procedural nebula clouds, Keplerian orbital mechanics, and stellar particle glow.",
     "params": [
       {
@@ -939,7 +939,7 @@
   {
     "id": "lenia-on-video",
     "name": "Lenia on Video",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lenia-on-video.wgsl",
+    "url": "shaders/lenia-on-video.wgsl",
     "category": "simulation",
     "description": "Continuous Lenia cellular automaton (Chan 2019) seeded and continuously driven by live video. Video luminance seeds the initial cell state; video hue and saturation modulate Lenia's growth center and width parameters in real time, coupling the CA tightly to the subject. Bass beats inject fresh cells from bright video regions. Mouse spawns or clears cells. Outputs a neon bioluminescent CA layer composited over the source video.",
     "tags": [
@@ -1001,7 +1001,7 @@
     "id": "lichtenberg-fractal",
     "name": "Lichtenberg Fractal",
     "description": "High-voltage electrical discharge with curl-noise branching, depth-aware strike targeting, audio-reactive spread, and chromatic glow (white core → cyan → deep purple).",
-    "url": "https://test.1ink.us/image_video_effects/shaders/lichtenberg-fractal.wgsl",
+    "url": "shaders/lichtenberg-fractal.wgsl",
     "features": [
       "mouse-driven",
       "depth-aware",
@@ -1055,7 +1055,7 @@
   {
     "id": "luma-flow-field",
     "name": "Luma Flow Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-flow-field.wgsl",
+    "url": "shaders/luma-flow-field.wgsl",
     "description": "Luma-gradient curl-noise flow field. Pixels stream along iso-luminance curves driven by multi-octave divergence-free noise, with depth-aware vortices, audio-reactive speed/turbulence, and iridescent palette streaks.",
     "features": [
       "audio-reactive",
@@ -1112,7 +1112,7 @@
   {
     "id": "nano-assembler",
     "name": "Nano Assembler",
-    "url": "https://test.1ink.us/image_video_effects/shaders/nano-assembler.wgsl",
+    "url": "shaders/nano-assembler.wgsl",
     "description": "Simulates nanobots constructing the image. Mouse movement disrupts the assembly, scattering the particles.",
     "params": [
       {
@@ -1155,7 +1155,7 @@
   {
     "id": "photonic-caustics",
     "name": "Photonic Caustics",
-    "url": "https://test.1ink.us/image_video_effects/shaders/photonic-caustics.wgsl",
+    "url": "shaders/photonic-caustics.wgsl",
     "description": "Light caustics simulation with chromatic dispersion, Fresnel reflections, and refractive surfaces.",
     "params": [
       {
@@ -1205,7 +1205,7 @@
   {
     "id": "pixel-sand",
     "name": "Pixel Sand",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-sand.wgsl",
+    "url": "shaders/pixel-sand.wgsl",
     "description": "Falling granular automata crossed with domain-warped FBM flow fields, temporal feedback echo, and an audio-driven palette. Warm blackbody spawns, OkLab video-to-sand blending, mouse gravity wells, ripple shockwaves, depth shading, ACES tone mapping, and IGN dither remain intact.",
     "features": [
       "upgraded-rgba",
@@ -1277,7 +1277,7 @@
   {
     "id": "predator-prey",
     "name": "Pixel Ecology",
-    "url": "https://test.1ink.us/image_video_effects/shaders/predator-prey.wgsl",
+    "url": "shaders/predator-prey.wgsl",
     "description": "Cellular automata ecosystem with plants, herbivores, and carnivores - watch the food chain unfold.",
     "params": [
       {
@@ -1323,7 +1323,7 @@
   {
     "id": "quantum-foam-pass1",
     "name": "Quantum Foam (Pass 1: Field Generation)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-foam-pass1.wgsl",
+    "url": "shaders/quantum-foam-pass1.wgsl",
     "description": "Generates quantum probability field with curl noise and FBM. First pass of 3-pass system.",
     "features": [
       "multi-pass-1",
@@ -1414,7 +1414,7 @@
   {
     "id": "quantum-foam-pass2",
     "name": "Quantum Foam (Pass 2: Particle Advection)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-foam-pass2.wgsl",
+    "url": "shaders/quantum-foam-pass2.wgsl",
     "description": "Advects particles through the quantum field. Second pass of 3-pass system.",
     "features": [
       "multi-pass-2",
@@ -1471,7 +1471,7 @@
   {
     "id": "quantum-foam-pass3",
     "name": "Quantum Foam (Pass 3: Compositing)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-foam-pass3.wgsl",
+    "url": "shaders/quantum-foam-pass3.wgsl",
     "description": "Volumetric rendering and final compositing with glow and tone mapping. Third pass of 3-pass system.",
     "features": [
       "multi-pass-3",
@@ -1527,7 +1527,7 @@
   {
     "id": "rd-on-video-pass1",
     "name": "RD on Video (Pass 1: State Update)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rd-on-video-pass1.wgsl",
+    "url": "shaders/rd-on-video-pass1.wgsl",
     "description": "Gray-Scott reaction-diffusion seeded and continuously driven by video luminance.",
     "features": [
       "multi-pass-1",
@@ -1585,7 +1585,7 @@
   {
     "id": "rd-on-video-pass2",
     "name": "RD on Video (Pass 2: Turing Color Map)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rd-on-video-pass2.wgsl",
+    "url": "shaders/rd-on-video-pass2.wgsl",
     "description": "Color-maps reaction-diffusion chemistry into vivid Turing pattern fields.",
     "features": [
       "multi-pass-2",
@@ -1642,7 +1642,7 @@
   {
     "id": "rd-on-video-pass3",
     "name": "RD on Video (Pass 3: Composite)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rd-on-video-pass3.wgsl",
+    "url": "shaders/rd-on-video-pass3.wgsl",
     "description": "Composites Turing color output over video using luminance-aware masking.",
     "features": [
       "multi-pass-3",
@@ -1699,7 +1699,7 @@
   {
     "id": "ripple-tank-pass2",
     "name": "Ripple Tank (Pass 2: Optics Gather)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ripple-tank-pass2.wgsl",
+    "url": "shaders/ripple-tank-pass2.wgsl",
     "description": "Reduces the wave field into a 10x10 caustic-energy grid in extraBuffer for same-frame use by the render pass. Second pass of the ripple-tank chain.",
     "multipass": {
       "pass": 2,
@@ -1721,7 +1721,7 @@
   {
     "id": "ripple-tank-pass3",
     "name": "Ripple Tank (Pass 3: Render)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ripple-tank-pass3.wgsl",
+    "url": "shaders/ripple-tank-pass3.wgsl",
     "description": "Chromatic refraction, phase-hue interference bands, specular glints, and coarse-grid caustic sparkles. Final pass of the ripple-tank chain.",
     "multipass": {
       "pass": 3,
@@ -1745,7 +1745,7 @@
   {
     "id": "ripple-tank",
     "name": "Ripple Tank",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ripple-tank-pass1.wgsl",
+    "url": "shaders/ripple-tank-pass1.wgsl",
     "description": "Psychedelic 3-pass wave-interference tank — click to drop rings, hold to drive an oscillator, bass pumps the sources while caustic sparkles chase the wavefronts.",
     "multipass": {
       "pass": 1,
@@ -1832,7 +1832,7 @@
   {
     "id": "sim-decay-system-rgba",
     "name": "Sim: Decay System RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-decay-system-rgba.wgsl",
+    "url": "shaders/sim-decay-system-rgba.wgsl",
     "description": "Four-layer material decay simulation with cross-coupling. Paint integrity, metal corrosion, organic rot, and structural integrity each decay at different rates. When one layer fails, others decay faster. Mouse interaction can restore/repair.",
     "tags": [
       "simulation",
@@ -1891,7 +1891,7 @@
   {
     "id": "sim-decay-system",
     "name": "Decay System",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-decay-system.wgsl",
+    "url": "shaders/sim-decay-system.wgsl",
     "description": "Multi-layer decay and corrosion simulation. Image corrodes from edges inward with different materials.",
     "features": [
       "simulation",
@@ -1955,7 +1955,7 @@
   {
     "id": "sim-fluid-feedback-coupled",
     "name": "Fluid Feedback Coupled",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-fluid-feedback-coupled.wgsl",
+    "url": "shaders/sim-fluid-feedback-coupled.wgsl",
     "description": "Mouse-steerable coupled fluid simulation combining Navier-Stokes feedback fields with viscous fluid stirring. Mouse drags fluid creating vortex streets; click ripples inject bursts. Fluid thickness drives color absorption, blur, and glow.",
     "features": [
       "simulation",
@@ -2027,7 +2027,7 @@
   {
     "id": "sim-fluid-feedback-field",
     "name": "Fluid Feedback Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-fluid-feedback-field-pass1.wgsl",
+    "url": "shaders/sim-fluid-feedback-field-pass1.wgsl",
     "description": "Multi-pass Navier-Stokes fluid simulation with feedback trails. Glowing fluid that swirls and mixes.",
     "features": [
       "simulation",
@@ -2114,7 +2114,7 @@
   {
     "id": "sim-heat-haze-field",
     "name": "Heat Haze Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-heat-haze-field.wgsl",
+    "url": "shaders/sim-heat-haze-field.wgsl",
     "description": "Temperature simulation with convection currents. Desert mirage effect with rising heat patterns.",
     "features": [
       "simulation",
@@ -2178,7 +2178,7 @@
   {
     "id": "sim-ink-diffusion-rgba",
     "name": "Sim: Ink Diffusion RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-ink-diffusion-rgba.wgsl",
+    "url": "shaders/sim-ink-diffusion-rgba.wgsl",
     "description": "Four-ink wet diffusion simulation on paper texture. RGB channels hold cyan, magenta, and yellow pigment concentrations; alpha holds water saturation that drives all diffusion. Pigments mix subtractively on wet paper.",
     "tags": [
       "simulation",
@@ -2237,7 +2237,7 @@
   {
     "id": "sim-ink-diffusion",
     "name": "Ink Diffusion",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-ink-diffusion.wgsl",
+    "url": "shaders/sim-ink-diffusion.wgsl",
     "description": "Fluid ink diffusion with paper absorption. Multi-channel Gray-Scott with Wolfram-validated parameters.",
     "features": [
       "simulation",
@@ -2306,7 +2306,7 @@
   {
     "id": "sim-sand-dunes-rgba",
     "name": "Sim: Sand Dunes RGBA",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-sand-dunes-rgba.wgsl",
+    "url": "shaders/sim-sand-dunes-rgba.wgsl",
     "description": "Four-grain-type sand physics with distinct behaviors. Fine sand blows easily in wind, coarse sand is stable with high angle of repose, moist sand clumps together, and dust rises on updrafts. RGBA packs all grain fractions per cell.",
     "tags": [
       "simulation",
@@ -2365,7 +2365,7 @@
   {
     "id": "sim-sand-dunes",
     "name": "Sand Dunes",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-sand-dunes.wgsl",
+    "url": "shaders/sim-sand-dunes.wgsl",
     "description": "Falling sand physics with wind erosion. Sand falls, piles at angle of repose, wind moves loose sand.",
     "features": [
       "simulation",
@@ -2428,7 +2428,7 @@
   {
     "id": "sim-slime-mold-growth-em",
     "name": "Slime Mold Growth + EM Field",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-slime-mold-growth-em.wgsl",
+    "url": "shaders/sim-slime-mold-growth-em.wgsl",
     "description": "Physarum slime mold simulation with mouse electromagnetic field interaction. Agents steer along electric field lines; click ripples spawn secondary charges.",
     "features": [
       "simulation",
@@ -2503,7 +2503,7 @@
   {
     "id": "sim-slime-mold-growth",
     "name": "Slime Mold Growth",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-slime-mold-growth.wgsl",
+    "url": "shaders/sim-slime-mold-growth.wgsl",
     "description": "Physarum-style slime mold with trail following. Branching network of glowing trails exploring space.",
     "features": [
       "simulation",
@@ -2568,7 +2568,7 @@
   {
     "id": "sim-smoke-trails",
     "name": "Smoke Trails",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-smoke-trails.wgsl",
+    "url": "shaders/sim-smoke-trails.wgsl",
     "description": "Volumetric smoke with vorticity and buoyancy. Billowing smoke rising with natural turbulence.",
     "features": [
       "simulation",
@@ -2632,7 +2632,7 @@
   {
     "id": "sim-volumetric-fake",
     "name": "Volumetric Fake (God Rays)",
-    "url": "https://test.1ink.us/image_video_effects/shaders/sim-volumetric-fake.wgsl",
+    "url": "shaders/sim-volumetric-fake.wgsl",
     "description": "Fast approximation of volumetric lighting. Radial blur from light source with depth-based scattering.",
     "features": [
       "simulation",
@@ -2697,7 +2697,7 @@
     "id": "slime-mold-on-video",
     "name": "Slime Mold on Video",
     "category": "simulation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/slime-mold-on-video.wgsl",
+    "url": "shaders/slime-mold-on-video.wgsl",
     "description": "Video luminance feeds a slime-mold trail simulation. Audio shifts tendril colors (bass green, mids cyan, treble magenta). Depth boosts glow intensity. Mouse deposits extra food.",
     "features": [
       "simulation",
@@ -2759,7 +2759,7 @@
   {
     "id": "spec-runge-kutta-advection",
     "name": "Runge-Kutta Advection",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spec-runge-kutta-advection.wgsl",
+    "url": "shaders/spec-runge-kutta-advection.wgsl",
     "description": "4th-order Runge-Kutta fluid advection. Dramatically more accurate than Euler method, preserving fine dye structures 10x longer. Mouse creates counter-rotating vortex pairs.",
     "tags": [
       "runge-kutta",
@@ -2816,7 +2816,7 @@
   {
     "id": "split-flap-display",
     "name": "Split Flap Display",
-    "url": "https://test.1ink.us/image_video_effects/shaders/split-flap-display.wgsl",
+    "url": "shaders/split-flap-display.wgsl",
     "features": [
       "interactive",
       "simulation",
@@ -2876,7 +2876,7 @@
   {
     "id": "steamy-glass",
     "name": "Steamy Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/steamy-glass.wgsl",
+    "url": "shaders/steamy-glass.wgsl",
     "description": "Simulates a foggy window that can be wiped clean with the mouse. The steam slowly returns over time.",
     "params": [
       {
@@ -2923,7 +2923,7 @@
   {
     "id": "wave-equation",
     "name": "Wave Tank",
-    "url": "https://test.1ink.us/image_video_effects/shaders/wave-equation.wgsl",
+    "url": "shaders/wave-equation.wgsl",
     "description": "Psychedelic ripple tank — click to drop interference rings, drag to stir, bass pulses the waves. Rainbow phase bands and caustic sparkles over your image.",
     "params": [
       {
@@ -2984,7 +2984,7 @@
   {
     "id": "wave-tank",
     "name": "Wave Tank",
-    "url": "https://test.1ink.us/image_video_effects/shaders/wave-step.wgsl",
+    "url": "shaders/wave-step.wgsl",
     "description": "Psychedelic 2D wave interference — click to drop ripples, drag to stir, bass pulses the tank. Tier C graph runner demo.",
     "params": [
       {

--- a/public/shader-lists/visual-effects.json
+++ b/public/shader-lists/visual-effects.json
@@ -2,7 +2,7 @@
   {
     "id": "alpha-depth-fog-volumetric",
     "name": "Alpha Depth Fog Volumetric",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-depth-fog-volumetric.wgsl",
+    "url": "shaders/alpha-depth-fog-volumetric.wgsl",
     "description": "Physically-motivated volumetric fog using depth texture. Alpha stores optical depth / transmittance via Beer-Lambert law. Fog density varies with 3D noise, depth, and height. Mouse clears local fog; ripples create swirling disturbances.",
     "tags": [
       "volumetric",
@@ -60,7 +60,7 @@
   {
     "id": "alpha-hdr-bloom-chain",
     "name": "Alpha HDR Bloom Chain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-hdr-bloom-chain.wgsl",
+    "url": "shaders/alpha-hdr-bloom-chain.wgsl",
     "description": "HDR bloom effect where alpha stores exposure/overexposure value. Identifies pixels above white point, radially blurs the excess brightness, and composites with ACES tone mapping. Mouse and ripples trigger localized flashes.",
     "tags": [
       "hdr",
@@ -117,7 +117,7 @@
   {
     "id": "alpha-luminance-history",
     "name": "Alpha Luminance History",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-luminance-history.wgsl",
+    "url": "shaders/alpha-luminance-history.wgsl",
     "description": "Temporal luminance history with rolling average stored in alpha. Areas that were recently bright retain a warm glow. Creates light-painting and after-image effects. Mouse leaves persistent bright trails.",
     "tags": [
       "temporal",
@@ -176,7 +176,7 @@
   {
     "id": "alpha-multi-layer-glass",
     "name": "Alpha Multi-Layer Glass",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-multi-layer-glass.wgsl",
+    "url": "shaders/alpha-multi-layer-glass.wgsl",
     "description": "Multi-layer glass refraction with RGBA data channels. Simulates looking through 3 layers of procedurally-distorted glass with Fresnel reflection, chromatic aberration, and per-layer tinting. Alpha stores accumulated transmittance.",
     "tags": [
       "glass",
@@ -233,7 +233,7 @@
   {
     "id": "alpha-spectral-decompose",
     "name": "Alpha Spectral Decompose",
-    "url": "https://test.1ink.us/image_video_effects/shaders/alpha-spectral-decompose.wgsl",
+    "url": "shaders/alpha-spectral-decompose.wgsl",
     "description": "Decomposes the image into 4 spectral frequency bands stored in RGBA. Low freq (R), mid-low (G), mid-high (B), high freq/detail (A). Recomposes with user-controlled per-band gain for frequency-equalizer style image manipulation.",
     "tags": [
       "spectral",
@@ -291,7 +291,7 @@
     "id": "anaglyph-3d",
     "name": "Anaglyph 3D",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/anaglyph-3d.wgsl",
+    "url": "shaders/anaglyph-3d.wgsl",
     "description": "Red-cyan stereoscopic anaglyph with temporal ghost fringing persistence, chromatic separation enhancement per depth, mouse focal depth curve refinement, bass-pulsed split width, and cinematic post-processing: film grain with temporal coherence, radial chromatic aberration, vignette darkening, CRT barrel distortion, color grading with lift/gamma/gain, anamorphic light streaks from bright points, and lens dirt overlay.",
     "features": [
       "mouse-driven",
@@ -356,7 +356,7 @@
   {
     "id": "anamorphic-caustic-flare",
     "name": "Anamorphic Caustic Flare",
-    "url": "https://test.1ink.us/image_video_effects/shaders/anamorphic-caustic-flare.wgsl",
+    "url": "shaders/anamorphic-caustic-flare.wgsl",
     "description": "Premium cinematic anamorphic lens flares combined with living, refracting water caustics that distort and project the source footage. Bass stretches the flares dramatically while treble animates the caustic ripples. Mouse tilts the virtual lens.",
     "tags": [
       "anamorphic",
@@ -413,7 +413,7 @@
   {
     "id": "ascii-shockwave",
     "name": "ASCII Shockwave",
-    "url": "https://test.1ink.us/image_video_effects/shaders/ascii-shockwave.wgsl",
+    "url": "shaders/ascii-shockwave.wgsl",
     "description": "A matrix-style digital shockwave that quantizes the image into procedural characters.",
     "features": [
       "mouse-driven"
@@ -461,7 +461,7 @@
     "id": "breathing-kaleidoscope",
     "name": "Breathing Kaleidoscope",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/breathing-kaleidoscope.wgsl",
+    "url": "shaders/breathing-kaleidoscope.wgsl",
     "description": "Organic breathing kaleidoscope driven by domain-warped FBM, fractional symmetry, jewel-tone palette cycling, film grain, and depth-aware sector fading.",
     "params": [
       {
@@ -513,7 +513,7 @@
   },
   {
     "id": "chroma-vortex",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chroma-vortex.wgsl",
+    "url": "shaders/chroma-vortex.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -567,7 +567,7 @@
   {
     "id": "chromatic-focus-interactive",
     "name": "Chromatic Focus",
-    "url": "https://test.1ink.us/image_video_effects/shaders/chromatic-focus-interactive.wgsl",
+    "url": "shaders/chromatic-focus-interactive.wgsl",
     "description": "Strong chromatic aberration that increases with distance from mouse focus.",
     "features": [
       "mouse-driven"
@@ -611,7 +611,7 @@
   {
     "id": "cross-spec-alpha-spectral-bloom",
     "name": "Spectral Bloom HDR",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cross-spec-alpha-spectral-bloom.wgsl",
+    "url": "shaders/cross-spec-alpha-spectral-bloom.wgsl",
     "description": "Crossover shader combining spectral dispersion with HDR bloom using RGBA as independent spectral bands. Decomposes the image into wavelength channels and applies per-band bloom with exposure control in alpha.",
     "tags": [
       "crossover",
@@ -667,7 +667,7 @@
   {
     "id": "crt-clear-zone",
     "name": "CRT Clear Zone",
-    "url": "https://test.1ink.us/image_video_effects/shaders/crt-clear-zone.wgsl",
+    "url": "shaders/crt-clear-zone.wgsl",
     "description": "Accurate CRT electron beam simulation with Gaussian spot spread, inline shadow mask, phosphor decay via temporal feedback, barrel distortion with corner darkening, per-RGB chromatic aberration, and ACES tone mapping.",
     "params": [
       {
@@ -724,7 +724,7 @@
   },
   {
     "id": "cyber-grid-pulse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-grid-pulse.wgsl",
+    "url": "shaders/cyber-grid-pulse.wgsl",
     "icon": "grid_on",
     "features": [
       "mouse-driven",
@@ -772,7 +772,7 @@
     "id": "cyber-physical-portal",
     "name": "Cyber Physical Portal",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-physical-portal.wgsl",
+    "url": "shaders/cyber-physical-portal.wgsl",
     "description": "Upgraded cyber portal with event-horizon frame dragging, gravitational lensing, accretion disk bands, cyan-magenta holographic rim, chromatic aberration, and HDR bloom. Bass drives spin, mouse positions portal, depth controls lensing.",
     "features": [
       "mouse-driven",
@@ -826,7 +826,7 @@
     "id": "cyber-scan",
     "name": "Cyber Scan",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/cyber-scan.wgsl",
+    "url": "shaders/cyber-scan.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -892,7 +892,7 @@
   },
   {
     "id": "data-scanner",
-    "url": "https://test.1ink.us/image_video_effects/shaders/data-scanner.wgsl",
+    "url": "shaders/data-scanner.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -942,7 +942,7 @@
   {
     "id": "elastic-chromatic",
     "name": "Elastic Chromatic",
-    "url": "https://test.1ink.us/image_video_effects/shaders/elastic-chromatic.wgsl",
+    "url": "shaders/elastic-chromatic.wgsl",
     "description": "Elastic chromatic aberration with radial RGB shift, per-channel temporal lag, Lissajous mouse source, depth-aware audio reactivity, split-tone blackbody grading, ACES tone mapping, IGN dither and advanced layered alpha compositing.",
     "features": [
       "mouse-driven",
@@ -1055,7 +1055,7 @@
     "id": "electric-contours",
     "name": "Electric Contours",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/electric-contours.wgsl",
+    "url": "shaders/electric-contours.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1125,7 +1125,7 @@
   {
     "id": "glitch-pixel-sort",
     "name": "Glitch Pixel Sort",
-    "url": "https://test.1ink.us/image_video_effects/shaders/glitch-pixel-sort.wgsl",
+    "url": "shaders/glitch-pixel-sort.wgsl",
     "description": "Luminance-based pixel stretching controlled by mouse position.",
     "params": [
       {
@@ -1172,7 +1172,7 @@
   {
     "id": "hex-circuit",
     "name": "Hex Circuit",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hex-circuit.wgsl",
+    "url": "shaders/hex-circuit.wgsl",
     "features": [
       "mouse-driven"
     ],
@@ -1217,7 +1217,7 @@
     "id": "holographic-flicker",
     "name": "Holographic Flicker",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-flicker.wgsl",
+    "url": "shaders/holographic-flicker.wgsl",
     "description": "Holographic flicker with temporal ghosting and depth-rainbow colorization. Bass drives blackout probability, treble adds micro-glitch. Chromatic ghosting separates RGB channels across frames.",
     "params": [
       {
@@ -1270,7 +1270,7 @@
   {
     "id": "holographic-projection-gpt52",
     "name": "Holo Projection Prism gpt52",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-projection-gpt52.wgsl",
+    "url": "shaders/holographic-projection-gpt52.wgsl",
     "description": "Prismatic hologram with stabilized focus, scan interference, and spectral tinting.",
     "features": [
       "mouse-driven",
@@ -1320,7 +1320,7 @@
   {
     "id": "holographic-projection",
     "name": "Holo Projector",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-projection.wgsl",
+    "url": "shaders/holographic-projection.wgsl",
     "description": "Transforms the image into a flickering hologram. Move mouse to focus and stabilize the projection.",
     "features": [
       "mouse-driven",
@@ -1369,7 +1369,7 @@
   {
     "id": "holographic-sticker",
     "name": "Holographic Sticker",
-    "url": "https://test.1ink.us/image_video_effects/shaders/holographic-sticker.wgsl",
+    "url": "shaders/holographic-sticker.wgsl",
     "description": "Mouse-centered iridescent sticker with chromatic view-angle dispersion, temporal foil shimmer persistence, audio-driven sticker pulse, depth-layered alpha, and rainbow phase shift.",
     "features": [
       "mouse-driven",
@@ -1430,7 +1430,7 @@
   {
     "id": "hyper-space-jump",
     "name": "Hyper Space Jump",
-    "url": "https://test.1ink.us/image_video_effects/shaders/hyper-space-jump.wgsl",
+    "url": "shaders/hyper-space-jump.wgsl",
     "description": "Streaks the image radially from the mouse position, simulating a hyperspace jump.",
     "features": [
       "mouse-driven"
@@ -1477,7 +1477,7 @@
   {
     "id": "interactive-fresnel",
     "name": "Interactive Fresnel",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-fresnel.wgsl",
+    "url": "shaders/interactive-fresnel.wgsl",
     "description": "Gravitational lensing with chromatic Einstein rings and depth mass simulation. Concentric rings warp the image with per-channel dispersion; depth acts as gravitational mass. Bass multiplies lensing power, treble sharpens chromatic separation.",
     "features": [
       "mouse-driven",
@@ -1530,7 +1530,7 @@
   {
     "id": "interactive-pcb-traces",
     "name": "Interactive PCB Traces",
-    "url": "https://test.1ink.us/image_video_effects/shaders/interactive-pcb-traces.wgsl",
+    "url": "shaders/interactive-pcb-traces.wgsl",
     "description": "Simulates a circuit board where traces light up with data pulses driven by the mouse.",
     "params": [
       {
@@ -1578,7 +1578,7 @@
     "id": "luma-smear-interactive",
     "name": "Kinetic Echo",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/luma-smear-interactive.wgsl",
+    "url": "shaders/luma-smear-interactive.wgsl",
     "description": "Creates a motion trail with chromatic smear (R lags, B leads). Bright objects leave decaying trails. Curl turbulence and audio gusts add organic chaos. Depth controls viscosity.",
     "features": [
       "mouse-driven",
@@ -1632,7 +1632,7 @@
   {
     "id": "neon-edge-glow",
     "name": "Neon Edge Glow",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-edge-glow.wgsl",
+    "url": "shaders/neon-edge-glow.wgsl",
     "category": "visual-effects",
     "description": "Gas discharge tube simulation with accurate neon emission spectrum, AC rectification flicker, mercury vapor secondary lines, electrode sputtering, and atmospheric haze. Bass drives flicker frequency, mouse bends the tube, depth controls atmospheric scatter.",
     "tags": [
@@ -1697,7 +1697,7 @@
   {
     "id": "neon-edge-pulse",
     "name": "Neon Edge Pulse",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-edge-pulse.wgsl",
+    "url": "shaders/neon-edge-pulse.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -1749,7 +1749,7 @@
   {
     "id": "neon-edge-reveal",
     "name": "Neon Edge Reveal",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-edge-reveal.wgsl",
+    "url": "shaders/neon-edge-reveal.wgsl",
     "description": "Neon edge detection with interactive flashlight reveal.",
     "params": [
       {
@@ -1801,7 +1801,7 @@
   },
   {
     "id": "neon-topology",
-    "url": "https://test.1ink.us/image_video_effects/shaders/neon-topology.wgsl",
+    "url": "shaders/neon-topology.wgsl",
     "description": "Renders the image as a glowing 3D topographic map.",
     "params": [
       {
@@ -1855,7 +1855,7 @@
   {
     "id": "phantom-lag",
     "name": "Phantom Lag",
-    "url": "https://test.1ink.us/image_video_effects/shaders/phantom-lag.wgsl",
+    "url": "shaders/phantom-lag.wgsl",
     "features": [
       "audio-reactive",
       "upgraded-rgba",
@@ -1902,7 +1902,7 @@
   {
     "id": "pixel-sorter",
     "name": "Pixel Sorter",
-    "url": "https://test.1ink.us/image_video_effects/shaders/pixel-sorter.wgsl",
+    "url": "shaders/pixel-sorter.wgsl",
     "description": "Glitch art pixel sorting with alpha translucency blending. Single sort pass with spectral tinting, depth-aware compositing, and audio-reactive shimmer.",
     "params": [
       {
@@ -1952,7 +1952,7 @@
   {
     "id": "quantum-field-visualizer",
     "name": "Quantum Field Visualizer",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-field-visualizer.wgsl",
+    "url": "shaders/quantum-field-visualizer.wgsl",
     "category": "visual-effects",
     "description": "Complex wavefunction visualization with real/imaginary parts mapped to hue, probability density to brightness, and phase to saturation. Features two-slit interference, Gaussian packet spreading, and mouse-driven quantum measurement collapse.",
     "params": [
@@ -2004,7 +2004,7 @@
     "id": "quantum-ghost",
     "name": "Quantum Ghost",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/quantum-ghost.wgsl",
+    "url": "shaders/quantum-ghost.wgsl",
     "description": "Quantum uncertainty visualization with Gaussian wave packet spreading, interference patterns from partial measurement, and entanglement correlation lines between ghost copies. Ghostly translucent copies with phase-dependent opacity, neon quantum numbers, HDR bloom on measurement events, ACES tone mapping, and chromatic separation by momentum uncertainty.",
     "features": [
       "mouse-driven",
@@ -2070,7 +2070,7 @@
       "audio-reactive",
       "upgraded-rgba"
     ],
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-distance-split.wgsl",
+    "url": "shaders/rgb-distance-split.wgsl",
     "description": "Chromatic aberration that intensifies with distance from the mouse.",
     "params": [
       {
@@ -2113,7 +2113,7 @@
     "id": "rgb-topology",
     "name": "RGB Topology",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/rgb-topology.wgsl",
+    "url": "shaders/rgb-topology.wgsl",
     "description": "Topographic contour extraction per RGB channel with 3D terrain visualization. Each channel is a heightfield with independent contour intervals, hypsometric tinting, HDR specular peaks, and chromatic blending at crossings.",
     "features": [
       "mouse-driven",
@@ -2165,7 +2165,7 @@
   {
     "id": "signal-modulation",
     "name": "Signal Modulation",
-    "url": "https://test.1ink.us/image_video_effects/shaders/signal-modulation.wgsl",
+    "url": "shaders/signal-modulation.wgsl",
     "description": "Simulates AM/FM signal distortion with mouse-controlled frequency and amplitude.",
     "features": [
       "mouse-driven",
@@ -2212,7 +2212,7 @@
   },
   {
     "id": "spectral-rain",
-    "url": "https://test.1ink.us/image_video_effects/shaders/spectral-rain.wgsl",
+    "url": "shaders/spectral-rain.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2274,7 +2274,7 @@
   {
     "id": "temporal-rgb-smear",
     "name": "Temporal RGB Smear",
-    "url": "https://test.1ink.us/image_video_effects/shaders/temporal-rgb-smear.wgsl",
+    "url": "shaders/temporal-rgb-smear.wgsl",
     "description": "Directional RGB smear with curl-noise velocity field, domain-warped drift, Halton-jittered chromatic sampling, temporal feedback decay, ACES tone mapping, and advanced layered alpha compositing (luminance key, edge preserve, effect intensity, depth layer, accumulative trails).",
     "params": [
       {
@@ -2388,7 +2388,7 @@
   {
     "id": "time-slit-scan",
     "name": "Time Slit Scan",
-    "url": "https://test.1ink.us/image_video_effects/shaders/time-slit-scan.wgsl",
+    "url": "shaders/time-slit-scan.wgsl",
     "description": "Multi-slit temporal scan with curved parametric slits, polar drift, and time-warp color tinting.",
     "features": [
       "mouse-driven",
@@ -2442,7 +2442,7 @@
   {
     "id": "voxel-grid",
     "name": "Voxel Grid",
-    "url": "https://test.1ink.us/image_video_effects/shaders/voxel-grid.wgsl",
+    "url": "shaders/voxel-grid.wgsl",
     "features": [
       "mouse-driven",
       "audio-reactive",
@@ -2502,7 +2502,7 @@
     "id": "warp-drive",
     "name": "Warp Drive",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/warp_drive.wgsl",
+    "url": "shaders/warp_drive.wgsl",
     "description": "Alcubierre warp metric approximation with radial compression ahead and expansion behind. Star streaks with relativistic Doppler shift, HDR bloom on contracted stars, chromatic aberration on high-velocity regions, and ACES tone mapping.",
     "features": [
       "audio-reactive",
@@ -2555,7 +2555,7 @@
     "id": "zipper-reveal",
     "name": "Zipper Reveal",
     "category": "visual-effects",
-    "url": "https://test.1ink.us/image_video_effects/shaders/zipper-reveal.wgsl",
+    "url": "shaders/zipper-reveal.wgsl",
     "description": "Mechanical zipper with interlocking tooth simulation, fabric physics, metallic specular highlights, and chromatic aberration on fast-moving teeth. Bass drives zipper speed and mouse controls pull position.",
     "params": [
       {

--- a/public/shaders/gen-prismatic-cyber-aether-void-kitsune.wgsl
+++ b/public/shaders/gen-prismatic-cyber-aether-void-kitsune.wgsl
@@ -1,0 +1,309 @@
+// ----------------------------------------------------------------
+// Prismatic Cyber-Aether Void-Kitsune
+// Category: generative
+// ----------------------------------------------------------------
+// --- COPY PASTE THIS HEADER ---
+@group(0) @binding(0) var u_sampler: sampler;
+@group(0) @binding(1) var readTexture: texture_2d<f32>;
+@group(0) @binding(2) var writeTexture: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(3) var<uniform> u: Uniforms;
+@group(0) @binding(4) var readDepthTexture: texture_2d<f32>;
+@group(0) @binding(5) var non_filtering_sampler: sampler;
+@group(0) @binding(6) var writeDepthTexture: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var dataTextureA: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(8) var dataTextureB: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(9) var dataTextureC: texture_2d<f32>;
+@group(0) @binding(10) var<storage, read_write> extraBuffer: array<f32>;
+@group(0) @binding(11) var comparison_sampler: sampler_comparison;
+@group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
+
+struct Uniforms {
+    config: vec4<f32>,       // x=Time, y=Audio/ClickCount, z=ResX, w=ResY
+    zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+    zoom_params: vec4<f32>,  // x=Tail Dispersion, y=Current Warp, z=Storm Density, w=Rune Glow
+    ripples: array<vec4<f32>, 50>,
+};
+
+const PI = 3.14159265359;
+
+fn rot2D(angle: f32) -> mat2x2<f32> {
+    let s = sin(angle);
+    let c = cos(angle);
+    return mat2x2<f32>(c, -s, s, c);
+}
+
+// 3D Simplex Noise for volumetric environment
+fn hash3(p: vec3<f32>) -> vec3<f32> {
+    var q = vec3<f32>(dot(p, vec3<f32>(127.1, 311.7, 74.7)),
+                      dot(p, vec3<f32>(269.5, 183.3, 246.1)),
+                      dot(p, vec3<f32>(113.5, 271.9, 124.6)));
+    return -1.0 + 2.0 * fract(sin(q) * 43758.5453123);
+}
+
+fn simplex_noise3d(p: vec3<f32>) -> f32 {
+    let i = floor(p + dot(p, vec3<f32>(1.0 / 3.0)));
+    let x0 = p - i + dot(i, vec3<f32>(1.0 / 6.0));
+    let g = step(x0.yzx, x0.xyz);
+    let l = 1.0 - g;
+    let i1 = min(g.xyz, l.zxy);
+    let i2 = max(g.xyz, l.zxy);
+    let x1 = x0 - i1 + vec3<f32>(1.0 / 6.0);
+    let x2 = x0 - i2 + vec3<f32>(1.0 / 3.0);
+    let x3 = x0 - 1.0 + vec3<f32>(0.5);
+    let i_hash = vec4<f32>(0.0);
+    var n = max(0.6 - vec4<f32>(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), vec4<f32>(0.0));
+    n = n * n * n * n;
+    let d0 = dot(hash3(i), x0);
+    let d1 = dot(hash3(i + i1), x1);
+    let d2 = dot(hash3(i + i2), x2);
+    let d3 = dot(hash3(i + 1.0), x3);
+    return 27.5 * dot(n, vec4<f32>(d0, d1, d2, d3));
+}
+
+fn fbm(p: vec3<f32>) -> f32 {
+    var f = 0.0;
+    var amp = 0.5;
+    var freq = p;
+    for(var i = 0; i < 4; i++) {
+        f += amp * simplex_noise3d(freq);
+        freq *= 2.0;
+        amp *= 0.5;
+    }
+    return f;
+}
+
+fn smooth_min(a: f32, b: f32, k: f32) -> f32 {
+    let h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+fn sdCapsule(p: vec3<f32>, a: vec3<f32>, b: vec3<f32>, r: f32) -> f32 {
+    let pa = p - a;
+    let ba = b - a;
+    let h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+    return length(pa - ba * h) - r;
+}
+
+fn sdBox(p: vec3<f32>, b: vec3<f32>) -> f32 {
+    let q = abs(p) - b;
+    return length(max(q, vec3<f32>(0.0))) + min(max(q.x, max(q.y, q.z)), 0.0);
+}
+
+// Distance, Material ID, Glow Intensity
+fn map(p: vec3<f32>) -> vec3<f32> {
+    var p_warp = p;
+    // Mouse current warp
+    let mouse = u.zoom_config.yz; // [-1, 1] normalized space
+    let dist = length(p_warp.xy - vec2<f32>(mouse.x * 3.0, -mouse.y * 3.0));
+    let warp_factor = u.zoom_params.y / (1.0 + dist * dist * 5.0); // u.zoom_params.y is Current Warp
+    p_warp -= vec3<f32>(mouse.x * 2.0, -mouse.y * 2.0, 0.0) * warp_factor;
+
+    let t = u.config.x;
+    let bass = plasmaBuffer[0].x;
+    let tail_disp = u.zoom_params.x; // Tail Dispersion
+
+    // 1. Cybernetic Kitsune Body (Mechanical/Crystalline Armor)
+    var p_body = p_warp;
+    // Slight breathing/floating motion
+    p_body.y += sin(t * 1.5) * 0.1;
+
+    // Core body (capsule)
+    var d_body = sdCapsule(p_body, vec3<f32>(0.0, 0.0, 1.0), vec3<f32>(0.0, -0.2, -1.0), 0.3);
+    // Head
+    let p_head = p_body - vec3<f32>(0.0, 0.4, 1.5);
+    var d_head = sdCapsule(p_head, vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(0.0, 0.0, 0.4), 0.25);
+    // Snout
+    d_head = smooth_min(d_head, sdCapsule(p_head, vec3<f32>(0.0, 0.0, 0.4), vec3<f32>(0.0, -0.1, 0.8), 0.1), 0.1);
+    // Ears
+    let p_ear_l = p_head - vec3<f32>(0.15, 0.2, 0.0);
+    var d_ear_l = sdCapsule(p_ear_l, vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(0.2, 0.4, -0.1), 0.05);
+    let p_ear_r = p_head - vec3<f32>(-0.15, 0.2, 0.0);
+    var d_ear_r = sdCapsule(p_ear_r, vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(-0.2, 0.4, -0.1), 0.05);
+    d_head = smooth_min(d_head, d_ear_l, 0.05);
+    d_head = smooth_min(d_head, d_ear_r, 0.05);
+
+    d_body = smooth_min(d_body, d_head, 0.2);
+
+    // Cyber-armor plates (boxes booleaned out or added)
+    let p_armor = p_body;
+    let d_armor = sdBox(p_armor, vec3<f32>(0.35, 0.35, 0.8)) - 0.05;
+    d_body = max(d_body, -sdBox(p_armor - vec3<f32>(0.0, 0.0, -0.2), vec3<f32>(0.4, 0.02, 1.0))); // Cuts
+    d_body = smooth_min(d_body, sdBox(p_armor - vec3<f32>(0.0, 0.2, 0.0), vec3<f32>(0.2, 0.2, 0.5)), 0.1); // Back ridge
+
+    // Rune Glow (Runes on body)
+    let rune_noise = simplex_noise3d(p_body * 10.0 + vec3<f32>(0.0, 0.0, -t * 2.0));
+    var rune_glow = 0.0;
+    if (d_body < 0.1 && rune_noise > 0.6) {
+        rune_glow = (rune_noise - 0.6) * 2.5 * u.zoom_params.w * (1.0 + bass * 2.0); // Rune Glow param
+    }
+
+    // 2. Nine Volumetric Aether Tails
+    var d_tails = 100.0;
+    var tail_glow = 0.0;
+    let tail_origin = vec3<f32>(0.0, -0.1, -1.0);
+
+    for (var i = 0; i < 9; i++) {
+        let angle = f32(i) / 9.0 * PI * 2.0 + sin(t * 0.5) * 0.2;
+        let s = sin(angle);
+        let c = cos(angle);
+
+        // Spread tails out backwards and outwards
+        let dir = vec3<f32>(s * tail_disp, sin(t + f32(i)) * 0.5 * tail_disp, -1.5 - cos(angle)*0.2 * tail_disp);
+        let dir_norm = normalize(dir);
+
+        var p_tail = p_warp - tail_origin;
+        // Project p_tail onto the tail direction
+        let h = clamp(dot(p_tail, dir_norm), 0.0, length(dir) * 2.0);
+
+        // Wavy motion based on audio and time
+        let wave = sin(h * 2.0 - t * 3.0 + f32(i)) * 0.2 * (1.0 + bass);
+        p_tail -= dir_norm * h + vec3<f32>(wave * c, wave, wave * s);
+
+        // Tapering tail radius
+        let r = 0.15 * smoothstep(0.0, 1.0, h) * smoothstep(length(dir) * 2.0, 1.0, h) * (1.0 + simplex_noise3d(p_tail * 5.0 + t) * 0.3);
+
+        let d_t = length(p_tail) - r;
+        d_tails = smooth_min(d_tails, d_t, 0.3);
+
+        if (d_t < 0.5) {
+            tail_glow += 0.05 / (0.01 + d_t * d_t) * (0.5 + bass * 1.5);
+        }
+    }
+
+    // Combine
+    var d_final = d_body;
+    var mat_id = 1.0; // 1 = Body, 2 = Tails
+
+    if (d_tails < d_body) {
+        d_final = d_tails;
+        mat_id = 2.0;
+    }
+
+    // Add floor/environment? No, floating in void.
+
+    return vec3<f32>(d_final, mat_id, max(rune_glow, tail_glow));
+}
+
+fn calcNormal(p: vec3<f32>) -> vec3<f32> {
+    let e = vec2<f32>(0.001, 0.0);
+    return normalize(vec3<f32>(
+        map(p + e.xyy).x - map(p - e.xyy).x,
+        map(p + e.yxy).x - map(p - e.yxy).x,
+        map(p + e.yyx).x - map(p - e.yyx).x
+    ));
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let dimensions = textureDimensions(writeTexture);
+    if (id.x >= dimensions.x || id.y >= dimensions.y) {
+        return;
+    }
+    let res = vec2<f32>(f32(dimensions.x), f32(dimensions.y));
+    let uv = (vec2<f32>(f32(id.x), f32(id.y)) - 0.5 * res) / res.y;
+
+    let t = u.config.x;
+    let bass = plasmaBuffer[0].x;
+
+    // Camera setup
+    var ro = vec3<f32>(0.0, 1.0, 4.0);
+    ro.x = sin(t * 0.2) * 2.0;
+    ro.z = cos(t * 0.2) * 4.0;
+    let ta = vec3<f32>(0.0, 0.0, 0.0);
+    let ww = normalize(ta - ro);
+    let uu = normalize(cross(ww, vec3<f32>(0.0, 1.0, 0.0)));
+    let vv = normalize(cross(uu, ww));
+    let rd = normalize(uv.x * uu + uv.y * vv + 1.2 * ww);
+
+    // Raymarching
+    var p = ro;
+    var t_dist = 0.0;
+    var res_map: vec3<f32>;
+    var hit = false;
+    var total_glow = 0.0;
+
+    for (var i = 0; i < 100; i++) {
+        p = ro + rd * t_dist;
+        res_map = map(p);
+        total_glow += res_map.z; // Accumulate glow from runes/tails
+        if (res_map.x < 0.001) {
+            hit = true;
+            break;
+        }
+        if (t_dist > 15.0) {
+            break;
+        }
+        t_dist += res_map.x * 0.8;
+    }
+
+    var col = vec3<f32>(0.0);
+    let storm_density = u.zoom_params.z;
+
+    if (hit) {
+        let n = calcNormal(p);
+        let v = -rd;
+        let l = normalize(vec3<f32>(1.0, 2.0, 3.0));
+        let h_vec = normalize(v + l);
+
+        let dif = max(dot(n, l), 0.0);
+        let amb = 0.1 + 0.9 * max(0.0, dot(n, vec3<f32>(0.0, 1.0, 0.0)));
+        let spec = pow(max(dot(n, h_vec), 0.0), 32.0);
+        let fre = pow(clamp(1.0 - dot(n, v), 0.0, 1.0), 3.0);
+
+        if (res_map.y == 1.0) {
+            // Body - Prismatic / Crystalline Armor
+            let base_col = vec3<f32>(0.1, 0.1, 0.15); // Dark cybernetic
+            col = base_col * (dif + amb) + spec * 0.5;
+
+            // Refraction/Subsurface approximation (Prismatic)
+            let refr = fbm(p * 2.0 + t);
+            let prism_col = vec3<f32>(
+                0.5 + 0.5 * sin(refr * 10.0 + 0.0),
+                0.5 + 0.5 * sin(refr * 10.0 + 2.0),
+                0.5 + 0.5 * sin(refr * 10.0 + 4.0)
+            );
+            col += prism_col * fre * 0.5;
+
+            // Runes
+            col += vec3<f32>(0.0, 0.8, 1.0) * res_map.z; // Cyan glow
+
+        } else {
+            // Tails - Aether Plasma
+            let tail_uv = length(p.xy);
+            let plasma_col = mix(
+                vec3<f32>(1.0, 0.2, 0.8), // Magenta
+                vec3<f32>(1.0, 0.5, 0.0), // Orange
+                sin(p.z * 2.0 - t * 4.0) * 0.5 + 0.5
+            );
+            col = plasma_col * (0.5 + amb * 0.5) + spec * 0.2;
+            col += plasma_col * res_map.z * 0.2; // Self illumination
+        }
+    } else {
+        // Quantum-Storm Void Environment (Volumetric)
+        var vol_col = vec3<f32>(0.0);
+        var vol_t = 0.0;
+        for (var i = 0; i < 40; i++) {
+            let p_vol = ro + rd * vol_t;
+            let density = fbm(p_vol * 1.5 - vec3<f32>(0.0, 0.0, t * 1.0));
+            if (density > 0.4) {
+                let d = (density - 0.4) * storm_density * (1.0 + bass);
+                vol_col += vec3<f32>(0.2, 0.0, 0.4) * d * 0.1; // Dark matter purple
+            }
+            vol_t += 0.3;
+        }
+        col = vol_col;
+    }
+
+    // Add accumulated glow bloom
+    let bloom_col = mix(vec3<f32>(1.0, 0.0, 0.5), vec3<f32>(0.0, 1.0, 1.0), sin(t)*0.5+0.5);
+    col += bloom_col * total_glow * 0.01;
+
+    // Vignette
+    col *= 1.0 - 0.5 * length(uv);
+
+    // Tone mapping
+    col = col / (1.0 + col);
+    col = pow(col, vec3<f32>(0.4545)); // Gamma
+
+    textureStore(writeTexture, vec2<i32>(i32(id.x), i32(id.y)), vec4<f32>(col, 1.0));
+}

--- a/shader_definitions/generative/gen-prismatic-cyber-aether-void-kitsune.json
+++ b/shader_definitions/generative/gen-prismatic-cyber-aether-void-kitsune.json
@@ -1,0 +1,52 @@
+{
+  "id": "gen-prismatic-cyber-aether-void-kitsune",
+  "name": "Prismatic Cyber-Aether Void-Kitsune",
+  "category": "generative",
+  "tags": [
+    "kitsune",
+    "cybernetic",
+    "prismatic",
+    "aether",
+    "volumetric",
+    "fractal",
+    "audio-reactive"
+  ],
+  "description": "A hyper-majestic, cybernetic celestial kitsune forged from shattered prismatic glass and liquid quantum-aether, bounding violently through a multi-dimensional volumetric particle-storm while its nine radiant tails carve temporal auroral rifts into the void.",
+  "url": "shaders/gen-prismatic-cyber-aether-void-kitsune.wgsl",
+  "updatedParams": [
+    {
+      "index": 0,
+      "name": "Tail Dispersion",
+      "default": 1.0,
+      "min": 0.1,
+      "max": 3.0,
+      "step": 0.05
+    },
+    {
+      "index": 1,
+      "name": "Current Warp",
+      "default": 0.6,
+      "min": 0.0,
+      "max": 2.0,
+      "step": 0.05
+    },
+    {
+      "index": 2,
+      "name": "Storm Density",
+      "default": 0.5,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+    },
+    {
+      "index": 3,
+      "name": "Rune Glow",
+      "default": 1.2,
+      "min": 0.0,
+      "max": 3.0,
+      "step": 0.1
+    }
+  ],
+  "supportsDepth": true,
+  "supportsDof": false
+}

--- a/shader_plans/queue.json
+++ b/shader_plans/queue.json
@@ -1,1000 +1,6 @@
 {
   "pending": [
     {
-      "filename": "2026-07-18_fractal-cyber-aether-void-whale.md",
-      "title": "Fractal Cyber-Aether Void-Whale",
-      "added": "2026-07-18T15:15:08.317617"
-  "current": null,
-  "queue": [
-    {
-      "id": "physarum-sacred-geometry",
-      "date": "2026-04-25",
-      "file": "2026-04-25_physarum-sacred-geometry.md",
-      "title": "Physarum (Slime Mold) Sacred Geometry",
-      "status": "completed",
-      "created_at": "2026-04-25T12:00:00Z",
-      "completed_at": "2026-04-29T20:58:37.037485"
-    },
-    {
-      "id": "depth-refracted-liquid-stained-glass",
-      "date": "2026-04-25",
-      "file": "2026-04-25_depth-refracted-liquid-stained-glass.md",
-      "title": "Depth-Refracted Liquid Stained Glass",
-      "status": "completed",
-      "created_at": "2026-04-25T12:05:00Z",
-      "completed_at": "2026-04-29T20:56:44.916295"
-    },
-    {
-      "id": "cellular-automata-tapestry",
-      "date": "2026-04-25",
-      "file": "2026-04-25_cellular-automata-tapestry.md",
-      "title": "Cellular Automata Tapestry (Reaction-Diffusion)",
-      "status": "completed",
-      "created_at": "2026-04-25T12:20:00Z",
-      "completed_at": "2026-05-20T08:13:09.193083"
-    },
-    {
-      "id": "bioluminescent-reaction-diffusion",
-      "date": "2026-04-25",
-      "file": "2026-04-25_bioluminescent-reaction-diffusion.md",
-      "title": "Bioluminescent Reaction-Diffusion",
-      "status": "completed",
-      "created_at": "2026-04-25T12:40:00Z",
-      "completed_at": "2026-04-30T08:26:06.527848"
-    },
-    {
-      "id": "psychedelic-time-warp-kaleidoscope",
-      "date": "2026-04-25",
-      "file": "2026-04-25_psychedelic-time-warp-kaleidoscope.md",
-      "title": "Psychedelic Time-Warp Kaleidoscope",
-      "status": "completed",
-      "created_at": "2026-04-25T12:45:00Z",
-      "completed_at": "2026-05-01T07:53:18.089076"
-    },
-    {
-      "id": "neural-network-glow-synaptic-pulse",
-      "date": "2026-04-25",
-      "file": "2026-04-25_neural-network-glow-synaptic-pulse.md",
-      "title": "Neural Network Glow (Synaptic Pulse)",
-      "status": "completed",
-      "created_at": "2026-04-25T12:50:00Z",
-      "completed_at": "2026-05-02T08:08:41.067676"
-    },
-    {
-      "id": "dynamic-tessellation-ornate-fractal-tiles",
-      "date": "2026-04-25",
-      "file": "2026-04-25_dynamic-tessellation-ornate-fractal-tiles.md",
-      "title": "Dynamic Tessellation (Ornate Fractal Tiles)",
-      "status": "completed",
-      "created_at": "2026-04-25T12:55:00Z",
-      "completed_at": "2026-05-03T07:56:13.225883"
-    },
-    {
-      "id": "holographic-lens-flare-matrix",
-      "date": "2026-04-25",
-      "file": "2026-04-25_holographic-lens-flare-matrix.md",
-      "title": "Holographic Lens-Flare Matrix",
-      "status": "completed",
-      "created_at": "2026-04-25T13:00:00Z",
-      "completed_at": "2026-05-04T07:58:22.996783"
-    },
-    {
-      "id": "magnetic-field-warp",
-      "date": "2026-04-25",
-      "file": "2026-04-25_magnetic-field-warp.md",
-      "title": "Magnetic Field Warp (Quadratic Distortion + Spectral Modulation)",
-      "status": "completed",
-      "created_at": "2026-04-25T13:10:00Z",
-      "completed_at": "2026-05-05T08:20:13.305702"
-    },
-    {
-      "id": "psychedelic-layered-time-stamps",
-      "date": "2026-04-25",
-      "file": "2026-04-25_psychedelic-layered-time-stamps.md",
-      "title": "Psychedelic Layered Time-Stamps",
-      "status": "completed",
-      "created_at": "2026-04-25T13:15:00Z",
-      "completed_at": "2026-05-06T08:48:26.715685"
-    },
-    {
-      "id": "aurora-borealis-synthesis",
-      "date": "2026-04-25",
-      "file": "2026-04-25_aurora-borealis-synthesis.md",
-      "title": "Aurora Borealis Synthesis",
-      "status": "completed",
-      "created_at": "2026-04-25T13:20:00Z",
-      "completed_at": "2026-05-07T08:15:26.460644"
-    },
-    {
-      "id": "cosmic-clockwork-dyson-sphere",
-      "date": "2026-05-07",
-      "file": "2026-05-07_cosmic-clockwork-dyson-sphere.md",
-      "title": "Cosmic-Clockwork Dyson-Sphere",
-      "status": "completed",
-      "created_at": "2026-05-07T12:00:00Z",
-      "completed_at": "2026-05-08T08:16:36.936331"
-    },
-    {
-      "filename": "2026-06-14_astro-mechanical-quantum-furnace-engine.md",
-      "title": "Astro-Mechanical Quantum-Furnace Engine",
-      "added": "2026-06-15T08:16:35.280528+00:00",
-      "status": "completed",
-      "completed_at": "2026-06-15T08:16:35.280548+00:00"
-    },
-    {
-      "filename": "2026-03-15_chromatic-glass-lattice.md",
-      "title": "Chromatic Glass Lattice",
-      "added": "2026-03-15T15:34:17.644228",
-      "status": "completed",
-      "completed_at": "2026-06-27T22:10:10.774492+00:00"
-    },
-    {
-      "filename": "2026-03-19_tectonic-plasma-crucible.md",
-      "title": "Tectonic Plasma-Crucible",
-      "added": "2026-03-19T15:11:20.768331",
-      "status": "completed",
-      "completed_at": "2026-06-27T22:10:10.774492+00:00"
-    },
-    {
-      "filename": "2026-03-29_hyper-bismuth-clockwork.md",
-      "title": "Hyper-Bismuth Clockwork",
-      "added": "2026-03-29T15:19:48.492218",
-      "status": "completed",
-      "completed_at": "2026-06-27T22:10:10.774492+00:00"
-    },
-    {
-      "filename": "2026-04-13_resonant-crystal-canyons.md",
-      "title": "Resonant Crystal-Canyons",
-      "added": "2026-04-13T15:34:48.736863",
-      "status": "completed",
-      "completed_at": "2026-06-27T22:10:10.774492+00:00"
-    },
-    {
-      "filename": "2026-04-24_chronos-monolith-resonator.md",
-      "title": "Chronos Monolith Resonator",
-      "added": "2026-04-24T15:22:10.929711",
-      "status": "completed",
-      "completed_at": "2026-06-27T22:10:10.774492+00:00"
-    }
-  ],
-  "completed": [
-    {
-      "id": "chronos-labyrinth",
-      "date": "2026-03-06",
-      "file": "2026-03-06_chronos-labyrinth.md",
-      "title": "Chronos Labyrinth",
-      "status": "completed",
-      "created_at": "2026-03-06T08:00:00Z",
-      "implemented_at": "2026-03-06T22:30:00Z",
-      "shader_file": "gen-chronos-labyrinth.wgsl",
-      "json_file": "shader_definitions/generative/gen-chronos-labyrinth.json"
-    },
-    {
-      "filename": "2026-03-07_wasm-hls-physarum-swarm.md",
-      "title": "WASM + HLS Live + Physarum Swarm",
-      "added": "2026-03-07T09:02:06.984929",
-      "completed": "2026-03-07T09:06:35.397417"
-    },
-    {
-      "filename": "2026-03-08_live-studio-tab.md",
-      "title": "Live Studio Tab \u2013 HLS + WASM Toggle + Bilibili + Danmaku",
-      "added": "2026-03-07T09:08:09.892871",
-      "completed": "2026-03-07T09:13:43.539459"
-    },
-    {
-      "filename": "2026-03-08_silica-tsunami.md",
-      "title": "Silica Tsunami",
-      "added": "2026-03-09T09:15:40.174132",
-      "completed": "2026-03-09T09:17:37.021489"
-    },
-    {
-      "filename": "2026-03-09_prismatic-bismuth-lattice.md",
-      "title": "Prismatic Bismuth Lattice",
-      "added": "2026-03-10T06:33:35.731684",
-      "completed": "2026-03-10T08:27:17.542488"
-    },
-    {
-      "filename": "2026-03-10_ethereal-anemone-bloom.md",
-      "title": "Ethereal Anemone Bloom",
-      "added": "2026-03-10T15:14:50.343797",
-      "completed": "2026-03-11T08:08:07.114865"
-    },
-    {
-      "filename": "2026-03-11_quantum-mycelium.md",
-      "title": "Quantum Mycelium",
-      "added": "2026-03-11T15:31:45.995632",
-      "completed": "2026-03-12T07:58:56.991876"
-    },
-    {
-      "filename": "2026-03-09_cyber-terminal.md",
-      "title": "Procedural Cyber Terminal (ASCII)",
-      "added": "2026-03-13T07:45:39.513095",
-      "completed": "2026-03-13T07:45:39.788909"
-    },
-    {
-      "filename": "2026-03-13_stellar-web-loom.md",
-      "title": "Stellar Web-Loom",
-      "added": "2026-03-13T15:21:49.263536",
-      "completed": "2026-03-14T08:17:00.858096"
-    },
-    {
-      "filename": "2026-03-14_singularity-forge.md",
-      "title": "Singularity Forge",
-      "added": "2026-03-14T15:18:58.957503",
-      "completed": "2026-03-15T07:55:05.055057"
-    },
-    {
-      "filename": "2026-03-16_xeno-botanical-synth-flora.md",
-      "title": "Xeno-Botanical Synth-Flora",
-      "added": "2026-03-16T15:25:27.944847",
-      "completed": "2026-03-18T08:04:16.193555"
-    },
-    {
-      "filename": "2026-03-18_astro-kinetic-chrono-orrery.md",
-      "title": "Astro-Kinetic Chrono-Orrery",
-      "added": "2026-03-18T19:02:46.758765",
-      "completed": "2026-03-19T07:53:16.943885"
-    },
-    {
-      "filename": "2026-03-17_liquid-crystal-hive-mind.md",
-      "title": "Liquid-Crystal Hive-Mind",
-      "added": "2026-03-17T15:31:54.434850",
-      "completed": "2026-03-20T08:01:20.651116"
-    },
-    {
-      "filename": "2026-03-20_cymatic-plasma-mandalas.md",
-      "title": "Cymatic Plasma-Mandalas",
-      "added": "2026-03-20T15:31:45.190424",
-      "completed": "2026-03-21T08:11:54.781401"
-    },
-    {
-      "filename": "2026-03-21_neural-bioluminescence-matrix.md",
-      "title": "Neural Bioluminescence Matrix",
-      "added": "2026-03-21T15:11:15.598852",
-      "completed": "2026-03-22T08:00:10.225904"
-    },
-    {
-      "filename": "2026-03-22_quantum-aether-origami.md",
-      "title": "Quantum Aether-Origami",
-      "added": "2026-03-22T15:09:22.078836",
-      "completed": "2026-03-23T07:56:23.926242"
-    },
-    {
-      "filename": "2026-03-23_abyssal-leviathan-scales.md",
-      "title": "Abyssal Leviathan-Scales",
-      "added": "2026-03-23T16:03:21.686103",
-      "completed": "2026-03-24T08:00:07.312231"
-    },
-    {
-      "filename": "2026-03-24_celestial-prism-orchid.md",
-      "title": "Celestial Prism-Orchid",
-      "added": "2026-03-24T15:26:48.566026",
-      "completed": "2026-03-25T07:43:11.594675"
-    },
-    {
-      "filename": "2026-03-25_holographic-plasma-geode.md",
-      "title": "Holographic Plasma-Geode",
-      "added": "2026-03-25T15:19:07.269083",
-      "completed": "2026-03-26T08:23:03.337386"
-    },
-    {
-      "filename": "2026-03-08_raptor-mini.md",
-      "title": "Raptor Mini \u2013 Fast Predatory Agent Swarm",
-      "added": "2026-03-07T09:06:05.264901",
-      "completed": "2026-03-27T18:17:59.800656"
-    },
-    {
-      "filename": "2026-03-27_neuro-kinetic-bloom.md",
-      "title": "Neuro-Kinetic Bloom",
-      "added": "2026-03-27T15:37:45.737133",
-      "completed": "2026-03-28T08:13:31.787716"
-    },
-    {
-      "filename": "2026-03-26_kinetic-neo-brutalist-megastructure.md",
-      "title": "Kinetic Neo-Brutalist Megastructure",
-      "added": "2026-03-26T15:39:40.056097",
-      "completed": "2026-03-30T09:38:28.194104"
-    },
-    {
-      "filename": "2026-03-28_superfluid-quantum-foam.md",
-      "title": "Superfluid Quantum-Foam",
-      "added": "2026-03-28T15:11:35.996556",
-      "completed": "2026-03-29T07:49:53.914696"
-    },
-    {
-      "filename": "2026-03-30_vitreous-chrono-chandelier.md",
-      "title": "Vitreous Chrono-Chandelier",
-      "added": "2026-03-30T15:31:13.516101",
-      "completed": "2026-03-31T08:30:09.469115"
-    },
-    {
-      "filename": "2026-03-31_crystalline-chrono-dyson.md",
-      "title": "Crystalline Chrono-Dyson",
-      "added": "2026-03-31T15:50:46.809370",
-      "completed": "2026-04-01T07:57:32.902179"
-    },
-    {
-      "filename": "2026-04-02_prismatic-fractal-dunes.md",
-      "title": "Prismatic Fractal-Dunes",
-      "added": "2026-04-02T15:13:51.148460",
-      "completed": "2026-04-04T09:12:22.516241"
-    },
-    {
-      "filename": "2026-04-04_auroral-ferrofluid-monolith.md",
-      "title": "Auroral Ferrofluid-Monolith",
-      "added": "2026-04-04T15:21:49.409534",
-      "completed": "2026-04-05T07:58:27.698442"
-    },
-    {
-      "filename": "2026-04-03_hyper-dimensional-tesseract-labyrinth.md",
-      "title": "Hyper-Dimensional Tesseract-Labyrinth",
-      "added": "2026-04-03T15:22:03.198322",
-      "completed": "2026-04-05T04:23:40.625270"
-    },
-    {
-      "filename": "2026-04-05_prismatic-aether-loom.md",
-      "title": "Prismatic Aether-Loom",
-      "added": "2026-04-05T15:46:55.506556",
-      "completed": "2026-04-06T08:07:31.227027"
-    },
-    {
-      "filename": "2026-04-06_stellar-plasma-ouroboros.md",
-      "title": "Stellar Plasma-Ouroboros",
-      "added": "2026-04-06T15:09:44.223195",
-      "completed": "2026-04-07T07:54:12.218139"
-    },
-    {
-      "filename": "2026-04-07_chromodynamic-plasma-collider.md",
-      "title": "Chromodynamic Plasma-Collider",
-      "added": "2026-04-07T15:10:39.717708",
-      "completed": "2026-04-08T08:01:14.203447"
-    },
-    {
-      "filename": "2026-04-08_abyssal-chrono-coral.md",
-      "title": "Abyssal Chrono-Coral",
-      "added": "2026-04-08T15:28:10.450796",
-      "completed": "2026-04-09T08:05:58.457041"
-    },
-    {
-      "filename": "2026-03-08_silica-tsunami.md",
-      "title": "Silica Tsunami",
-      "added": "2026-03-08T15:23:19.072421",
-      "completed": "2026-04-10T07:53:58.129004"
-    },
-    {
-      "filename": "2026-04-08_abyssal-chrono-coral.md",
-      "title": "Abyssal Chrono-Coral",
-      "added": "2026-04-11T07:53:28.005948",
-      "completed": "2026-04-11T07:53:47.709581"
-    },
-    {
-      "filename": "2026-04-11_ethereal-quantum-medusa.md",
-      "title": "Ethereal Quantum-Medusa",
-      "added": "2026-04-11T15:33:41.719534",
-      "completed": "2026-04-12T07:54:46.291741"
-    },
-    {
-      "filename": "2026-04-10_nebular-chrono-astrolabe.md",
-      "title": "Nebular Chrono-Astrolabe",
-      "added": "2026-04-10T15:29:37.625891",
-      "completed": "2026-04-13T08:04:09.237312"
-    },
-    {
-      "filename": "2026-04-12_celestial-glass-tornado.md",
-      "title": "Celestial Glass-Tornado",
-      "added": "2026-04-12T15:14:01.691892",
-      "completed": "2026-04-14T19:23:51.665485"
-    },
-    {
-      "filename": "2026-04-14_graviton-plasma-lotus.md",
-      "title": "Graviton Plasma-Lotus",
-      "added": "2026-04-14T15:39:29.625548",
-      "completed": "2026-04-15T07:43:43.433522"
-    },
-    {
-      "filename": "2026-04-15_bioluminescent-aether-pulsar.md",
-      "title": "Bioluminescent Aether-Pulsar",
-      "added": "2026-04-15T15:49:38.606422",
-      "completed": "2026-04-16T08:50:49.214642"
-    },
-    {
-      "filename": "2026-04-16_hyper-refractive-rain-matrix.md",
-      "title": "Hyper-Refractive Rain-Matrix",
-      "added": "2026-04-16T19:08:37.280752",
-      "completed": "2026-04-17T08:28:04.125293"
-    },
-    {
-      "filename": "2026-04-17_obsidian-echo-chamber.md",
-      "title": "Obsidian Echo-Chamber",
-      "added": "2026-04-17T15:57:03.286480",
-      "completed": "2026-04-18T07:44:05.096378"
-    },
-    {
-      "filename": "2026-04-18_cybernetic-liquid-chrome-engine.md",
-      "title": "Cybernetic Liquid-Chrome Engine",
-      "added": "2026-04-18T15:22:21.729047",
-      "completed": "2026-04-19T07:55:07.659291"
-    },
-    {
-      "filename": "2026-04-19_liquid-neon-cyber-metropolis.md",
-      "title": "Liquid-Neon Cyber-Metropolis",
-      "added": "2026-04-19T15:27:30.255576",
-      "completed": "2026-04-21T08:31:57.908741"
-    },
-    {
-      "filename": "2026-04-21_xeno-mycelial-resonance-web.md",
-      "title": "Xeno-Mycelial Resonance-Web",
-      "added": "2026-04-21T15:55:37.022732",
-      "completed": "2026-04-23T08:07:44.631143"
-    },
-    {
-      "filename": "2026-04-22_photonic-crystal-brain.md",
-      "title": "Photonic Crystal-Brain",
-      "added": "2026-04-22T15:34:57.537389",
-      "completed": "2026-04-24T08:18:20.871715"
-    },
-    {
-      "filename": "2026-04-24_celestial-yggdrasil-matrix.md",
-      "title": "Celestial Yggdrasil-Matrix",
-      "added": "2026-04-24T08:20:42.751653",
-      "completed": "2026-04-25T07:41:52.548207"
-    },
-    {
-      "filename": "shader_plans/2026-04-25_gen-chromatic-vortex.md",
-      "title": "gen-chromatic-vortex",
-      "added": "2026-04-25T16:49:46.262667",
-      "completed": "2026-04-25T16:49:46.262667"
-    },
-    {
-      "filename": "shader_plans/2026-04-25_gen-nebula-light-trail-swarm.md",
-      "title": "gen-nebula-light-trail-swarm",
-      "added": "2026-04-25T16:49:46.262667",
-      "completed": "2026-04-25T16:49:46.262667"
-    },
-    {
-      "filename": "shader_plans/2026-04-25_gen-chrono-erosion-feedback-melting.md",
-      "title": "gen-chrono-erosion-feedback-melting",
-      "added": "2026-04-25T16:49:46.262667",
-      "completed": "2026-04-25T16:49:46.262667"
-    },
-    {
-      "filename": "2026-04-25_audiovisual-mandelbulb-raymarcher.md",
-      "title": "Audiovisual Mandelbulb Raymarcher",
-      "added": "2026-04-25T12:15:00Z",
-      "completed": "2026-04-25T14:56:15.153887+00:00"
-    },
-    {
-      "filename": "2026-04-25_glass-mosaic-liquid-refraction.md",
-      "title": "Glass Mosaic + Liquid Refraction",
-      "added": "2026-04-25T12:35:00Z",
-      "completed": "2026-04-25T14:56:15.153887+00:00"
-    },
-    {
-      "filename": "2026-04-25_sonic-lava-flow.md",
-      "title": "Sonic Lava Flow (Real-time Fluid + Feedback)",
-      "added": "2026-04-25T13:05:00Z",
-      "completed": "2026-04-25T14:56:15.153887+00:00"
-    },
-    {
-      "filename": "2026-04-25_physarum-sacred-geometry.md",
-      "title": "Physarum (Slime Mold) Sacred Geometry",
-      "added": "2026-04-26T07:58:29.428109",
-      "completed": "2026-04-26T07:58:42.364431"
-    },
-    {
-      "filename": "2026-04-25_depth-refracted-liquid-stained-glass.md",
-      "title": "Depth-Refracted Liquid Stained Glass",
-      "added": "2026-04-27T08:35:53.653297",
-      "completed": "2026-04-27T08:38:05.314618"
-    },
-    {
-      "filename": "2026-04-25_cellular-automata-tapestry.md",
-      "title": "Cellular Automata Tapestry",
-      "added": "2026-04-28T08:45:33.366898",
-      "completed": "2026-04-28T09:19:32.957866"
-    },
-    {
-      "filename": "2026-05-08_luminous-fluid-chladni-resonator.md",
-      "title": "Luminous-Fluid Chladni-Resonator",
-      "added": "2026-05-08T15:16:53.042126",
-      "completed": "2026-05-09T07:58:14.321343"
-    },
-    {
-      "filename": "2026-05-09_eldritch-tesseract-hive-mind.md",
-      "title": "Eldritch Tesseract-Hive Mind",
-      "added": "2026-05-09T15:44:19.573334",
-      "status": "completed",
-      "completed_at": "2026-05-10T08:06:56.153090"
-    },
-    {
-      "filename": "2026-05-11_holographic-bismuth-core-reactor.md",
-      "title": "Holographic Bismuth-Core Reactor",
-      "added": "2026-05-11T15:26:13.364552",
-      "status": "completed",
-      "completed_at": "2026-05-13T01:27:50.084790"
-    },
-    {
-      "filename": "2026-05-12_chronodynamic-aether-weaver-automata.md",
-      "title": "Chronodynamic Aether-Weaver Automata",
-      "added": "2026-05-12T16:02:59.245775",
-      "status": "completed",
-      "completed_at": "2026-05-13T08:00:43.479413"
-    },
-    {
-      "filename": "2026-05-13_sonoluminescent-chrono-geode-matrix.md",
-      "title": "Sonoluminescent Chrono-Geode Matrix",
-      "added": "2026-05-13T15:31:30.309550",
-      "status": "completed",
-      "completed_at": "2026-05-14T08:06:15.168165"
-    },
-    {
-      "filename": "2026-05-10_luminescent-chrono-fluid-astrolabe.md",
-      "title": "Luminescent Chrono-Fluid Astrolabe",
-      "added": "2026-05-10T15:17:16.993907",
-      "status": "completed",
-      "completed_at": "2026-05-15T09:32:43.396000"
-    },
-    {
-      "filename": "2026-05-15_chromatic-singularity-loom.md",
-      "title": "Chromatic Singularity-Loom",
-      "added": "2026-05-15T15:39:20.139263",
-      "status": "completed",
-      "completed_at": "2026-05-16T08:14:36.177786"
-    },
-    {
-      "filename": "2026-05-16_eldritch-quantum-fractal-eye.md",
-      "title": "Eldritch-Quantum Fractal-Eye",
-      "added": "2026-05-16T15:31:28.839031",
-      "status": "completed",
-      "completed_at": "2026-05-17T08:07:57.045934+00:00"
-    },
-    {
-      "filename": "2026-05-14_sentient-aether-flora-biosphere.md",
-      "title": "Sentient Aether-Flora Biosphere",
-      "added": "2026-05-14T15:36:23.346130",
-      "status": "completed",
-      "completed_at": "2026-05-18T08:05:26.307418"
-    },
-    {
-      "filename": "2026-05-18_neuro-kinetic-liquid-gold-lotus.md",
-      "title": "Neuro-Kinetic Liquid-Gold Lotus",
-      "added": "2026-05-18T15:31:30.137181",
-      "status": "completed",
-      "completed_at": "2026-05-19T08:05:03.936764"
-    },
-    {
-      "filename": "2026-05-20_glacial-aether-quantum-cavern.md",
-      "title": "Glacial-Aether Quantum-Cavern",
-      "added": "2026-05-20T15:23:23.838885",
-      "status": "completed",
-      "completed_at": "2026-05-21T08:04:09.058349Z"
-    },
-    {
-      "filename": "2026-05-19_radiant-quantum-crystalline-forge.md",
-      "title": "Radiant Quantum-Crystalline Forge",
-      "added": "2026-05-19T15:31:57.542248",
-      "status": "completed",
-      "completed_at": "2026-05-22T08:06:27.894420+00:00"
-    },
-    {
-      "filename": "2026-05-22_celestial-nanite-swarm-nebula.md",
-      "title": "Celestial Nanite-Swarm Nebula",
-      "added": "2026-05-22T15:37:16.206489",
-      "status": "completed",
-      "completed_at": "2026-05-23T08:00:21.072247+00:00"
-    },
-    {
-      "filename": "2026-05-23_radiant-chrono-glass-nautilus.md",
-      "title": "Radiant Chrono-Glass Nautilus",
-      "added": "2026-05-23T15:29:18.932464",
-      "status": "completed",
-      "completed_at": "2026-05-24T08:02:21.451411"
-    },
-    {
-      "filename": "2026-05-21_symbiotic-chrono-mycelium-engine.md",
-      "title": "Symbiotic Chrono-Mycelium Engine",
-      "added": "2026-05-21T15:41:08.968049",
-      "status": "completed",
-      "completed_at": "2026-05-25T08:09:38.635604+00:00"
-    },
-    {
-      "filename": "2026-05-25_quantum-entangled-ferrofluid-engine.md",
-      "title": "Quantum-Entangled Ferrofluid Engine",
-      "added": "2026-05-25T15:20:45.404707",
-      "status": "completed",
-      "completed_at": "2026-05-26T07:47:52.899529"
-    },
-    {
-      "filename": "2026-05-17_neon-plasma-biomechanical-hive.md",
-      "title": "Neon-Plasma Biomechanical Hive",
-      "added": "2026-05-17T15:31:50.867791",
-      "status": "completed",
-      "completed_at": "2026-05-27T08:04:46.221045"
-    },
-    {
-      "filename": "2026-05-27_quantum-fluorescent-aether-moth-swarm.md",
-      "title": "Quantum-Fluorescent Aether-Moth Swarm",
-      "added": "2026-05-27T15:22:31.200548",
-      "status": "completed",
-      "completed_at": "2026-05-28T08:20:01.794483"
-    },
-    {
-      "filename": "2026-05-26_prismatic-void-weaver-ouroboros.md",
-      "title": "Prismatic Void-Weaver Ouroboros",
-      "added": "2026-05-26T15:11:09.110950",
-      "status": "completed",
-      "completed_at": "2026-05-29T07:56:50.578853"
-    },
-    {
-      "filename": "2026-05-29_abyssal-quantum-leviathan-skeleton.md",
-      "title": "Abyssal Quantum-Leviathan Skeleton",
-      "added": "2026-05-29T15:12:02.977716",
-      "status": "completed",
-      "completed_at": "2026-05-30T08:07:04.507041Z"
-    },
-    {
-      "filename": "2026-05-30_celestial-aether-seraphim-wings.md",
-      "title": "Celestial Aether-Seraphim Wings",
-      "added": "2026-05-30T15:39:39.803092",
-      "status": "completed",
-      "completed_at": "2026-05-31T08:07:11.991076Z"
-    },
-    {
-      "filename": "2026-05-31_fractal-bioluminescence-spore-network.md",
-      "title": "Fractal Bioluminescence Spore-Network",
-      "added": "2026-05-31T15:24:58.286396",
-      "status": "completed",
-      "completed_at": "2026-06-01T08:15:01.889818"
-    },
-    {
-      "filename": "2026-06-01_bioluminescent-aether-jellyfish-swarm.md",
-      "title": "Bioluminescent Aether-Jellyfish Swarm",
-      "added": "2026-06-01T15:31:20.549711",
-      "status": "completed",
-      "completed_at": "2026-06-02T08:00:13.316393"
-    },
-    {
-      "filename": "2026-06-02_ethereal-aurora-ghost-orchid.md",
-      "title": "Ethereal-Aurora Ghost-Orchid",
-      "added": "2026-06-02T15:23:11.925761",
-      "status": "completed",
-      "completed_at": "2026-06-03T07:52:28.041657"
-    },
-    {
-      "filename": "2026-06-03_kryonic-quantum-aether-fractal-core.md",
-      "title": "Kryonic Quantum-Aether Fractal-Core",
-      "added": "2026-06-03T15:20:14.092972",
-      "status": "completed",
-      "completed_at": "2026-06-04T07:49:20.431145"
-    },
-    {
-      "filename": "2026-06-04_celestial-quantum-glass-dragonfly.md",
-      "title": "Celestial Quantum-Glass Dragonfly",
-      "added": "2026-06-04T15:14:39.362763",
-      "status": "completed",
-      "completed_at": "2026-06-05T07:46:24.481824"
-    },
-    {
-      "filename": "2026-06-05_cyber-organic-liquid-neon-pulsar.md",
-      "title": "Cyber-Organic Liquid-Neon Pulsar",
-      "added": "2026-06-05T15:36:13.973797",
-      "status": "completed",
-      "completed_at": "2026-06-06T08:04:08.472825"
-    },
-    {
-      "filename": "2026-06-06_resonant-quantum-obsidian-scarab-engine.md",
-      "title": "Resonant Quantum-Obsidian Scarab-Engine",
-      "added": "2026-06-06T15:23:53.271172",
-      "status": "completed",
-      "completed_at": "2026-06-07T08:03:28.527857"
-    },
-    {
-      "filename": "2026-06-07_prismatic-cyber-auroral-manta-swarm.md",
-      "title": "Prismatic Cyber-Auroral Manta-Swarm",
-      "added": "2026-06-07T15:33:14.275573",
-      "status": "completed",
-      "completed_at": "2026-06-08T07:42:17.908374"
-    },
-    {
-      "filename": "2026-06-08_luminescent-quantum-glass-phoenix-egg.md",
-      "title": "Luminescent Quantum-Glass Phoenix-Egg",
-      "added": "2026-06-08T15:22:03.386466",
-      "status": "completed",
-      "completed_at": "2026-06-09T07:55:38.051585"
-    },
-    {
-      "filename": "2026-06-09_astral-silk-chrono-weaver-arachnid.md",
-      "title": "Astral-Silk Chrono-Weaver Arachnid",
-      "added": "2026-06-10T10:14:25.165391",
-      "status": "completed",
-      "completed_at": "2026-06-10T10:15:17.541581"
-    },
-    {
-      "filename": "2026-06-11_quantum-chrome-serpent-ouroboros.md",
-      "title": "Quantum-Chrome Serpent Ouroboros",
-      "added": "2026-06-11T15:28:50.752892",
-      "completed_at": "2026-06-12T08:04:00.397648"
-    },
-    {
-      "filename": "2026-06-12_galactic-aether-crystal-geode-core.md",
-      "title": "Galactic Aether-Crystal Geode-Core",
-      "added": "2026-06-12T15:24:16.468502",
-      "status": "completed",
-      "completed_at": "2026-06-13T07:58:07.092058"
-    },
-    {
-      "filename": "2026-06-13_quantum-fluorescent-nebula-anemone.md",
-      "title": "Quantum-Fluorescent Nebula-Anemone",
-      "added": "2026-06-13T15:22:08.269147",
-      "completed_at": "2026-06-14T08:01:11.577449Z",
-      "status": "completed"
-    },
-    {
-      "filename": "2026-06-15_ethereal-cyber-chrono-void-whale.md",
-      "title": "Ethereal Cyber-Chrono Void-Whale",
-      "added": "2026-06-15T15:39:03.587165",
-      "status": "completed",
-      "completed_at": "2026-06-16T07:58:13.747882"
-    },
-    {
-      "filename": "2026-06-16_radiant-quantum-plasma-kraken-core.md",
-      "title": "Radiant Quantum-Plasma Kraken-Core",
-      "added": "2026-06-16T15:20:48.581241",
-      "status": "completed",
-      "completed_at": "2026-06-17T08:05:34.723472+00:00"
-    },
-    {
-      "filename": "2026-06-17_ethereal-cyber-aurora-hummingbird-core.md",
-      "title": "Ethereal Cyber-Aurora Hummingbird-Core",
-      "added": "2026-06-17T15:33:53.664289",
-      "status": "completed",
-      "completed_at": "2026-06-18T08:06:36.537323Z"
-    },
-    {
-      "filename": "2026-06-18_luminescent-cyber-chrono-void-turtle.md",
-      "title": "Luminescent Cyber-Chrono Void-Turtle",
-      "added": "2026-06-18T15:10:05.146090",
-      "status": "completed",
-      "completed_at": "2026-06-19T07:51:53.315061"
-    },
-    {
-      "filename": "2026-06-19_sentient-liquid-neon-fractal-heart.md",
-      "title": "Sentient Liquid-Neon Fractal-Heart",
-      "added": "2026-06-19T15:25:04.778724",
-      "status": "completed",
-      "completed_at": "2026-06-20T07:57:23.769674"
-    },
-    {
-      "filename": "2026-06-22_sentient-quantum-chrono-leviathan-moth.md",
-      "title": "Sentient Quantum-Chrono Leviathan-Moth",
-      "added": "2026-06-22T16:53:28.307478",
-      "status": "completed",
-      "completed_at": "2026-06-23T08:06:03.999951"
-    },
-    {
-      "filename": "2026-06-23_radiant-cyber-chrono-void-stag.md",
-      "title": "Radiant Cyber-Chrono Void-Stag",
-      "added": "2026-06-23T15:35:22.251064",
-      "completed_at": "2026-06-24T07:53:52.437686"
-    },
-    {
-      "filename": "2026-06-24_luminescent-quantum-void-anglerfish.md",
-      "title": "Luminescent Quantum-Void Anglerfish",
-      "added": "2026-06-24T15:24:55.093666",
-      "status": "completed",
-      "completed_at": "2026-06-26T07:53:01.590413+00:00"
-    },
-    {
-      "filename": "2026-04-28_quantum-singularity-forge.md",
-      "title": "Quantum Singularity-Forge",
-      "added": "2026-04-28T15:29:27.490165",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:38:42.215772+00:00"
-    },
-    {
-      "filename": "2026-04-30_symbiotic-plasma-reef-matrix.md",
-      "title": "Symbiotic Plasma-Reef Matrix",
-      "added": "2026-04-30T15:18:07.778113",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:38:42.215772+00:00"
-    },
-    {
-      "filename": "2026-05-01_cymatic-quantum-silk-loom.md",
-      "title": "Cymatic Quantum-Silk Loom",
-      "added": "2026-05-01T15:13:04.099296",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:38:42.215772+00:00"
-    },
-    {
-      "filename": "2026-05-02_ethereal-glass-flora-terrarium.md",
-      "title": "Ethereal Glass-Flora Terrarium",
-      "added": "2026-05-02T15:31:52.502855",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:38:42.215772+00:00"
-    },
-    {
-      "filename": "2026-04-26_magnetic-ferrofluid-sculpture.md",
-      "title": "Magnetic Ferrofluid-Sculpture",
-      "added": "2026-04-26T15:06:38.672034",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:40:08.194Z"
-    },
-    {
-      "filename": "2026-04-27_hyper-dimensional-bismuth-matrix.md",
-      "title": "Hyper-Dimensional Bismuth-Matrix",
-      "added": "2026-04-27T15:22:10.278813",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:40:08.199Z"
-    },
-    {
-      "filename": "2026-05-03_cryogenic-frost-plasma-matrix.md",
-      "title": "Cryogenic Frost-Plasma Matrix",
-      "added": "2026-05-03T15:21:10.239966",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:45:27.480Z"
-    },
-    {
-      "filename": "2026-05-04_sentient-ferro-silicate-swarm.md",
-      "title": "Sentient Ferro-Silicate Swarm",
-      "added": "2026-05-04T15:48:06.428969",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:45:27.491Z"
-    },
-    {
-      "filename": "2026-05-06_cybernetic-mycelium-neural-web.md",
-      "title": "Cybernetic-Mycelium Neural-Web",
-      "added": "2026-05-06T15:43:32.368734",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:45:27.494Z"
-    },
-    {
-      "filename": "2026-05-28_ethereal-quantum-hologram-bonsai.md",
-      "title": "Ethereal Quantum-Hologram Bonsai",
-      "added": "2026-05-28T15:23:06.697098",
-      "status": "completed",
-      "completed_at": "2026-06-27T23:45:27.499Z"
-    },
-    {
-      "filename": "2026-06-27_prismatic-cyber-chrono-void-kitsune.md",
-      "title": "Prismatic Cyber-Chrono Void-Kitsune",
-      "added": "2026-06-27T15:24:02.938835",
-      "status": "completed",
-      "completed_at": "2026-06-28T07:41:07.235521"
-    },
-    {
-      "filename": "2026-06-10_neuro-fluid-plasma-lotus.md",
-      "title": "Neuro-Fluid Plasma-Lotus",
-      "added": "2026-06-10T15:27:36.556094",
-      "status": "completed",
-      "completed_at": "2026-06-28T07:41:07.235471"
-    },
-    {
-      "filename": "2026-06-20_prismatic-quantum-fractal-nautilus-engine.md",
-      "title": "Prismatic Quantum-Fractal Nautilus-Engine",
-      "added": "2026-06-20T15:09:34.367199",
-      "status": "completed",
-      "completed_at": "2026-06-28T07:41:07.235513"
-    },
-    {
-      "filename": "2026-06-21_resonant-quantum-plasma-dragon-eye.md",
-      "title": "Resonant Quantum-Plasma Dragon-Eye",
-      "added": "2026-06-21T15:07:33.808369",
-      "status": "completed",
-      "completed_at": "2026-06-28T07:41:07.235517"
-    },
-    {
-      "filename": "2026-06-29_prismatic-cyber-chrono-nebula-peacock.md",
-      "title": "Prismatic Cyber-Chrono Nebula-Peacock",
-      "added": "2026-06-29T15:34:23.065054",
-      "status": "completed",
-      "completed_at": "2026-07-03T08:13:30.033474+00:00"
-    },
-    {
-      "filename": "2026-06-30_chrono-kitsune-prism-weaver.md",
-      "title": "Chrono-Kitsune Prism Weaver",
-      "added": "2026-06-30T00:00:00.000000",
-      "status": "completed",
-      "completed_at": "2026-06-30T22:14:50.031014+00:00"
-    },
-    {
-      "filename": "2026-07-04_ethereal-cyber-chrono-nebula-phoenix.md",
-      "title": "Ethereal Cyber-Chrono Nebula-Phoenix",
-      "added": "2026-07-04T07:47:29.783993",
-      "status": "completed",
-      "completed_at": "2026-07-04T19:45:50.569799+00:00"
-    },
-    {
-      "filename": "2026-07-04_ethereal-chrono-plasma-void-manta.md",
-      "title": "Ethereal Chrono-Plasma Void-Manta",
-      "added": "2026-07-04T15:19:54.098199",
-      "status": "completed",
-      "completed_at": "2026-07-05T08:34:32.089112+00:00"
-    },
-    {
-      "filename": "2026-07-06_prismatic-cyber-aurora-astral-dragonfly.md",
-      "title": "Prismatic Cyber-Aurora Astral-Dragonfly",
-      "added": "2026-07-06T09:12:47.917316",
-      "status": "completed",
-      "completed_at": "2026-07-06T09:37:38.389539+00:00"
-    },
-    {
-      "filename": "2026-07-02_luminescent-aether-plasma-nebula-koi.md",
-      "title": "Luminescent Aether-Plasma Nebula-Koi",
-      "added": "2026-07-02T15:17:55.851373",
-      "status": "completed",
-      "completed_at": "2026-07-08T00:22:46.930125+00:00"
-    },
-    {
-      "filename": "2026-07-07_ethereal-cyber-plasma-void-dragon.md",
-      "title": "Ethereal Cyber-Plasma Void-Dragon",
-      "added": "2026-07-07T15:21:35.078095",
-      "status": "completed",
-      "completed_at": "2026-07-09T10:19:11.342685+00:00"
-    },
-    {
-      "filename": "2026-07-10_luminescent-quantum-void-astral-turtle.md",
-      "title": "Luminescent Quantum-Void Astral-Turtle",
-      "added": "2026-07-10T15:15:18.904449",
-      "completed_at": "2026-07-11T07:55:47.993769+00:00",
-      "status": "completed"
-    },
-    {
-      "filename": "2026-07-11_bismuth-singularity-loom-engine.md",
-      "title": "Bismuth Singularity-Loom Engine",
-      "added": "2026-07-11T15:35:18.997905",
-      "completed_at": "2026-07-12T07:55:51.187169+00:00",
-      "status": "completed"
-    },
-    {
-      "filename": "2026-07-12_luminescent-chrono-prism-astro-stag.md",
-      "title": "Luminescent Chrono-Prism Astro-Stag",
-      "added": "2026-07-12T15:23:12.897598",
-      "completed_at": "2026-07-14T20:05:24.099703+00:00",
-      "status": "completed"
-    },
-    {
-      "filename": "2026-07-14_sentient-aether-plasma-nebula-moth.md",
-      "title": "Sentient Aether-Plasma Nebula-Moth",
-      "added": "2026-07-14T15:38:28.284590",
-      "status": "completed",
-      "completed_at": "2026-07-15T08:20:22.112486+00:00"
-    },
-    {
-      "filename": "2026-07-13_sentient-cyber-chrono-void-serpent.md",
-      "title": "Sentient Cyber-Chrono Void-Serpent",
-      "added": "2026-07-14T20:05:24.142806",
-      "completed_at": "2026-07-18T09:11:03.115830+00:00",
-      "status": "completed"
-    },
-    {
-      "filename": "2026-07-17_radiant-cyber-plasma-astro-griffin.md",
-      "title": "Radiant Cyber-Plasma Astro-Griffin",
-      "added": "2026-07-17T15:35:54.880329",
-      "status": "completed",
-      "completed_at": "2026-07-19T08:12:36.374269"
-    },
-    {
-      "filename": "2026-07-16_bioluminescent-chrono-plasma-astro-owl.md",
-      "title": "Bioluminescent Chrono-Plasma Astro-Owl",
-      "added": "2026-07-16T15:27:50.271053",
-      "status": "completed",
-      "completed_at": "2026-07-20T11:07:16.223369+00:00"
-    }
-  ],
-  "rejected": [],
-  "on_hold": [],
-  "metadata": {
-    "version": "1.0",
-    "description": "Shader plan queue - implement in FIFO order",
-    "rules": [
-      "Only implement 'approved' plans",
-      "Process in date order (oldest first)",
-      "Create one plan per day max",
-      "Each plan gets its own dated file"
-    ]
-  },
-  "pending": [
-    {
       "filename": "2026-03-12_cybernetic-ferro-coral.md",
       "title": "Cybernetic Ferro-Coral",
       "added": "2026-03-12T15:17:02.885309"
@@ -1323,13 +329,181 @@
       "filename": "2026-07-19_luminescent-aether-plasma-astro-axolotl.md",
       "title": "Luminescent Aether-Plasma Astro-Axolotl",
       "added": "2026-07-19T15:28:40.874418"
+    }
+  ],
+  "current": null,
+  "queue": [
+    {
+      "id": "physarum-sacred-geometry",
+      "date": "2026-04-25",
+      "file": "2026-04-25_physarum-sacred-geometry.md",
+      "title": "Physarum (Slime Mold) Sacred Geometry",
+      "status": "completed",
+      "created_at": "2026-04-25T12:00:00Z",
+      "completed_at": "2026-04-29T20:58:37.037485"
     },
+    {
+      "id": "depth-refracted-liquid-stained-glass",
+      "date": "2026-04-25",
+      "file": "2026-04-25_depth-refracted-liquid-stained-glass.md",
+      "title": "Depth-Refracted Liquid Stained Glass",
+      "status": "completed",
+      "created_at": "2026-04-25T12:05:00Z",
+      "completed_at": "2026-04-29T20:56:44.916295"
+    },
+    {
+      "id": "cellular-automata-tapestry",
+      "date": "2026-04-25",
+      "file": "2026-04-25_cellular-automata-tapestry.md",
+      "title": "Cellular Automata Tapestry (Reaction-Diffusion)",
+      "status": "completed",
+      "created_at": "2026-04-25T12:20:00Z",
+      "completed_at": "2026-05-20T08:13:09.193083"
+    },
+    {
+      "id": "bioluminescent-reaction-diffusion",
+      "date": "2026-04-25",
+      "file": "2026-04-25_bioluminescent-reaction-diffusion.md",
+      "title": "Bioluminescent Reaction-Diffusion",
+      "status": "completed",
+      "created_at": "2026-04-25T12:40:00Z",
+      "completed_at": "2026-04-30T08:26:06.527848"
+    },
+    {
+      "id": "psychedelic-time-warp-kaleidoscope",
+      "date": "2026-04-25",
+      "file": "2026-04-25_psychedelic-time-warp-kaleidoscope.md",
+      "title": "Psychedelic Time-Warp Kaleidoscope",
+      "status": "completed",
+      "created_at": "2026-04-25T12:45:00Z",
+      "completed_at": "2026-05-01T07:53:18.089076"
+    },
+    {
+      "id": "neural-network-glow-synaptic-pulse",
+      "date": "2026-04-25",
+      "file": "2026-04-25_neural-network-glow-synaptic-pulse.md",
+      "title": "Neural Network Glow (Synaptic Pulse)",
+      "status": "completed",
+      "created_at": "2026-04-25T12:50:00Z",
+      "completed_at": "2026-05-02T08:08:41.067676"
+    },
+    {
+      "id": "dynamic-tessellation-ornate-fractal-tiles",
+      "date": "2026-04-25",
+      "file": "2026-04-25_dynamic-tessellation-ornate-fractal-tiles.md",
+      "title": "Dynamic Tessellation (Ornate Fractal Tiles)",
+      "status": "completed",
+      "created_at": "2026-04-25T12:55:00Z",
+      "completed_at": "2026-05-03T07:56:13.225883"
+    },
+    {
+      "id": "holographic-lens-flare-matrix",
+      "date": "2026-04-25",
+      "file": "2026-04-25_holographic-lens-flare-matrix.md",
+      "title": "Holographic Lens-Flare Matrix",
+      "status": "completed",
+      "created_at": "2026-04-25T13:00:00Z",
+      "completed_at": "2026-05-04T07:58:22.996783"
+    },
+    {
+      "id": "magnetic-field-warp",
+      "date": "2026-04-25",
+      "file": "2026-04-25_magnetic-field-warp.md",
+      "title": "Magnetic Field Warp (Quadratic Distortion + Spectral Modulation)",
+      "status": "completed",
+      "created_at": "2026-04-25T13:10:00Z",
+      "completed_at": "2026-05-05T08:20:13.305702"
+    },
+    {
+      "id": "psychedelic-layered-time-stamps",
+      "date": "2026-04-25",
+      "file": "2026-04-25_psychedelic-layered-time-stamps.md",
+      "title": "Psychedelic Layered Time-Stamps",
+      "status": "completed",
+      "created_at": "2026-04-25T13:15:00Z",
+      "completed_at": "2026-05-06T08:48:26.715685"
+    },
+    {
+      "id": "aurora-borealis-synthesis",
+      "date": "2026-04-25",
+      "file": "2026-04-25_aurora-borealis-synthesis.md",
+      "title": "Aurora Borealis Synthesis",
+      "status": "completed",
+      "created_at": "2026-04-25T13:20:00Z",
+      "completed_at": "2026-05-07T08:15:26.460644"
+    },
+    {
+      "id": "cosmic-clockwork-dyson-sphere",
+      "date": "2026-05-07",
+      "file": "2026-05-07_cosmic-clockwork-dyson-sphere.md",
+      "title": "Cosmic-Clockwork Dyson-Sphere",
+      "status": "completed",
+      "created_at": "2026-05-07T12:00:00Z",
+      "completed_at": "2026-05-08T08:16:36.936331"
+    },
+    {
+      "filename": "2026-06-14_astro-mechanical-quantum-furnace-engine.md",
+      "title": "Astro-Mechanical Quantum-Furnace Engine",
+      "added": "2026-06-15T08:16:35.280528+00:00",
+      "status": "completed",
+      "completed_at": "2026-06-15T08:16:35.280548+00:00"
+    },
+    {
+      "filename": "2026-03-15_chromatic-glass-lattice.md",
+      "title": "Chromatic Glass Lattice",
+      "added": "2026-03-15T15:34:17.644228",
+      "status": "completed",
+      "completed_at": "2026-06-27T22:10:10.774492+00:00"
+    },
+    {
+      "filename": "2026-03-19_tectonic-plasma-crucible.md",
+      "title": "Tectonic Plasma-Crucible",
+      "added": "2026-03-19T15:11:20.768331",
+      "status": "completed",
+      "completed_at": "2026-06-27T22:10:10.774492+00:00"
+    },
+    {
+      "filename": "2026-03-29_hyper-bismuth-clockwork.md",
+      "title": "Hyper-Bismuth Clockwork",
+      "added": "2026-03-29T15:19:48.492218",
+      "status": "completed",
+      "completed_at": "2026-06-27T22:10:10.774492+00:00"
+    },
+    {
+      "filename": "2026-04-13_resonant-crystal-canyons.md",
+      "title": "Resonant Crystal-Canyons",
+      "added": "2026-04-13T15:34:48.736863",
+      "status": "completed",
+      "completed_at": "2026-06-27T22:10:10.774492+00:00"
+    },
+    {
+      "filename": "2026-04-24_chronos-monolith-resonator.md",
+      "title": "Chronos Monolith Resonator",
+      "added": "2026-04-24T15:22:10.929711",
+      "status": "completed",
+      "completed_at": "2026-06-27T22:10:10.774492+00:00"
+    }
+  ],
+  "completed": [
     {
       "filename": "2026-07-20_prismatic-cyber-aether-void-kitsune.md",
       "title": "Prismatic Cyber-Aether Void-Kitsune",
-      "added": "2026-07-20T15:39:23.592783"
+      "added": "2026-07-20T15:39:23.592783",
+      "status": "completed",
+      "completed_at": "2026-07-21T07:51:32.683192"
     }
   ],
-  "completed": [],
+  "rejected": [],
+  "on_hold": [],
+  "metadata": {
+    "version": "1.0",
+    "description": "Shader plan queue - implement in FIFO order",
+    "rules": [
+      "Only implement 'approved' plans",
+      "Process in date order (oldest first)",
+      "Create one plan per day max",
+      "Each plan gets its own dated file"
+    ]
+  },
   "in_progress": null
 }


### PR DESCRIPTION
Implements the `gen-prismatic-cyber-aether-void-kitsune.wgsl` generative shader based on the most recent plan, generates shader lists, syncs to the storage manager, and marks the task as completed in the queue. Also fixed a structural bug in `shader_plans/queue.json`.

---
*PR created automatically by Jules for task [11852454243403509985](https://jules.google.com/task/11852454243403509985) started by @ford442*