### PR TITLE
fix: shader console 404/-sg spam + rating 422 against live API

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,7 +5,8 @@
 ## WGSL cross-cutting improvements (2026-07-12 audit)
 - **Engine wins (all shaders):** gate historyTex copy (only 11 use binding 13); reuse extraBuffer Float32Array; fix dataTexA/B→C double-copy in chained slots; merge queue submits; GPU image upload path.
 - **Mouse Y convention (2026-07-19):** Removed erroneous `1.0 - y` flip in `WebGPURenderer.updateMouse` — `zoom_config.yz` is now canvas UV (0=top, 1=bottom), matching WASM + `WGSL_BUILTINS_GENERATIVE.md`. Patched ~70 WGSL files that had compensating `1.0 - zoom_config.z` / `1.0 - mouseUV.y` / `(0.5 - mouse.y)` flips. Script: `scripts/fix_mouse_y_compensation.py`.
-- **Dormant infra:** subgroup `-sg.wgsl` loader (0 files); TS timestamp-query alloc unused.
+- **Dormant infra:** subgroup `-sg.wgsl` loader (0 files; probe disabled 2026-07-22 to stop 404 spam); TS timestamp-query alloc unused.
+- **Live rating API (2026-07-22):** `POST /api/shaders/{id}/rate` wants JSON `{ rating }` not FormData `{ stars }`. No `/api/shaders/{id}/play` on production. Use `postShaderRating()`.
 - **Format tradeoff:** rgba32float pipeline is quality-correct for HDR/sim but 4× bandwidth — don't downgrade without tiering.
 
 **Last updated (prior):** 2026-07-11 (Epic #912 foundation hardening in flight)

--- a/memory/2026-07-22.md
+++ b/memory/2026-07-22.md
@@ -133,3 +133,16 @@ User asked for project progress review, org/TS/C++/compile audit, next features 
 - #1011 generative updatedParams + extraBuffer CI
 - #1012 thumbs 27%→80%
 - #1013 WASM Tier A go/no-go + build de-dupe
+
+## Shader load blank / console 404+422 (afternoon)
+
+User report (Edge): rate 422, `*-sg.wgsl` 404, `/play` 404 — shaders “fail to load or load blank”.
+
+Root cause (live `storage.noahcohn.com` OpenAPI):
+1. **Rate 422:** client sent FormData `{stars}`; live expects JSON `{rating:0–5}` (`ShaderRatingUpdate`). Verified: FormData→422, JSON→200.
+2. **-sg 404:** pipeline probed optional subgroup variants; **0** `*-sg.wgsl` in repo → DevTools 404 spam (base `.wgsl` still 200).
+3. **Play 404:** `/api/shaders/{id}/play` **not deployed** (only songs/preset-packs have `/play`). Generic FastAPI `Not Found`.
+
+Fix branch `cursor/fix-shader-load-404-rate-422-167e`: `postShaderRating` helper, disable `-sg` probe, drop play POST, normalize `rating`→`stars`. Jest 339 pass.
+
+Note: true black canvas on headless Cloud VM is still no-GPU / blocked media hosts — separate from these console errors.

--- a/src/hooks/useShaderMode.ts
+++ b/src/hooks/useShaderMode.ts
@@ -3,7 +3,6 @@ import { RenderMode, ShaderEntry, InputSource, SlotParams } from '../renderer/ty
 import { RendererManager } from '../renderer/RendererManager';
 import { mapOrderedParamsToSlotParams } from '../utils/shaderParamMapping';
 import { getShaderDefaults } from '../app/constants/shaderDefaults';
-import { SHADER_WGSL_URL } from '../app/constants/fallbackContent';
 
 export interface UseShaderModeOptions {
     rendererRef: RefObject<RendererManager | null>;
@@ -124,12 +123,9 @@ export function useShaderMode({
                     });
                 }
 
-                if (ok) {
-                    fetch(`${SHADER_WGSL_URL}/${shaderEntry.id}/play`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                    }).catch(() => {});
-                }
+                // Note: production storage API has no /api/shaders/{id}/play
+                // (OpenAPI only exposes song/preset-pack play). Skipping avoids
+                // a 404 on every successful shader load that looks like a failure.
             } catch (error) {
                 console.error(`❌ Failed to load shader ${shaderEntry.id}:`, error);
                 slotShaderStatusRef.current[index] = 'error';

--- a/src/renderer/webgpu/pipeline.ts
+++ b/src/renderer/webgpu/pipeline.ts
@@ -105,10 +105,18 @@ export class WebGPUShaderManager {
 
     const resolvedUrl = resolveShaderUrl(url);
 
-    if (supportsSubgroups && !id.endsWith('-sg') && resolvedUrl.endsWith('.wgsl')) {
+    // Subgroup variants (`*-sg.wgsl`) are not shipped yet (0 files in-repo).
+    // Probing them on every load floods DevTools with 404s that look like
+    // "shader failed to load". Flip this when real -sg assets land.
+    const PROBE_SUBGROUP_VARIANTS = false;
+    if (
+      PROBE_SUBGROUP_VARIANTS &&
+      supportsSubgroups &&
+      !id.endsWith('-sg') &&
+      resolvedUrl.endsWith('.wgsl')
+    ) {
       const sgUrl = resolvedUrl.replace(/\.wgsl$/, '-sg.wgsl');
-      // Optional probe — primaryOnly avoids cascading 404s to CDN/storage when
-      // no subgroup variant exists (currently zero *-sg.wgsl files in-repo).
+      // Optional probe — primaryOnly avoids cascading 404s to CDN/storage.
       const sgWgsl = await fetchShaderWgsl(`${id}-sg`, sgUrl, { primaryOnly: true });
       if (sgWgsl) {
         const ok = this.compile(device, pipelineLayout, id, sgWgsl);

--- a/src/services/ShaderRatingIntegration.ts
+++ b/src/services/ShaderRatingIntegration.ts
@@ -12,8 +12,26 @@ import {
   getDirtyRatings,
   initOfflineSync,
 } from './ratingCache';
+import { postShaderRating } from './postShaderRating';
 
 const STORAGE_MANAGER_URL = STORAGE_API_URL;
+
+/** Live list payloads use `rating`; legacy used `stars`. Normalize for the UI. */
+function normalizeListedRating(raw: Record<string, unknown>): ShaderRating {
+  const id = String(raw.id ?? '');
+  const starsRaw = raw.stars ?? raw.rating ?? 0;
+  const stars = typeof starsRaw === 'number' ? starsRaw : 0;
+  const countRaw = raw.rating_count;
+  return {
+    id,
+    stars,
+    rating_count: typeof countRaw === 'number' ? countRaw : 0,
+    play_count: typeof raw.play_count === 'number' ? raw.play_count : undefined,
+    description: typeof raw.description === 'string' ? raw.description : undefined,
+    author: typeof raw.author === 'string' ? raw.author : undefined,
+    date: typeof raw.date === 'string' ? raw.date : undefined,
+  };
+}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 //  Types
@@ -68,15 +86,17 @@ export class ShaderRatingService {
       if (!response.ok) throw new Error('Failed to fetch ratings');
       const responseData = await response.json();
       
-      // Handle both array and wrapped response formats
-      let ratings: ShaderRating[];
+      // Handle both array and wrapped response formats; map `rating` → `stars`.
+      let rawList: Record<string, unknown>[];
       if (Array.isArray(responseData)) {
-        ratings = responseData;
+        rawList = responseData;
       } else if (responseData && typeof responseData === 'object' && Array.isArray(responseData.shaders)) {
-        ratings = responseData.shaders;
+        rawList = responseData.shaders;
       } else {
         throw new Error('Invalid response format');
       }
+
+      const ratings = rawList.map((r) => normalizeListedRating(r));
       
       // Update cache
       ratings.forEach(r => this.cache.set(r.id, r));
@@ -116,19 +136,21 @@ export class ShaderRatingService {
     cacheSetRating(shaderId, stars);
 
     try {
-      const formData = new FormData();
-      formData.append('stars', stars.toString());
-      
-      const response = await fetch(
-        `${STORAGE_MANAGER_URL}/api/shaders/${shaderId}/rate`,
-        { method: 'POST', body: formData }
-      );
-      
-      if (!response.ok) throw new Error('Failed to submit rating');
-      const updated: ShaderRating = await response.json();
+      const normalized = await postShaderRating(STORAGE_MANAGER_URL, shaderId, stars);
 
       // POST succeeded — mark the cached entry as synced
       markSynced(shaderId);
+
+      const cached = this.cache.get(shaderId);
+      const updated: ShaderRating = {
+        id: normalized.id,
+        stars: normalized.stars,
+        rating_count: normalized.rating_count || (cached?.rating_count ?? 0),
+        play_count: cached?.play_count,
+        description: cached?.description,
+        author: cached?.author,
+        date: cached?.date,
+      };
 
       // Update the individual cache entry and invalidate the list timestamp so
       // the next enrichWithRatings() / getRating() call fetches fresh data.

--- a/src/services/postShaderRating.test.ts
+++ b/src/services/postShaderRating.test.ts
@@ -1,0 +1,100 @@
+import {
+  normalizeShaderRatingResponse,
+  postShaderRating,
+} from './postShaderRating';
+
+describe('postShaderRating', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('POSTs JSON { rating } (not FormData stars)', async () => {
+    global.fetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          shader_id: 'glass-brick-distortion',
+          rating: 5,
+          has_errors: false,
+          message: 'Rating updated successfully',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    ) as typeof fetch;
+
+    const result = await postShaderRating(
+      'https://storage.noahcohn.com',
+      'glass-brick-distortion',
+      5,
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://storage.noahcohn.com/api/shaders/glass-brick-distortion/rate',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(typeof init.body).toBe('string');
+    expect(JSON.parse(String(init.body))).toEqual({ rating: 5 });
+    expect(result).toEqual({
+      id: 'glass-brick-distortion',
+      stars: 5,
+      rating_count: 0,
+      your_rating: 5,
+      has_errors: false,
+      message: 'Rating updated successfully',
+    });
+  });
+
+  it('includes notes and idempotency_key when provided', async () => {
+    global.fetch = jest.fn(async () =>
+      new Response(JSON.stringify({ rating: 4 }), { status: 200 }),
+    ) as typeof fetch;
+
+    await postShaderRating('https://storage.example.com/', 'liquid', 4, {
+      notes: 'nice',
+      idempotencyKey: 'abc123',
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      rating: 4,
+      notes: 'nice',
+      idempotency_key: 'abc123',
+    });
+  });
+
+  it('rejects out-of-range ratings before fetch', async () => {
+    global.fetch = jest.fn() as typeof fetch;
+    await expect(postShaderRating('https://x', 'a', 9)).rejects.toThrow(/0 and 5/);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('normalizeShaderRatingResponse', () => {
+  it('maps live { shader_id, rating } payload', () => {
+    expect(
+      normalizeShaderRatingResponse('x', { shader_id: 'x', rating: 3 }, 3),
+    ).toMatchObject({ id: 'x', stars: 3, your_rating: 3 });
+  });
+
+  it('maps legacy { id, stars, rating_count, your_rating } payload', () => {
+    expect(
+      normalizeShaderRatingResponse(
+        'x',
+        { id: 'x', stars: 4.2, rating_count: 10, your_rating: 5 },
+        5,
+      ),
+    ).toEqual({
+      id: 'x',
+      stars: 4.2,
+      rating_count: 10,
+      your_rating: 5,
+      has_errors: undefined,
+      message: undefined,
+    });
+  });
+});

--- a/src/services/postShaderRating.ts
+++ b/src/services/postShaderRating.ts
@@ -1,0 +1,109 @@
+/**
+ * POST /api/shaders/{id}/rate against storage.noahcohn.com.
+ *
+ * Live API contract (OpenAPI ShaderRatingUpdate):
+ *   Content-Type: application/json
+ *   body: { rating: 0–5, notes?: string | null }
+ *
+ * Response shape varies by backend revision; normalize to a stable client form.
+ */
+
+export interface PostShaderRatingOptions {
+  notes?: string | null;
+  /** Optional client-side dedupe token (ignored by current live schema). */
+  idempotencyKey?: string;
+}
+
+export interface NormalizedShaderRating {
+  id: string;
+  stars: number;
+  rating_count: number;
+  your_rating: number;
+  has_errors?: boolean;
+  message?: string;
+}
+
+function clampRating(rating: number): number {
+  if (!Number.isFinite(rating)) {
+    throw new RangeError('Rating must be a finite number');
+  }
+  const n = Math.round(rating);
+  if (n < 0 || n > 5) {
+    throw new RangeError('Rating must be between 0 and 5');
+  }
+  return n;
+}
+
+/**
+ * Normalize heterogeneous rate-endpoint payloads into { id, stars, ... }.
+ */
+export function normalizeShaderRatingResponse(
+  shaderId: string,
+  payload: unknown,
+  fallbackRating: number,
+): NormalizedShaderRating {
+  const data = (payload && typeof payload === 'object')
+    ? (payload as Record<string, unknown>)
+    : {};
+
+  const starsRaw = data.stars ?? data.rating ?? fallbackRating;
+  const stars = typeof starsRaw === 'number' ? starsRaw : fallbackRating;
+
+  const countRaw = data.rating_count;
+  const rating_count = typeof countRaw === 'number' ? countRaw : 0;
+
+  const yoursRaw = data.your_rating ?? data.rating ?? fallbackRating;
+  const your_rating = typeof yoursRaw === 'number' ? yoursRaw : fallbackRating;
+
+  const idRaw = data.id ?? data.shader_id ?? shaderId;
+  const id = typeof idRaw === 'string' ? idRaw : shaderId;
+
+  return {
+    id,
+    stars,
+    rating_count,
+    your_rating,
+    has_errors: typeof data.has_errors === 'boolean' ? data.has_errors : undefined,
+    message: typeof data.message === 'string' ? data.message : undefined,
+  };
+}
+
+/**
+ * Submit a shader star rating as JSON (production storage API).
+ */
+export async function postShaderRating(
+  apiBaseUrl: string,
+  shaderId: string,
+  rating: number,
+  options?: PostShaderRatingOptions,
+): Promise<NormalizedShaderRating> {
+  const value = clampRating(rating);
+  const base = apiBaseUrl.replace(/\/$/, '');
+  const body: Record<string, unknown> = { rating: value };
+
+  if (options?.notes !== undefined) {
+    body.notes = options.notes;
+  }
+  if (options?.idempotencyKey) {
+    body.idempotency_key = options.idempotencyKey;
+  }
+
+  const response = await fetch(`${base}/api/shaders/${encodeURIComponent(shaderId)}/rate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Rating failed (${response.status})`);
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  return normalizeShaderRatingResponse(shaderId, payload, value);
+}

--- a/src/services/ratingCache.test.ts
+++ b/src/services/ratingCache.test.ts
@@ -103,38 +103,41 @@ describe('ratingCache', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('POSTs dirty ratings to the correct endpoint', async () => {
+    it('POSTs dirty ratings as JSON { rating } to the correct endpoint', async () => {
       setRating('shader-a', 4);
       fetchMock.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ id: 'shader-a', stars: 4, rating_count: 1 }),
+        json: async () => ({ shader_id: 'shader-a', rating: 4 }),
       });
 
       await flushDirtyRatings(API_URL);
 
       expect(fetchMock).toHaveBeenCalledWith(
         `${API_URL}/api/shaders/shader-a/rate`,
-        expect.objectContaining({ method: 'POST' }),
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
       );
     });
 
-    it('sends idempotency_key in FormData without custom CORS headers', async () => {
+    it('sends idempotency_key in JSON body without custom CORS headers', async () => {
       setRating('shader-a', 4);
       fetchMock.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ id: 'shader-a', stars: 4, rating_count: 1 }),
+        json: async () => ({ shader_id: 'shader-a', rating: 4 }),
       });
 
       await flushDirtyRatings(API_URL);
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(init.headers).toBeUndefined();
-      expect(init.body).toBeInstanceOf(FormData);
-      const body = init.body as FormData;
-      expect(body.get('stars')).toBe('4');
-      expect(typeof body.get('idempotency_key')).toBe('string');
-      expect(String(body.get('idempotency_key')).length).toBeGreaterThan(0);
+      expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(typeof init.body).toBe('string');
+      const body = JSON.parse(String(init.body));
+      expect(body.rating).toBe(4);
+      expect(typeof body.idempotency_key).toBe('string');
+      expect(String(body.idempotency_key).length).toBeGreaterThan(0);
     });
 
     it('marks ratings as synced after a successful POST', async () => {

--- a/src/services/ratingCache.ts
+++ b/src/services/ratingCache.ts
@@ -5,9 +5,11 @@
 //  Features:
 //  - O(1) dirty index (px_dirty_list) so getDirtyRatings() avoids a linear scan
 //  - Jittered exponential backoff + circuit breaker in flushDirtyRatings()
-//  - Idempotency key sent as FormData (not a custom header) so CORS preflight
+//  - Idempotency key sent in JSON body (not a custom header) so CORS preflight
 //    stays compatible with storage.noahcohn.com Access-Control-Allow-Headers
 // ═══════════════════════════════════════════════════════════════════════════════
+
+import { postShaderRating } from './postShaderRating';
 
 const STORAGE_KEY_PREFIX = 'px_rating_';
 const DIRTY_LIST_KEY = 'px_dirty_list';
@@ -33,7 +35,7 @@ export interface CachedRating {
   readonly rating: number;
   readonly dirty: boolean;
   readonly timestamp: number;
-  /** Unique key sent as FormData `idempotency_key` so the server can deduplicate retries. */
+  /** Unique key sent as JSON `idempotency_key` so the server can deduplicate retries. */
   readonly idempotencyKey: string;
 }
 
@@ -206,8 +208,8 @@ export function markSynced(shaderId: string): void {
  * Attempt to flush all dirty ratings to the API.
  *
  * - Skips silently if the circuit-breaker is open.
- * - Sends idempotency_key in FormData (not a custom header) so CORS preflight
- *   does not require x-idempotency-key in Access-Control-Allow-Headers.
+ * - Sends idempotency_key in the JSON body (not a custom header) so CORS
+ *   preflight does not require x-idempotency-key in Access-Control-Allow-Headers.
  * - Consecutive failures open the circuit-breaker to prevent hammering a down backend.
  */
 export async function flushDirtyRatings(apiUrl: string): Promise<void> {
@@ -222,22 +224,12 @@ export async function flushDirtyRatings(apiUrl: string): Promise<void> {
 
     const entry = dirty[shaderId];
     try {
-      const formData = new FormData();
-      formData.append('stars', entry.rating.toString());
-      // Body field — avoids custom-header CORS preflight rejection on storage API.
-      formData.append('idempotency_key', entry.idempotencyKey);
-
-      const response = await fetch(`${apiUrl}/api/shaders/${shaderId}/rate`, {
-        method: 'POST',
-        body: formData,
+      // Live API: JSON { rating } — FormData { stars } returns 422.
+      await postShaderRating(apiUrl, shaderId, entry.rating, {
+        idempotencyKey: entry.idempotencyKey,
       });
-
-      if (response.ok) {
-        markSynced(shaderId);
-        recordSuccess();
-      } else {
-        recordFailure();
-      }
+      markSynced(shaderId);
+      recordSuccess();
     } catch (err: unknown) {
       console.warn(`[ratingCache] flush error for "${shaderId}":`, err);
       recordFailure();

--- a/src/services/shaderApi.ts
+++ b/src/services/shaderApi.ts
@@ -6,6 +6,7 @@
 import { STORAGE_API_URL, API_BASE_URL, SHADER_FILES_BASE_URL } from '../config/appConfig';
 import { resolveShaderUrl } from '../utils/resolveShaderUrl';
 import { fetchShaderWgsl } from '../utils/fetchShaderWgsl';
+import { postShaderRating } from './postShaderRating';
 
 const API_BASE = process.env.REACT_APP_API_BASE_URL || API_BASE_URL;
 
@@ -261,23 +262,14 @@ export async function updateShaderMetadata(
 
 /**
  * Rate a shader (1–5 stars).
- * Backend accepts FormData with a `stars` field via POST /api/shaders/{id}/rate.
+ * Live API: JSON `{ rating }` via POST /api/shaders/{id}/rate.
  */
 export async function rateShader(
   shaderId: string,
   stars: number
 ): Promise<{ id: string; stars: number; rating_count: number; your_rating: number }> {
   if (stars < 1 || stars > 5) throw new RangeError('Stars must be between 1 and 5');
-  const form = new FormData();
-  form.append('stars', String(stars));
-  
-  const res = await fetch(`${API_BASE}/api/shaders/${shaderId}/rate`, {
-    method: 'POST',
-    body: form,
-  });
-  
-  if (!res.ok) throw new Error('Rating failed');
-  return res.json();
+  return postShaderRating(API_BASE, shaderId, stars);
 }
 
 /**

--- a/src/services/storage/client.ts
+++ b/src/services/storage/client.ts
@@ -214,7 +214,7 @@ export class StorageClient {
     id: string;
     play_count: number;
     last_played: string;
-  }> {
+  } | null> {
     return ratings.recordShaderPlay(this.config, shaderId);
   }
 

--- a/src/services/storage/ratings.ts
+++ b/src/services/storage/ratings.ts
@@ -1,8 +1,12 @@
 /**
  * Shader rating endpoints — POST /api/shaders/{id}/rate
+ *
+ * Live storage API expects JSON `{ rating, notes? }` (ShaderRatingUpdate).
+ * Play recording (`/play`) is not deployed on production — no-op with warn.
  */
 
-import { encodeResourcePath, fetchJson, mapHttpError } from './http';
+import { encodeResourcePath, fetchJson } from './http';
+import { postShaderRating } from '../postShaderRating';
 import type { RateShaderResponse, ShaderItem, ShaderRatingInfo, StorageClientConfig } from './types';
 import { getShaderMeta } from './shaders';
 
@@ -10,25 +14,22 @@ export async function rateShader(
   config: StorageClientConfig,
   shaderId: string,
   stars: number,
-  _notes?: string
+  notes?: string
 ): Promise<RateShaderResponse> {
-  const encoded = encodeResourcePath(shaderId.replace(/\.json$/, ''));
-  const form = new FormData();
-  form.append('stars', String(stars));
-
-  const response = await fetch(`${config.apiUrl}/api/shaders/${encoded}/rate`, {
-    method: 'POST',
-    body: form,
+  const id = shaderId.replace(/\.json$/, '');
+  const normalized = await postShaderRating(config.apiUrl, id, stars, {
+    notes: notes ?? null,
   });
 
-  if (!response.ok) {
-    throw await mapHttpError(response);
-  }
-
-  return response.json() as Promise<RateShaderResponse>;
+  return {
+    id: normalized.id,
+    stars: normalized.stars,
+    rating_count: normalized.rating_count,
+    your_rating: normalized.your_rating,
+  };
 }
 
-/** Rating summary derived from shader metadata (no dedicated /rating route on backend). */
+/** Rating summary derived from shader metadata (no dedicated /rating route required). */
 export async function getShaderRating(
   config: StorageClientConfig,
   shaderId: string
@@ -44,10 +45,24 @@ export async function getShaderRating(
   };
 }
 
+/**
+ * Record a shader play.
+ *
+ * Production OpenAPI has no `/api/shaders/{id}/play` (only songs/preset-packs).
+ * Soft-fail so missing routes never surface as console load failures.
+ */
 export async function recordShaderPlay(
   config: StorageClientConfig,
   shaderId: string
-): Promise<{ success: boolean; id: string; play_count: number; last_played: string }> {
+): Promise<{ success: boolean; id: string; play_count: number; last_played: string } | null> {
   const encoded = encodeResourcePath(shaderId.replace(/\.json$/, ''));
-  return fetchJson(`${config.apiUrl}/api/shaders/${encoded}/play`, { method: 'POST' });
+  try {
+    return await fetchJson(`${config.apiUrl}/api/shaders/${encoded}/play`, { method: 'POST' });
+  } catch (err) {
+    // 404 = route or shader missing on this backend revision — not a load failure.
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[storage] recordShaderPlay skipped:', shaderId, err);
+    }
+    return null;
+  }
 }

--- a/src/services/storage/shaders.ts
+++ b/src/services/storage/shaders.ts
@@ -28,8 +28,12 @@ function attachShaderUrls(shaders: ShaderItem[], shaderFilesBaseUrl: string): Sh
     const wgslFilename = shader.filename.replace(/\.json$/, '.wgsl');
     const normalized: ShaderItem = { ...shader };
     normalized.url = `${base}/shaders/${wgslFilename}`;
+    // Live API uses `rating`; some clients still read `stars`.
     if (normalized.rating === null || normalized.rating === undefined) {
       normalized.rating = normalized.stars ?? null;
+    }
+    if (normalized.stars === undefined || normalized.stars === null) {
+      normalized.stars = typeof normalized.rating === 'number' ? normalized.rating : undefined;
     }
     return normalized;
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Console noise looked like shaders “failing to load”:

- `POST …/api/shaders/{id}/rate` → **422** (FormData `{ stars }` vs live JSON `{ rating }`)
- `shaders/*-sg.wgsl` → **404** (optional subgroup probes; **0** `-sg` files ship)
- `POST …/api/shaders/{id}/play` → **404** (route not in production OpenAPI)

Base `.wgsl` assets were fine; the errors were side-channel noise that read as load failures.

## Fix

- Shared `postShaderRating()` posts JSON `{ rating }` and normalizes live `{ shader_id, rating }` responses
- Wired through `ratingCache`, `ShaderRatingIntegration`, `shaderApi`, and `storage/ratings`
- Disabled `-sg.wgsl` probing until variants exist (`PROBE_SUBGROUP_VARIANTS = false`)
- Removed the undeployed play-count POST from `useShaderMode`
- Map live list `rating` → UI `stars`

## Tests

- `npx react-scripts test --watchAll=false --ci` → **49 suites / 339 pass**
- New `postShaderRating.test.ts`; updated `ratingCache` flush expectations

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf6e598f-8145-4946-bbd4-7a577824167e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf6e598f-8145-4946-bbd4-7a577824167e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

