### PR TITLE
fix: repair corrupted fetchShaderWgsl.test.ts (TS1005)

### DIFF
--- a/src/renderer/webgpu/resources.test.ts
+++ b/src/renderer/webgpu/resources.test.ts
@@ -63,11 +63,14 @@ describe('WebGPUResourcePool', () => {
     const device = makeMockDevice();
     createTextures(device, 800, 600, 400, 300);
 
-    const readCall = (device.createTexture as jest.Mock).mock.calls.find(
-      ([desc]: [{ label?: string }]) => desc?.label === 'readTex',
+    const createTexture = device.createTexture as unknown as {
+      mock: { calls: Array<[{ label?: string; usage: number }]> };
+    };
+    const readCall = createTexture.mock.calls.find(
+      (call) => call[0]?.label === 'readTex',
     );
     expect(readCall).toBeDefined();
-    const usage = (readCall![0] as { usage: number }).usage;
+    const usage = readCall![0].usage;
     expect(usage & TU.RENDER_ATTACHMENT).toBe(TU.RENDER_ATTACHMENT);
     expect(usage & TU.STORAGE_BINDING).toBe(TU.STORAGE_BINDING);
   });

--- a/src/utils/fetchShaderWgsl.test.ts
+++ b/src/utils/fetchShaderWgsl.test.ts
@@ -51,9 +51,6 @@ describe('fetchShaderWgsl', () => {
     global.fetch = jest.fn(async (input: RequestInfo | URL) => {
       urls.push(String(input));
       if (String(input).includes('/api/shaders/')) {
-    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes('/api/shaders/')) {
         return new Response(JSON.stringify({ code: 'should-not-reach' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -61,7 +58,6 @@ describe('fetchShaderWgsl', () => {
       }
       return new Response('not found', { status: 404 });
     }) as typeof fetch;
-    global.fetch = fetchMock;
 
     const code = await fetchShaderWgsl(
       'motion-heatmap-sg',
@@ -70,7 +66,6 @@ describe('fetchShaderWgsl', () => {
     );
 
     expect(code).toBeNull();
-    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
     expect(urls.some((u) => u.includes('/api/shaders/'))).toBe(false);
     expect(urls.some((u) => u.includes('storage.noahcohn.com'))).toBe(false);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`main` has a broken `src/utils/fetchShaderWgsl.test.ts` from a bad merge (#1014/#1015) that spliced two implementations of the `primaryOnly` test together mid-function. That left unclosed braces → **TS1005: '}' expected** / Babel `Unexpected token`.

## Fix

- Rewrote the `primaryOnly` test cleanly: capture request URLs in a local array (no `fetchMock.mock`).
- Simplified the `readTex` RENDER_ATTACHMENT assertion in `resources.test.ts` to avoid `jest.Mock` cast + typed destructuring.

## Test plan

- [x] `npx react-scripts test --watchAll=false --ci --testPathPattern='fetchShaderWgsl|resources\\.test'`
- [ ] CI green on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eaa7c55-cd87-490c-87f1-de1f0a96393b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eaa7c55-cd87-490c-87f1-de1f0a96393b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for texture usage configuration.
  * Strengthened verification that primary-only shader fetching avoids storage fallback and remote requests.
  * Updated test mocks to provide more reliable request and resource-call tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->