### PR TITLE
fix: image effects blank black after adaptive resolution scale

### DIFF
--- a/memory/2026-07-22.md
+++ b/memory/2026-07-22.md
@@ -146,3 +146,16 @@ Root cause (live `storage.noahcohn.com` OpenAPI):
 Fix branch `cursor/fix-shader-load-404-rate-422-167e`: `postShaderRating` helper, disable `-sg` probe, drop play POST, normalize `rating`→`stars`. Jest 339 pass.
 
 Note: true black canvas on headless Cloud VM is still no-GPU / blocked media hosts — separate from these console errors.
+
+## Image effects blank black after load (afternoon) — FIXED ✅
+
+User: “image effect shaders load, but then the image goes to blank black. generative shaders are working.”
+
+Root cause: default quality `auto` → adaptive resolution scale → `setResolutionScale` → `recreateScaleTextures` destroys `sourceTex`/`readTex` with **no re-upload**. Frame loop then copies empty black source every frame. Generative ignores source pixels → still works.
+
+Fix PR #1018 (`cursor/fix-image-blank-after-scale-973f`):
+- `restoreSourceFromOffscreen` after recreate (skip generative)
+- restore on generative → image switch
+- `uploadRGBA8` skips scaled `readTex` write (scalePass fills from source)
+- Tests: `WebGPUMediaInput.test.ts`; full Jest 50 suites / 344 pass
+

--- a/src/renderer/WebGPURenderer.ts
+++ b/src/renderer/WebGPURenderer.ts
@@ -32,6 +32,7 @@ import {
   updateVideoFrame as mediaUpdateVideoFrame,
   loadImage as mediaLoadImage,
   clearSourceTexture,
+  restoreSourceFromOffscreen,
   WebGPUMediaInputContext,
 } from './webgpu/WebGPUMediaInput';
 import { ShaderSlot, SlotMode, WG_SIZE_X, WG_SIZE_Y, WG_SIZE_1D } from './webgpu/webgpuConstants';
@@ -269,6 +270,12 @@ export class WebGPURenderer implements Renderer, ShaderSlotRenderer {
       );
       this.blitReadTex = this.resources.blitReadTex;
       this.lastBlitReadTex = null;
+      // recreateScaleTextures destroys sourceTex/readTex. Re-upload the last
+      // image/video frame so image-effect shaders don't go blank black after
+      // adaptive quality changes scale. Generative mode intentionally stays clear.
+      if (this.inputSource !== 'generative') {
+        restoreSourceFromOffscreen(this.getMediaContext(), this.mediaState);
+      }
     }
   }
 
@@ -368,7 +375,12 @@ export class WebGPURenderer implements Renderer, ShaderSlotRenderer {
 
   setInputSource(source: 'image' | 'video' | 'webcam' | 'generative' | 'live'): void {
     this.inputSource = source;
-    if (source === 'generative') clearSourceTexture(this.getMediaContext());
+    if (source === 'generative') {
+      clearSourceTexture(this.getMediaContext());
+    } else if (source === 'image') {
+      // Leaving generative: restore last uploaded image if still in offscreen.
+      restoreSourceFromOffscreen(this.getMediaContext(), this.mediaState);
+    }
   }
 
   getInputSource() { return this.inputSource; }

--- a/src/renderer/webgpu/WebGPUMediaInput.test.ts
+++ b/src/renderer/webgpu/WebGPUMediaInput.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  createMediaInputState,
+  uploadRGBA8,
+  uploadSourceRGBA8,
+  restoreSourceFromOffscreen,
+  WebGPUMediaInputContext,
+} from './WebGPUMediaInput';
+
+function makeCtx(overrides: Partial<{
+  canvasW: number;
+  canvasH: number;
+  readW: number;
+  readH: number;
+}> = {}): {
+  ctx: WebGPUMediaInputContext;
+  writeTexture: jest.Mock;
+  sourceTex: GPUTexture;
+  readTex: GPUTexture;
+} {
+  const writeTexture = jest.fn();
+  const sourceTex = { width: overrides.canvasW ?? 64, height: overrides.canvasH ?? 48 } as unknown as GPUTexture;
+  const readTex = {
+    width: overrides.readW ?? overrides.canvasW ?? 64,
+    height: overrides.readH ?? overrides.canvasH ?? 48,
+  } as unknown as GPUTexture;
+
+  const ctx: WebGPUMediaInputContext = {
+    device: {
+      queue: { writeTexture },
+    } as unknown as GPUDevice,
+    sourceTex,
+    readTex,
+    canvasW: overrides.canvasW ?? 64,
+    canvasH: overrides.canvasH ?? 48,
+    filterSampler: {} as GPUSampler,
+    supportsExternalTexture: false,
+    videoCopyPipeline: null,
+    videoCopyBindGroupLayout: null,
+  };
+
+  return { ctx, writeTexture, sourceTex, readTex };
+}
+
+describe('WebGPUMediaInput', () => {
+  it('uploadSourceRGBA8 writes only sourceTex', () => {
+    const { ctx, writeTexture, sourceTex, readTex } = makeCtx();
+    const pixels = new Uint8ClampedArray(64 * 48 * 4);
+    pixels[0] = 255;
+
+    uploadSourceRGBA8(ctx, pixels, 64, 48);
+
+    expect(writeTexture).toHaveBeenCalledTimes(1);
+    expect(writeTexture.mock.calls[0][0].texture).toBe(sourceTex);
+    expect(writeTexture.mock.calls[0][0].texture).not.toBe(readTex);
+  });
+
+  it('uploadRGBA8 skips readTex when it is resolution-scaled', () => {
+    const { ctx, writeTexture, sourceTex, readTex } = makeCtx({
+      canvasW: 64,
+      canvasH: 48,
+      readW: 32,
+      readH: 24,
+    });
+    const pixels = new Uint8ClampedArray(64 * 48 * 4);
+
+    uploadRGBA8(ctx, pixels, 64, 48);
+
+    expect(writeTexture).toHaveBeenCalledTimes(1);
+    expect(writeTexture.mock.calls[0][0].texture).toBe(sourceTex);
+    expect(writeTexture.mock.calls.every((c) => c[0].texture !== readTex)).toBe(true);
+  });
+
+  it('uploadRGBA8 writes both textures when sizes match', () => {
+    const { ctx, writeTexture, sourceTex, readTex } = makeCtx();
+    const pixels = new Uint8ClampedArray(64 * 48 * 4);
+
+    uploadRGBA8(ctx, pixels, 64, 48);
+
+    expect(writeTexture).toHaveBeenCalledTimes(2);
+    expect(writeTexture.mock.calls[0][0].texture).toBe(sourceTex);
+    expect(writeTexture.mock.calls[1][0].texture).toBe(readTex);
+  });
+
+  it('restoreSourceFromOffscreen re-uploads after texture recreate', () => {
+    const { ctx, writeTexture, sourceTex } = makeCtx();
+    const state = createMediaInputState();
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 48;
+    const offCtx = canvas.getContext('2d', { willReadFrequently: true })!;
+    offCtx.fillStyle = 'rgb(10, 20, 30)';
+    offCtx.fillRect(0, 0, 64, 48);
+    state.offscreen = canvas;
+    state.offCtx = offCtx;
+
+    expect(restoreSourceFromOffscreen(ctx, state)).toBe(true);
+    expect(writeTexture).toHaveBeenCalledTimes(1);
+    expect(writeTexture.mock.calls[0][0].texture).toBe(sourceTex);
+
+    const floats = writeTexture.mock.calls[0][1] as Float32Array;
+    expect(floats[0]).toBeCloseTo(10 / 255, 5);
+    expect(floats[1]).toBeCloseTo(20 / 255, 5);
+    expect(floats[2]).toBeCloseTo(30 / 255, 5);
+  });
+
+  it('restoreSourceFromOffscreen returns false when offscreen missing or wrong size', () => {
+    const { ctx, writeTexture } = makeCtx();
+    const empty = createMediaInputState();
+    expect(restoreSourceFromOffscreen(ctx, empty)).toBe(false);
+
+    const state = createMediaInputState();
+    const canvas = document.createElement('canvas');
+    canvas.width = 16;
+    canvas.height = 16;
+    state.offscreen = canvas;
+    state.offCtx = canvas.getContext('2d');
+    expect(restoreSourceFromOffscreen(ctx, state)).toBe(false);
+    expect(writeTexture).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/webgpu/WebGPUMediaInput.test.ts
+++ b/src/renderer/webgpu/WebGPUMediaInput.test.ts
@@ -88,16 +88,23 @@ describe('WebGPUMediaInput', () => {
     const { ctx, writeTexture, sourceTex } = makeCtx();
     const state = createMediaInputState();
 
+    const pixels = new Uint8ClampedArray(64 * 48 * 4);
+    pixels[0] = 10;
+    pixels[1] = 20;
+    pixels[2] = 30;
+    pixels[3] = 255;
+
     const canvas = document.createElement('canvas');
     canvas.width = 64;
     canvas.height = 48;
-    const offCtx = canvas.getContext('2d', { willReadFrequently: true })!;
-    offCtx.fillStyle = 'rgb(10, 20, 30)';
-    offCtx.fillRect(0, 0, 64, 48);
+    const offCtx = {
+      getImageData: jest.fn(() => ({ data: pixels, width: 64, height: 48 })),
+    } as unknown as CanvasRenderingContext2D;
     state.offscreen = canvas;
     state.offCtx = offCtx;
 
     expect(restoreSourceFromOffscreen(ctx, state)).toBe(true);
+    expect(offCtx.getImageData).toHaveBeenCalledWith(0, 0, 64, 48);
     expect(writeTexture).toHaveBeenCalledTimes(1);
     expect(writeTexture.mock.calls[0][0].texture).toBe(sourceTex);
 
@@ -117,7 +124,9 @@ describe('WebGPUMediaInput', () => {
     canvas.width = 16;
     canvas.height = 16;
     state.offscreen = canvas;
-    state.offCtx = canvas.getContext('2d');
+    state.offCtx = {
+      getImageData: jest.fn(),
+    } as unknown as CanvasRenderingContext2D;
     expect(restoreSourceFromOffscreen(ctx, state)).toBe(false);
     expect(writeTexture).not.toHaveBeenCalled();
   });

--- a/src/renderer/webgpu/WebGPUMediaInput.ts
+++ b/src/renderer/webgpu/WebGPUMediaInput.ts
@@ -34,18 +34,15 @@ export function createMediaInputState(): WebGPUMediaInputState {
   };
 }
 
-export function uploadRGBA8(
-  ctx: WebGPUMediaInputContext,
+function rgba8ToFloat32(
   data: Uint8ClampedArray,
   srcW: number,
   srcH: number,
-): void {
-  if (!ctx.device) return;
-  const dstW = ctx.canvasW;
-  const dstH = ctx.canvasH;
+  dstW: number,
+  dstH: number,
+): { floats: Float32Array; cW: number; cH: number } {
   const cW = Math.min(srcW, dstW);
   const cH = Math.min(srcH, dstH);
-
   const floats = new Float32Array(cW * cH * 4);
   for (let y = 0; y < cH; y++) {
     for (let x = 0; x < cW; x++) {
@@ -57,6 +54,34 @@ export function uploadRGBA8(
       floats[di + 3] = data[si + 3] / 255;
     }
   }
+  return { floats, cW, cH };
+}
+
+/** Upload pixels into sourceTex only (full-res). Frame loop copies/scales into readTex. */
+export function uploadSourceRGBA8(
+  ctx: WebGPUMediaInputContext,
+  data: Uint8ClampedArray,
+  srcW: number,
+  srcH: number,
+): void {
+  if (!ctx.device) return;
+  const { floats, cW, cH } = rgba8ToFloat32(data, srcW, srcH, ctx.canvasW, ctx.canvasH);
+  ctx.device.queue.writeTexture(
+    { texture: ctx.sourceTex },
+    floats,
+    { bytesPerRow: cW * 16, rowsPerImage: cH },
+    [cW, cH],
+  );
+}
+
+export function uploadRGBA8(
+  ctx: WebGPUMediaInputContext,
+  data: Uint8ClampedArray,
+  srcW: number,
+  srcH: number,
+): void {
+  if (!ctx.device) return;
+  const { floats, cW, cH } = rgba8ToFloat32(data, srcW, srcH, ctx.canvasW, ctx.canvasH);
 
   ctx.device.queue.writeTexture(
     { texture: ctx.sourceTex },
@@ -64,12 +89,42 @@ export function uploadRGBA8(
     { bytesPerRow: cW * 16, rowsPerImage: cH },
     [cW, cH],
   );
-  ctx.device.queue.writeTexture(
-    { texture: ctx.readTex },
-    floats,
-    { bytesPerRow: cW * 16, rowsPerImage: cH },
-    [cW, cH],
-  );
+  // readTex may be resolution-scaled; only write when dimensions match canvas
+  // (scale === 1). Otherwise the frame loop's scalePass/copy restores from sourceTex.
+  const readW = (ctx.readTex as GPUTexture & { width?: number }).width ?? ctx.canvasW;
+  const readH = (ctx.readTex as GPUTexture & { height?: number }).height ?? ctx.canvasH;
+  if (readW === ctx.canvasW && readH === ctx.canvasH) {
+    ctx.device.queue.writeTexture(
+      { texture: ctx.readTex },
+      floats,
+      { bytesPerRow: cW * 16, rowsPerImage: cH },
+      [cW, cH],
+    );
+  }
+}
+
+/**
+ * Re-upload the last letterboxed image/video frame from the CPU offscreen canvas
+ * into sourceTex after GPU textures were recreated (e.g. adaptive resolution scale).
+ * Without this, image-effect shaders go blank black after a scale change while
+ * generative shaders keep working (they don't need source pixels).
+ */
+export function restoreSourceFromOffscreen(
+  ctx: WebGPUMediaInputContext,
+  state: WebGPUMediaInputState,
+): boolean {
+  if (!ctx.device || !state.offscreen || !state.offCtx) return false;
+  if (state.offscreen.width !== ctx.canvasW || state.offscreen.height !== ctx.canvasH) {
+    return false;
+  }
+  try {
+    const imageData = state.offCtx.getImageData(0, 0, ctx.canvasW, ctx.canvasH);
+    uploadSourceRGBA8(ctx, imageData.data, ctx.canvasW, ctx.canvasH);
+    return true;
+  } catch (e) {
+    console.warn('[WebGPU] Failed to restore source texture from offscreen:', e);
+    return false;
+  }
 }
 
 export function clearSourceTexture(ctx: WebGPUMediaInputContext): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Image-effect shaders loaded correctly for a moment, then the canvas went blank black. Generative shaders kept working.

## Root cause
Default quality mode is `auto`, which enables adaptive resolution scaling. When scale changes, `WebGPURenderer.setResolutionScale` → `recreateScaleTextures` destroys and recreates `sourceTex`/`readTex` **without re-uploading the image**. Every subsequent frame copies empty (black) `sourceTex` → `readTex`, so image effects go black. Generative shaders do not depend on preserved source pixels, so they still looked fine.

## Fix
- After texture recreate, restore pixels from the CPU offscreen canvas via `restoreSourceFromOffscreen` (skipped in generative mode).
- Also restore when switching back from generative → image.
- Avoid writing full-res pixels into a resolution-scaled `readTex` in `uploadRGBA8` (frame loop scalePass/copy fills it from `sourceTex`).

## Tests
- New `WebGPUMediaInput.test.ts` covers upload/restore behavior including scaled `readTex` skip.
- Full Jest: 50 suites / 344 passed / 1 skipped.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce892670-44e4-4c90-8a1d-dedc6e2c973f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce892670-44e4-4c90-8a1d-dedc6e2c973f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image effects appearing as a blank black frame after resolution scaling or switching inputs.
  * Preserved image and video source content when scaled textures are recreated.
  * Improved transitions between generative and image-based inputs.

* **Tests**
  * Added coverage for image uploads, scaled resolutions, source restoration, and invalid offscreen data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->