### PR TITLE
Fix QuotaExceededError when persisting control bindings

### DIFF
--- a/src/services/controlBindings.test.ts
+++ b/src/services/controlBindings.test.ts
@@ -4,6 +4,7 @@ import {
   LiveActionsHandle,
   loadBindings,
   saveBindings,
+  sanitizeBindings,
 } from './controlBindings';
 
 describe('ControlBindingRegistry', () => {
@@ -168,5 +169,93 @@ describe('localStorage persistence', () => {
     saveBindings(bindings);
     const loaded = loadBindings();
     expect(loaded).toHaveLength(100);
+  });
+
+  test('saveBindings survives QuotaExceededError without throwing', () => {
+    const bindings = [
+      {
+        trigger: { source: 'key' as const, id: 'a' },
+        action: { type: 'randomizeAll' as const },
+      },
+    ];
+    const originalSetItem = Storage.prototype.setItem;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    Storage.prototype.setItem = function setItem(key: string, value: string) {
+      if (key === 'vj_control_bindings') {
+        throw new DOMException('Quota exceeded', 'QuotaExceededError');
+      }
+      return originalSetItem.call(this, key, value);
+    };
+
+    expect(() => saveBindings(bindings)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+
+    Storage.prototype.setItem = originalSetItem;
+    warnSpy.mockRestore();
+  });
+
+  test('saveBindings retries with fewer entries after quota errors', () => {
+    const bindings = Array.from({ length: 4 }, (_, i) => ({
+      trigger: { source: 'key' as const, id: `key${i}` },
+      action: { type: 'randomizeAll' as const },
+    }));
+    const originalSetItem = Storage.prototype.setItem;
+    let attempts = 0;
+
+    Storage.prototype.setItem = function setItem(key: string, value: string) {
+      if (key === 'vj_control_bindings') {
+        attempts += 1;
+        const parsed = JSON.parse(value);
+        if (parsed.length > 2) {
+          throw new DOMException('Quota exceeded', 'QuotaExceededError');
+        }
+      }
+      return originalSetItem.call(this, key, value);
+    };
+
+    saveBindings(bindings);
+    expect(attempts).toBeGreaterThan(1);
+    expect(loadBindings()).toHaveLength(2);
+
+    Storage.prototype.setItem = originalSetItem;
+  });
+});
+
+describe('sanitizeBindings', () => {
+  test('filters invalid entries and truncates oversized strings', () => {
+    const longId = 'x'.repeat(200);
+    const longParam = 'p'.repeat(300);
+    const sanitized = sanitizeBindings([
+      {
+        trigger: { source: 'midi-cc', id: longId },
+        action: { type: 'setSlotParam', slot: 99, param: longParam },
+      },
+      {
+        trigger: { source: 'bad-source', id: 'x' },
+        action: { type: 'randomizeAll' },
+      },
+    ]);
+
+    expect(sanitized).toHaveLength(1);
+    expect(sanitized[0].trigger.id).toHaveLength(64);
+    expect((sanitized[0].action as { param: string }).param).toHaveLength(128);
+    expect((sanitized[0].action as { slot: number }).slot).toBe(2);
+  });
+
+  test('dedupes bindings by trigger', () => {
+    const sanitized = sanitizeBindings([
+      {
+        trigger: { source: 'key', id: 'a' },
+        action: { type: 'randomizeAll' },
+      },
+      {
+        trigger: { source: 'key', id: 'a' },
+        action: { type: 'triggerTransition' },
+      },
+    ]);
+
+    expect(sanitized).toHaveLength(1);
+    expect(sanitized[0].action).toEqual({ type: 'triggerTransition' });
   });
 });

--- a/src/services/controlBindings.ts
+++ b/src/services/controlBindings.ts
@@ -45,9 +45,59 @@ export interface LiveActionsHandle {
 
 const STORAGE_KEY = 'vj_control_bindings';
 const MAX_ENTRIES = 100;
+const MAX_TRIGGER_ID_LENGTH = 64;
+const MAX_PARAM_LENGTH = 128;
+const MAX_SLOT_INDEX = 2;
 
 function triggerKey(trigger: ControlTrigger): string {
   return `${trigger.source}::${trigger.id}`;
+}
+
+function clampString(value: string, maxLen: number): string {
+  return value.length <= maxLen ? value : value.slice(0, maxLen);
+}
+
+function isQuotaExceededError(err: unknown): boolean {
+  return (
+    err instanceof DOMException &&
+    (err.name === 'QuotaExceededError' || err.code === 22)
+  );
+}
+
+function normalizeBinding(binding: ControlBinding): ControlBinding {
+  const trigger: ControlTrigger = {
+    source: binding.trigger.source,
+    id: clampString(binding.trigger.id, MAX_TRIGGER_ID_LENGTH),
+  };
+
+  switch (binding.action.type) {
+    case 'setSlotParam':
+      return {
+        trigger,
+        action: {
+          type: 'setSlotParam',
+          slot: Math.max(0, Math.min(MAX_SLOT_INDEX, Math.floor(binding.action.slot))),
+          param: clampString(binding.action.param, MAX_PARAM_LENGTH),
+        },
+      };
+    case 'randomizeSlot':
+      return {
+        trigger,
+        action: {
+          type: 'randomizeSlot',
+          slot: Math.max(0, Math.min(MAX_SLOT_INDEX, Math.floor(binding.action.slot))),
+        },
+      };
+    default:
+      return { trigger, action: binding.action };
+  }
+}
+
+/** Validate, normalize, dedupe, and cap bindings before persistence or import. */
+export function sanitizeBindings(bindings: unknown[]): ControlBinding[] {
+  const valid = bindings.filter(isValidControlBinding).map(normalizeBinding);
+  const registry = new ControlBindingRegistry(valid);
+  return registry.getBindings().slice(0, MAX_ENTRIES);
 }
 
 export function makeTrigger(source: ControlSource, id: string): ControlTrigger {
@@ -137,7 +187,7 @@ export function loadBindings(): ControlBinding[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
-    return ControlBindingRegistry.deserialize(raw);
+    return sanitizeBindings(ControlBindingRegistry.deserialize(raw));
   } catch {
     return [];
   }
@@ -145,8 +195,40 @@ export function loadBindings(): ControlBinding[] {
 
 export function saveBindings(bindings: ControlBinding[]): void {
   if (typeof localStorage === 'undefined') return;
-  const capped = bindings.slice(0, MAX_ENTRIES);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(capped));
+
+  let attempt = sanitizeBindings(bindings);
+  let clearedStale = false;
+
+  while (true) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(attempt));
+      return;
+    } catch (err) {
+      if (!isQuotaExceededError(err)) {
+        console.warn('[controlBindings] failed to persist bindings:', err);
+        return;
+      }
+
+      if (!clearedStale) {
+        try {
+          localStorage.removeItem(STORAGE_KEY);
+        } catch {
+          // ignore
+        }
+        clearedStale = true;
+        continue;
+      }
+
+      if (attempt.length === 0) {
+        console.warn('[controlBindings] localStorage quota exceeded; bindings not saved');
+        return;
+      }
+
+      const nextLen = attempt.length <= 1 ? 0 : Math.floor(attempt.length / 2);
+      attempt = attempt.slice(0, nextLen);
+      clearedStale = false;
+    }
+  }
 }
 
 function isValidControlBinding(value: unknown): value is ControlBinding {

--- a/src/services/vjSetExport.ts
+++ b/src/services/vjSetExport.ts
@@ -5,7 +5,7 @@
  * Complements localStorage `myVjSets` and URL `?chain=` sharing.
  */
 
-import { ControlBinding } from './controlBindings';
+import { ControlBinding, sanitizeBindings } from './controlBindings';
 import { SharedChain, decodeChain, encodeChain, SHARED_CHAIN_VERSION } from './layerChainShare';
 import type { MyVjSet } from './myVjSets';
 
@@ -67,7 +67,9 @@ export function parseVjSetExport(raw: string): VjSetExportPayload | null {
       savedAt: typeof parsed.savedAt === 'number' ? parsed.savedAt : Date.now(),
       chain,
       chainString: typeof parsed.chainString === 'string' ? parsed.chainString : encodeChain(chain),
-      bindings: Array.isArray(parsed.bindings) ? parsed.bindings : undefined,
+      bindings: Array.isArray(parsed.bindings)
+        ? sanitizeBindings(parsed.bindings)
+        : undefined,
     };
   } catch {
     return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`saveBindings()` called `localStorage.setItem('vj_control_bindings', …)` without error handling. When localStorage is full (from ratings cache, VJ presets/history, etc.) or when imported bindings contain bloated data, the write throws an uncaught `QuotaExceededError` and crashes the live-control effect loop.

## Fix

- **`sanitizeBindings()`** — validates, normalizes, dedupes by trigger, truncates oversized strings, and caps at 100 entries before any persistence or import.
- **`saveBindings()`** — wraps `setItem` in try/catch; on quota errors, clears the stale key and retries with progressively fewer entries instead of throwing.
- **`loadBindings()`** — returns sanitized bindings so corrupted/oversized stored data is cleaned on read.
- **`parseVjSetExport()`** — sanitizes imported bindings so bad VJ set files can't poison localStorage.

## Tests

- QuotaExceededError no longer propagates uncaught
- Progressive retry saves a reduced binding set when quota is tight
- Sanitization filters invalid entries, truncates long strings, and dedupes triggers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b07e629-1235-4d3b-a5a9-4962d27be31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b07e629-1235-4d3b-a5a9-4962d27be31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic validation and normalization of imported and saved control bindings.
  - Duplicate, invalid, oversized, or out-of-range bindings are cleaned up automatically.
  - Binding storage now recovers from local storage quota limits by retrying with fewer entries.

- **Bug Fixes**
  - Prevented binding saves from failing when local storage is full.
  - Ensured imported control bindings are sanitized before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->