### PR TITLE
fix: CORS rating sync, readTex scalePass usage, quiet -sg probes

### DIFF
--- a/src/renderer/webgpu/pipeline.ts
+++ b/src/renderer/webgpu/pipeline.ts
@@ -107,7 +107,9 @@ export class WebGPUShaderManager {
 
     if (supportsSubgroups && !id.endsWith('-sg') && resolvedUrl.endsWith('.wgsl')) {
       const sgUrl = resolvedUrl.replace(/\.wgsl$/, '-sg.wgsl');
-      const sgWgsl = await fetchShaderWgsl(`${id}-sg`, sgUrl);
+      // Optional probe — primaryOnly avoids cascading 404s to CDN/storage when
+      // no subgroup variant exists (currently zero *-sg.wgsl files in-repo).
+      const sgWgsl = await fetchShaderWgsl(`${id}-sg`, sgUrl, { primaryOnly: true });
       if (sgWgsl) {
         const ok = this.compile(device, pipelineLayout, id, sgWgsl);
         if (ok) {

--- a/src/renderer/webgpu/resources.test.ts
+++ b/src/renderer/webgpu/resources.test.ts
@@ -1,12 +1,13 @@
 import { WebGPUResourcePool, createTextures } from './resources';
 
 // Minimal WebGPU globals for unit tests (no real GPU in Jest).
+// Values match the WebGPU TextureUsage bitflags.
 const TU = {
-  TEXTURE_BINDING: 0x04,
-  COPY_DST: 0x08,
   COPY_SRC: 0x01,
-  RENDER_ATTACHMENT: 0x10,
+  COPY_DST: 0x02,
+  TEXTURE_BINDING: 0x04,
   STORAGE_BINDING: 0x08,
+  RENDER_ATTACHMENT: 0x10,
 } as const;
 (global as unknown as { GPUTextureUsage: typeof TU }).GPUTextureUsage = TU;
 (global as unknown as { GPUBufferUsage: { UNIFORM: number; COPY_DST: number; STORAGE: number } }).GPUBufferUsage = {
@@ -56,5 +57,18 @@ describe('WebGPUResourcePool', () => {
     expect(set.sourceTex).toBeDefined();
     expect(set.readTex).toBeDefined();
     expect(set.readTex).not.toBe(set.sourceTex);
+  });
+
+  it('createTextures gives readTex RENDER_ATTACHMENT for scalePass', () => {
+    const device = makeMockDevice();
+    createTextures(device, 800, 600, 400, 300);
+
+    const readCall = (device.createTexture as jest.Mock).mock.calls.find(
+      ([desc]: [{ label?: string }]) => desc?.label === 'readTex',
+    );
+    expect(readCall).toBeDefined();
+    const usage = (readCall![0] as { usage: number }).usage;
+    expect(usage & TU.RENDER_ATTACHMENT).toBe(TU.RENDER_ATTACHMENT);
+    expect(usage & TU.STORAGE_BINDING).toBe(TU.STORAGE_BINDING);
   });
 });

--- a/src/renderer/webgpu/resources.ts
+++ b/src/renderer/webgpu/resources.ts
@@ -61,6 +61,11 @@ export function createTextures(
     GPUTextureUsage.COPY_DST |
     GPUTextureUsage.COPY_SRC;
 
+  // scalePass renders into readTex when resolutionScale < 1, so RENDER_ATTACHMENT
+  // is required in addition to the usual storage/copy usages.
+  const USAGE_READ =
+    USAGE_STANDARD | GPUTextureUsage.RENDER_ATTACHMENT;
+
   const sourceTex = device.createTexture({
     label: 'sourceTex',
     size: [fullW, fullH],
@@ -72,7 +77,7 @@ export function createTextures(
     label: 'readTex',
     size: [sw, sh],
     format: 'rgba32float',
-    usage: USAGE_STANDARD,
+    usage: USAGE_READ,
   });
 
   const writeTex = device.createTexture({

--- a/src/services/ratingCache.test.ts
+++ b/src/services/ratingCache.test.ts
@@ -118,7 +118,7 @@ describe('ratingCache', () => {
       );
     });
 
-    it('includes X-Idempotency-Key header in the POST', async () => {
+    it('sends idempotency_key in FormData without custom CORS headers', async () => {
       setRating('shader-a', 4);
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -127,14 +127,14 @@ describe('ratingCache', () => {
 
       await flushDirtyRatings(API_URL);
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'X-Idempotency-Key': expect.any(String),
-          }),
-        }),
-      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.headers).toBeUndefined();
+      expect(init.body).toBeInstanceOf(FormData);
+      const body = init.body as FormData;
+      expect(body.get('stars')).toBe('4');
+      expect(typeof body.get('idempotency_key')).toBe('string');
+      expect(String(body.get('idempotency_key')).length).toBeGreaterThan(0);
     });
 
     it('marks ratings as synced after a successful POST', async () => {

--- a/src/services/ratingCache.ts
+++ b/src/services/ratingCache.ts
@@ -5,7 +5,8 @@
 //  Features:
 //  - O(1) dirty index (px_dirty_list) so getDirtyRatings() avoids a linear scan
 //  - Jittered exponential backoff + circuit breaker in flushDirtyRatings()
-//  - X-Idempotency-Key header on sync POSTs so the server can deduplicate retries
+//  - Idempotency key sent as FormData (not a custom header) so CORS preflight
+//    stays compatible with storage.noahcohn.com Access-Control-Allow-Headers
 // ═══════════════════════════════════════════════════════════════════════════════
 
 const STORAGE_KEY_PREFIX = 'px_rating_';
@@ -32,7 +33,7 @@ export interface CachedRating {
   readonly rating: number;
   readonly dirty: boolean;
   readonly timestamp: number;
-  /** Unique key sent as X-Idempotency-Key so the server can deduplicate retries. */
+  /** Unique key sent as FormData `idempotency_key` so the server can deduplicate retries. */
   readonly idempotencyKey: string;
 }
 
@@ -205,7 +206,8 @@ export function markSynced(shaderId: string): void {
  * Attempt to flush all dirty ratings to the API.
  *
  * - Skips silently if the circuit-breaker is open.
- * - Sends X-Idempotency-Key on every POST so the server can deduplicate retries.
+ * - Sends idempotency_key in FormData (not a custom header) so CORS preflight
+ *   does not require x-idempotency-key in Access-Control-Allow-Headers.
  * - Consecutive failures open the circuit-breaker to prevent hammering a down backend.
  */
 export async function flushDirtyRatings(apiUrl: string): Promise<void> {
@@ -222,10 +224,11 @@ export async function flushDirtyRatings(apiUrl: string): Promise<void> {
     try {
       const formData = new FormData();
       formData.append('stars', entry.rating.toString());
+      // Body field — avoids custom-header CORS preflight rejection on storage API.
+      formData.append('idempotency_key', entry.idempotencyKey);
 
       const response = await fetch(`${apiUrl}/api/shaders/${shaderId}/rate`, {
         method: 'POST',
-        headers: { 'X-Idempotency-Key': entry.idempotencyKey },
         body: formData,
       });
 

--- a/src/utils/fetchShaderWgsl.test.ts
+++ b/src/utils/fetchShaderWgsl.test.ts
@@ -45,4 +45,29 @@ describe('fetchShaderWgsl', () => {
     const code = await fetchShaderWgsl('liquid', 'shaders/liquid.wgsl');
     expect(code).toContain('local');
   });
+
+  it('primaryOnly skips storage API fallback for optional probes', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/shaders/')) {
+        return new Response(JSON.stringify({ code: 'should-not-reach' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch;
+    global.fetch = fetchMock;
+
+    const code = await fetchShaderWgsl(
+      'motion-heatmap-sg',
+      'shaders/motion-heatmap-sg.wgsl',
+      { primaryOnly: true },
+    );
+
+    expect(code).toBeNull();
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/api/shaders/'))).toBe(false);
+    expect(urls.some((u) => u.includes('storage.noahcohn.com'))).toBe(false);
+  });
 });

--- a/src/utils/fetchShaderWgsl.ts
+++ b/src/utils/fetchShaderWgsl.ts
@@ -1,6 +1,16 @@
 import { STORAGE_API_URL } from '../config/appConfig';
 import { resolveShaderUrl } from './resolveShaderUrl';
 
+export interface FetchShaderWgslOptions {
+  /**
+   * When true, only try the caller-provided URL (plus a same-origin
+   * `./shaders/{id}.wgsl` probe). Skips CDN / storage API fallbacks.
+   * Use for optional assets such as `-sg.wgsl` subgroup variants so a
+   * missing file does not cascade into remote 404 spam.
+   */
+  primaryOnly?: boolean;
+}
+
 async function tryFetchWgsl(url: string): Promise<string | null> {
   try {
     const response = await fetch(url);
@@ -22,27 +32,35 @@ async function tryFetchWgsl(url: string): Promise<string | null> {
 /**
  * Fetch WGSL source for a shader, trying several hosting locations.
  *
- * Order:
- * 1. Caller-provided URL (absolute or resolved)
- * 2. Same-origin public/shaders copy (local dev + full app deploys)
- * 3. Static CDN base (test.1ink.us)
+ * Order (full cascade):
+ * 1. Same-origin public/shaders copy (local dev + full app deploys)
+ * 2. Caller-provided URL (absolute or resolved)
+ * 3. Static CDN base (test.1ink.us) via resolveShaderUrl
  * 4. Storage manager API (/api/shaders/{id}/code)
+ *
+ * With `primaryOnly: true`, only steps 1–2 run (no remote fallbacks).
  */
-export async function fetchShaderWgsl(id: string, url?: string): Promise<string | null> {
+export async function fetchShaderWgsl(
+  id: string,
+  url?: string,
+  options?: FetchShaderWgslOptions,
+): Promise<string | null> {
   const candidates: string[] = [
     `./shaders/${id}.wgsl`,
   ];
 
   if (url) {
     candidates.push(url);
-    if (!/^https?:\/\//i.test(url)) {
+    if (!options?.primaryOnly && !/^https?:\/\//i.test(url)) {
       candidates.push(resolveShaderUrl(url));
     }
-  } else {
+  } else if (!options?.primaryOnly) {
     candidates.push(resolveShaderUrl(`shaders/${id}.wgsl`));
   }
 
-  candidates.push(`${STORAGE_API_URL}/api/shaders/${id}/code`);
+  if (!options?.primaryOnly) {
+    candidates.push(`${STORAGE_API_URL}/api/shaders/${id}/code`);
+  }
 
   const seen = new Set<string>();
   for (const candidate of candidates) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three console failures seen on `test.1ink.us` against `storage.noahcohn.com`:

1. **CORS on star ratings** — `flushDirtyRatings` sent `X-Idempotency-Key`, which is not in the storage API’s `Access-Control-Allow-Headers`. Idempotency is now a FormData field (`idempotency_key`) so the preflight no longer fails.
2. **WebGPU `scalePass`** — when `resolutionScale < 1`, the frame encoder renders into `readTex`, but that texture lacked `RENDER_ATTACHMENT`. Added it via `USAGE_READ`.
3. **`-sg.wgsl` 404 cascade** — optional subgroup probes used the full WGSL fetch fallback chain (local → CDN → `/api/.../code`). With zero `*-sg` files in-repo, that spammed 404s. Probes now use `primaryOnly: true`.

## Notes

- `/api/shaders/{id}/play` 404s remain a backend/catalog issue (client already swallows the rejection).
- No GPU in this Cloud VM; validated via unit tests.

## Test plan

- [x] Targeted: `ratingCache` / `resources.test` / `fetchShaderWgsl`
- [x] Full Jest suite (48 suites / all pass)
- [ ] On a real GPU browser: rate a shader (network POST succeeds, no CORS error); confirm no `readTex` RenderAttachment validation error when resolution scale &lt; 1

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eaa7c55-cd87-490c-87f1-de1f0a96393b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eaa7c55-cd87-490c-87f1-de1f0a96393b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

