### PR TITLE
Foundation: Uniforms source of truth (#1038) + format-tier bench harness & FP32 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,11 @@ jobs:
     - name: Verify device policy sync (TS ↔ C++)
       run: npm run verify:device-policy
 
+    - name: Verify Uniforms layout contract (TS ↔ C++ ↔ docs)
+      run: |
+        node scripts/test_verify_uniforms_layout.js
+        npm run verify:uniforms
+
     - name: Run unit tests
       run: npm test -- --watchAll=false --ci --coverage
       env:

--- a/agents/CLOUD_UPGRADE.md
+++ b/agents/CLOUD_UPGRADE.md
@@ -32,8 +32,8 @@ Every compute shader MUST declare exactly these bindings:
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,       // x=Time, y=MouseClickCount/FrameCount, z=ResX, w=ResY
-  zoom_config: vec4<f32>,  // x=Time, y=MouseX, z=MouseY, w=MouseDown
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
   ripples: array<vec4<f32>, 50>,
 };

--- a/agents/FIREWORKS_CONTRIBUTOR_KIT.md
+++ b/agents/FIREWORKS_CONTRIBUTOR_KIT.md
@@ -53,10 +53,10 @@
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,       // .x = time, .y = delta_time, .zw = resolution (w, h)
-  zoom_config: vec4<f32>,  // .x = zoom, .yz = mouse (pixel coords), .w = mouse_down (>0.5)
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // .xyzw = UI sliders p1–p4 (always 0–1 from engine)
-  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = time_created, .w = strength
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
 };
 ```
 

--- a/agents/FIREWORKS_LIBRARY_GUIDE.md
+++ b/agents/FIREWORKS_LIBRARY_GUIDE.md
@@ -58,8 +58,8 @@ Copy the header **verbatim** from `public/shaders/_template_canonical_compute.wg
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,       // .x = time, .y = delta_time, .zw = resolution
-  zoom_config: vec4<f32>,  // .x = zoom, .yz = mouse_uv, .w = mouse_down
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // .xyzw = p1…p4 sliders
   ripples: array<vec4<f32>, 50>,
 };

--- a/agents/WGSL_BUILTINS_GENERATIVE.md
+++ b/agents/WGSL_BUILTINS_GENERATIVE.md
@@ -28,10 +28,10 @@ For temporal effects that sample past frames, add the **optional binding 13** ex
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,       // .x = time, .y = delta_time, .zw = resolution (width, height)
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
   zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0–1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // .xyzw = user params p1…p4 (mapped from UI sliders)
-  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = time_created, .w = strength
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
 };
 
 const PI: f32 = 3.14159265359;

--- a/agents/claude_opus_tier1_integration_prompt.md
+++ b/agents/claude_opus_tier1_integration_prompt.md
@@ -38,10 +38,10 @@ Perform a **integration & polish pass** on **9 foundational shaders** that were 
 
 ```wgsl
 struct Uniforms {
-  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
-  zoom_config: vec4<f32>,  // x=Time, y=MouseX, z=MouseY, w=MouseDown
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
-  ripples: array<vec4<f32>, 50>,  // x, y, startTime, unused
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
 };
 ```
 

--- a/agents/shader-upgrade-round-2026-05.md
+++ b/agents/shader-upgrade-round-2026-05.md
@@ -76,8 +76,8 @@ Every upgraded shader MUST conform to these requirements. Non-conformance fails 
 // -----------------------------------------------
 
 struct Uniforms {
-  config: vec4<f32>,       // x=Time, y=ClickCount, z=ResX, w=ResY
-  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
   ripples: array<vec4<f32>, 50>,
 };
@@ -101,7 +101,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 | Field | Usage |
 |-------|-------|
 | `u.config.x` | Time (seconds, continuous) |
-| `u.config.y` | Click count / generic seed |
+| `u.config.y` | Active ripple count (0–50) — **not** delta time / audio |
 | `u.config.zw` | Resolution (width, height) |
 | `u.zoom_config.yz` | Mouse position (0–1 normalized) |
 | `u.zoom_params.x` | Param1 — slider value 0.0–1.0 |

--- a/agents/upgrade_swarm.md
+++ b/agents/upgrade_swarm.md
@@ -632,8 +632,8 @@ All ported shaders MUST use the exact 13-binding header:
 // ---------------------------------------------------
 
 struct Uniforms {
-  config: vec4<f32>,       // x=Time, y=Generic1, z=ResX, w=ResY
-  zoom_config: vec4<f32>,  // x=ZoomTime, y=MouseX, z=MouseY, w=Generic2
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
   ripples: array<vec4<f32>, 50>,
 };

--- a/docs/BINDING_CONTRACT.md
+++ b/docs/BINDING_CONTRACT.md
@@ -8,7 +8,8 @@ Single source of truth for the Pixelocity compute bind group layout and device p
 - C++ layout: [`wasm_renderer/pipeline.cpp`](../wasm_renderer/pipeline.cpp) (`CreateBindGroupLayout`)
 - Device limits: [`src/contracts/webgpu_limits.json`](../src/contracts/webgpu_limits.json) ↔ [`src/renderer/webgpuDevicePolicy.ts`](../src/renderer/webgpuDevicePolicy.ts) ↔ [`wasm_renderer/device.cpp`](../wasm_renderer/device.cpp)
 - WGSL authoring: [`agents/WGSL_BUILTINS_GENERATIVE.md`](../agents/WGSL_BUILTINS_GENERATIVE.md)
-- CI sync check: `npm run verify:device-policy`
+- Uniforms layout: [`src/contracts/uniforms_layout.json`](../src/contracts/uniforms_layout.json) ↔ [`src/renderer/UniformBuffer.ts`](../src/renderer/UniformBuffer.ts) ↔ [`wasm_renderer/renderer.h`](../wasm_renderer/renderer.h)
+- CI sync checks: `npm run verify:device-policy`, `npm run verify:uniforms`
 
 ## Naming
 
@@ -47,6 +48,54 @@ Do **not** reverse this order. (Audit 2026-07-21: prior A-then-B order clobbered
 | 11 | `comparisonSampler` | sampler_comparison | compare |
 | 12 | `plasmaBuffer` | storage read-only | read |
 | 13 | `historyTexture` | texture_2d_array\<f32\> | sample (**opt-in**) |
+
+## Uniforms struct (binding 3)
+
+**Authoritative.** Engine truth lives in [`src/contracts/uniforms_layout.json`](../src/contracts/uniforms_layout.json), mirrored by
+[`src/renderer/UniformBuffer.ts`](../src/renderer/UniformBuffer.ts) (`UNIFORM_OFFSETS`) + [`src/renderer/webgpu/frame.ts`](../src/renderer/webgpu/frame.ts) (`writeUniforms`)
+and [`wasm_renderer/renderer.h`](../wasm_renderer/renderer.h) + [`wasm_renderer/frame.cpp`](../wasm_renderer/frame.cpp) (`UpdateUniformBuffer`).
+Drift is a CI failure: `npm run verify:uniforms`.
+
+```wgsl
+struct Uniforms {
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
+  zoom_params: vec4<f32>,  // .xyzw = user params p1..p4 (mapped from UI sliders)
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
+};
+```
+
+Total size **848 bytes** (212 floats) — matches `UNIFORM_BUFFER_LAYOUT.TOTAL_SIZE` and `maxUniformBufferBindingSize`.
+
+| Field | Byte offset | Meaning | Range / units |
+|-------|-------------|---------|---------------|
+| `config.x` | 0 | **time** | Seconds since renderer start; monotonic, never resets |
+| `config.y` | 4 | **rippleCount** | Number of active ripples, `0..50` as f32 |
+| `config.z` | 8 | **resolutionWidth** | Render-target width in pixels (post scaling) |
+| `config.w` | 12 | **resolutionHeight** | Render-target height in pixels (post scaling) |
+| `zoom_config.x` | 16 | **time** | Same value as `config.x` |
+| `zoom_config.y` | 20 | **mouseX** | Canvas UV `0..1`, 0 = left |
+| `zoom_config.z` | 24 | **mouseY** | Canvas UV `0..1`, **0 = top** |
+| `zoom_config.w` | 28 | **mouseDown** | `1.0` pressed / `0.0` released — test with `> 0.5` |
+| `zoom_params.x` | 32 | **p1** | User slider 1 (range per shader JSON `controls`) |
+| `zoom_params.y` | 36 | **p2** | User slider 2 |
+| `zoom_params.z` | 40 | **p3** | User slider 3 |
+| `zoom_params.w` | 44 | **p4** | User slider 4 |
+| `ripples[i].x` | 48 + 16·i | ripple UV x | `0..1` |
+| `ripples[i].y` | 52 + 16·i | ripple UV y | `0..1`, 0 = top |
+| `ripples[i].z` | 56 + 16·i | **startTime** | Seconds, same clock as `config.x` — `age = u.config.x - r.z` |
+| `ripples[i].w` | 60 + 16·i | **padding** | Always `0.0` — reserved, *not* a strength value |
+
+### Do-not-reintroduce list
+
+- **`config.y` is `rippleCount`, not delta time.** No per-frame `dt` is uploaded on either backend; drive
+  motion from absolute `config.x`. Guard ripple loops with `min(u32(u.config.y), 50u)`.
+- **`config.y/z/w` is not audio.** Audio comes from `plasmaBuffer[0].xyz` (bass/mids/treble) and the FFT bins
+  in `extraBuffer[5..132]`. Reading audio out of `config` is the recurring dead-audio bug (batches 15–19).
+- **`config.y` is not a click count.** Legacy briefs called it `MouseClickCount` / `Generic1`; those were
+  already wrong when written. Use `zoom_config.w` for mouse-down state.
+- **Mouse Y is top-down** (fixed 2026-07-19). Do not add a `1.0 - y` flip.
+- **Ripple slots past `rippleCount` are fully zeroed** — a zero `startTime` means "empty", not "created at t=0".
 
 ## extraBuffer packing (binding 10)
 

--- a/docs/TEXTURE_OPTIMIZATIONS.md
+++ b/docs/TEXTURE_OPTIMIZATIONS.md
@@ -118,7 +118,7 @@ struct BadUniforms {
 
 // ✅ Efficient: vec4 packing
 struct GoodUniforms {
-  config: vec4<f32>,       // time, mouseX, mouseY, unused
+  frameData: vec4<f32>,    // time, mouseX, mouseY, unused
   params: vec4<f32>,       // param1, param2, param3, param4
 };
 ```

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "thumbnails:generate": "npm run thumbs:generate",
     "thumbnails:status": "npm run thumbs:status",
     "verify:device-policy": "node scripts/verify-device-policy-sync.js",
+    "verify:uniforms": "node scripts/verify-uniforms-layout.js",
     "audit:shaders:sample": "bash scripts/wgsl-audit-swarm.sh 4 --sample",
     "deploy": "python scripts/deploy.py",
     "deploy:app": "python scripts/deploy_app_only.py",
@@ -59,6 +60,7 @@
     "audit:audio-mappings": "python3 scripts/audit_audio_mappings.py",
     "audit:extrabuffer": "python3 scripts/audit_extrabuffer.py",
     "audit:dead-sliders": "python3 scripts/audit_dead_sliders.py",
+    "audit:config-y": "python3 scripts/audit_config_y_misuse.py",
     "audit:dead-sliders:generative": "python3 scripts/audit_dead_sliders.py --category generative"
   },
   "eslintConfig": {

--- a/public/shaders/_template_canonical_compute.wgsl
+++ b/public/shaders/_template_canonical_compute.wgsl
@@ -19,10 +19,10 @@
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,
-  zoom_config: vec4<f32>,
-  zoom_params: vec4<f32>,
-  ripples: array<vec4<f32>, 50>,
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
+  zoom_params: vec4<f32>,  // .xyzw = user params p1..p4 (mapped from UI sliders)
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
 };
 
 @compute @workgroup_size(16, 16, 1)

--- a/public/shaders/_template_shared_memory.wgsl
+++ b/public/shaders/_template_shared_memory.wgsl
@@ -20,10 +20,10 @@
 @group(0) @binding(9) var dataTextureC: texture_2d<f32>;  // Persistent data
 
 struct Uniforms {
-  config: vec4<f32>,
-  zoom_config: vec4<f32>,
-  zoom_params: vec4<f32>,
-  ripples: array<vec4<f32>, 50>,
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
+  zoom_params: vec4<f32>,  // .xyzw = user params p1..p4 (mapped from UI sliders)
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
 };
 @group(0) @binding(3) var<uniform> u: Uniforms;
 @group(0) @binding(4) var readDepthTexture: texture_2d<f32>;

--- a/public/shaders/_template_workgroup_atomics.wgsl
+++ b/public/shaders/_template_workgroup_atomics.wgsl
@@ -23,10 +23,10 @@
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,
-  zoom_config: vec4<f32>,
-  zoom_params: vec4<f32>,
-  ripples: array<vec4<f32>, 50>,
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
+  zoom_params: vec4<f32>,  // .xyzw = user params p1..p4 (mapped from UI sliders)
+  ripples: array<vec4<f32>, 50>,  // .xy = ripple uv, .z = startTime (seconds), .w = padding (0)
   particleCount: f32,
   gridResolution: vec2<f32>,
 };

--- a/reports/config_y_misuse.json
+++ b/reports/config_y_misuse.json
@@ -1,0 +1,720 @@
+{
+  "total": 118,
+  "byCategory": {
+    "delta_time": 12,
+    "click_or_frame_count": 15,
+    "unclassified": 22,
+    "audio": 68,
+    "resolution": 1
+  },
+  "findings": [
+    {
+      "file": "public/shaders/4d-projection-dream-weavers.wgsl",
+      "line": 131,
+      "category": "delta_time",
+      "code": "let dt = clamp(u.config.y, 0.001, 0.05);"
+    },
+    {
+      "file": "public/shaders/acoustic-string-theory.wgsl",
+      "line": 92,
+      "category": "delta_time",
+      "code": "let dt = clamp(u.config.y, 0.001, 0.05);"
+    },
+    {
+      "file": "public/shaders/alpha-em-field-simulation.wgsl",
+      "line": 131,
+      "category": "click_or_frame_count",
+      "code": "let clickParity = select(-1.0, 1.0, u.config.y % 2.0 < 1.0);"
+    },
+    {
+      "file": "public/shaders/aurora-rift-pass2.wgsl",
+      "line": 153,
+      "category": "unclassified",
+      "code": "let globalIntensity = clamp(u.config.y, 0.1, 1.5);"
+    },
+    {
+      "file": "public/shaders/cellular-automata-3d.wgsl",
+      "line": 167,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/cellular-automata-3d.wgsl",
+      "line": 168,
+      "category": "audio",
+      "code": "let audioBass = u.config.y * 1.2;"
+    },
+    {
+      "file": "public/shaders/chronos-brush.wgsl",
+      "line": 56,
+      "category": "click_or_frame_count",
+      "code": "let clickCount = u.config.y;"
+    },
+    {
+      "file": "public/shaders/cyber-rain.wgsl",
+      "line": 87,
+      "category": "delta_time",
+      "code": "let dt = u.config.y;"
+    },
+    {
+      "file": "public/shaders/datamosh.wgsl",
+      "line": 131,
+      "category": "click_or_frame_count",
+      "code": "let frame_count = u.config.y;"
+    },
+    {
+      "file": "public/shaders/dla-crystals.wgsl",
+      "line": 93,
+      "category": "click_or_frame_count",
+      "code": "let frame = u.config.y;"
+    },
+    {
+      "file": "public/shaders/elastic-chromatic.wgsl",
+      "line": 167,
+      "category": "delta_time",
+      "code": "let dt = clamp(u.config.y, 0.001, 0.05);"
+    },
+    {
+      "file": "public/shaders/gen-abyssal-chrono-coral.wgsl",
+      "line": 164,
+      "category": "click_or_frame_count",
+      "code": "let clickCount = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-abyssal-leviathan-iridescence.wgsl",
+      "line": 145,
+      "category": "unclassified",
+      "code": "g_audio = u.config.y * 0.1;"
+    },
+    {
+      "file": "public/shaders/gen-abyssal-leviathan-scales.wgsl",
+      "line": 134,
+      "category": "audio",
+      "code": "g_audio = u.config.y * 0.1; // u.config.y accumulates clicks/beats"
+    },
+    {
+      "file": "public/shaders/gen-abyssal-quantum-leviathan-skeleton.wgsl",
+      "line": 69,
+      "category": "audio",
+      "code": "let audio_react = u.zoom_params.w * u.config.y; // 1.0 default"
+    },
+    {
+      "file": "public/shaders/gen-abyssal-quantum-leviathan-skeleton.wgsl",
+      "line": 183,
+      "category": "audio",
+      "code": "color += vec3<f32>(0.5, 0.0, 1.0) * marrow_intensity * (1.0 + audio_pulse * u.config.y);"
+    },
+    {
+      "file": "public/shaders/gen-astro-mechanical-quantum-furnace-engine.wgsl",
+      "line": 191,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-auroral-ferrofluid-monolith.wgsl",
+      "line": 220,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-bismuth-singularity-loom-engine.wgsl",
+      "line": 59,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-bismuth-singularity-loom-engine.wgsl",
+      "line": 167,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-celestial-quantum-glass-dragonfly.wgsl",
+      "line": 155,
+      "category": "audio",
+      "code": "let audio = u.config.y * 2.0;"
+    },
+    {
+      "file": "public/shaders/gen-celestial-quantum-glass-dragonfly.wgsl",
+      "line": 202,
+      "category": "audio",
+      "code": "let audio = u.config.y * 2.0;"
+    },
+    {
+      "file": "public/shaders/gen-cellular-automata-tapestry.wgsl",
+      "line": 89,
+      "category": "delta_time",
+      "code": "let dt = 1.0 + u.config.y * 0.5;"
+    },
+    {
+      "file": "public/shaders/gen-chromatic-singularity-loom.wgsl",
+      "line": 104,
+      "category": "audio",
+      "code": "let audio_intensity = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-chrono-kitsune-prism-weaver.wgsl",
+      "line": 109,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-chronodynamic-aether-weaver-automata.wgsl",
+      "line": 81,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-depth-refracted-liquid-stained-glass.wgsl",
+      "line": 78,
+      "category": "unclassified",
+      "code": "a += u.config.x * 0.2 + u.config.y * 0.5;"
+    },
+    {
+      "file": "public/shaders/gen-depth-refracted-liquid-stained-glass.wgsl",
+      "line": 102,
+      "category": "unclassified",
+      "code": "let depth_mod = sin(u.config.x * 2.0 + u.config.y * 3.0) * 0.5 + 0.5;"
+    },
+    {
+      "file": "public/shaders/gen-eldritch-tesseract-hive-mind.wgsl",
+      "line": 138,
+      "category": "resolution",
+      "code": "let resolution = vec2<f32>(u.config.x, u.config.y);"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-anemone-bloom.wgsl",
+      "line": 338,
+      "category": "audio",
+      "code": "let audio_pulse = plasmaBuffer[0].x; // was u.config.y (MouseClickCount)"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-aurora-ghost-orchid.wgsl",
+      "line": 154,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-chrono-plasma-void-manta.wgsl",
+      "line": 131,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-chrono-plasma-void-manta.wgsl",
+      "line": 169,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-cyber-aurora-hummingbird-core.wgsl",
+      "line": 184,
+      "category": "audio",
+      "code": "let audio = u.config.y * 2.0 + 1.0;"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-cyber-chrono-void-whale.wgsl",
+      "line": 113,
+      "category": "unclassified",
+      "code": "let core_pulse = sin(time * 2.0) * 0.1 + u.config.y * 0.5;"
+    },
+    {
+      "file": "public/shaders/gen-ethereal-cyber-plasma-void-dragon.wgsl",
+      "line": 196,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-fireworks-nocturne.wgsl",
+      "line": 137,
+      "category": "delta_time",
+      "code": "let dt = max(u.config.y, 0.001);"
+    },
+    {
+      "file": "public/shaders/gen-fractured-monolith.wgsl",
+      "line": 72,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-fractured-monolith.wgsl",
+      "line": 73,
+      "category": "audio",
+      "code": "let audioBass = u.config.y * 1.2;"
+    },
+    {
+      "file": "public/shaders/gen-galactic-aether-crystal-geode-core.wgsl",
+      "line": 107,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-galactic-aether-crystal-geode-core.wgsl",
+      "line": 220,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-glacial-aether-quantum-cavern.wgsl",
+      "line": 44,
+      "category": "unclassified",
+      "code": "let qxy = q.xy * rotate(u.config.x * 0.1 + u.config.y * 0.5);"
+    },
+    {
+      "file": "public/shaders/gen-glacial-aether-quantum-cavern.wgsl",
+      "line": 107,
+      "category": "unclassified",
+      "code": "let fracture = fract(length(p) * u.zoom_params.z * 5.0 + u.config.y * 2.0);"
+    },
+    {
+      "file": "public/shaders/gen-glacial-aether-quantum-cavern.wgsl",
+      "line": 110,
+      "category": "audio",
+      "code": "+ vec3<f32>(0.2, 0.8, 1.0) * step(0.95, fracture) * (u.config.y + treble) * depth_fade;"
+    },
+    {
+      "file": "public/shaders/gen-glacial-aether-quantum-cavern.wgsl",
+      "line": 113,
+      "category": "audio",
+      "code": "col += vec3<f32>(0.2, 0.5, 0.6) * (u.config.y + bass * 0.5) * 0.1;"
+    },
+    {
+      "file": "public/shaders/gen-kinetic-neo-brutalist-megastructure.wgsl",
+      "line": 94,
+      "category": "unclassified",
+      "code": "pos.x += sin(u.config.x * 0.5 + u.config.y) * 2.0;"
+    },
+    {
+      "file": "public/shaders/gen-liquid-neon-cyber-metropolis.wgsl",
+      "line": 96,
+      "category": "audio",
+      "code": "let audioAmp = u.config.y * u.zoom_params.z;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-aether-plasma-nebula-koi.wgsl",
+      "line": 175,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-chrono-fluid-astrolabe.wgsl",
+      "line": 141,
+      "category": "unclassified",
+      "code": "let uv = (vec2<f32>(id.xy) * 2.0 - vec2<f32>(u.config.xy)) / u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-cyber-chrono-void-turtle.wgsl",
+      "line": 211,
+      "category": "audio",
+      "code": "audioVal = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-quantum-glass-phoenix-egg.wgsl",
+      "line": 131,
+      "category": "unclassified",
+      "code": "let base = length(p) - 0.7 - u.config.y * 0.3;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-quantum-glass-phoenix-egg.wgsl",
+      "line": 158,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-quantum-void-anglerfish.wgsl",
+      "line": 79,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-quantum-void-anglerfish.wgsl",
+      "line": 143,
+      "category": "unclassified",
+      "code": "let shockwave = clamp(sin(t * 10.0) * exp(-fract(u.config.y)), 0.0, 1.0);"
+    },
+    {
+      "file": "public/shaders/gen-luminescent-quantum-void-astral-turtle.wgsl",
+      "line": 211,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-neon-plasma-biomechanical-hive.wgsl",
+      "line": 136,
+      "category": "audio",
+      "code": "let audio = u.config.y * 2.0;"
+    },
+    {
+      "file": "public/shaders/gen-neuro-kinetic-liquid-gold-lotus.wgsl",
+      "line": 150,
+      "category": "audio",
+      "code": "let audio_val = u.config.y; // Simplified audio metric"
+    },
+    {
+      "file": "public/shaders/gen-obsidian-echo-chamber.wgsl",
+      "line": 156,
+      "category": "audio",
+      "code": "let audioIntensity = u.config.y * u.zoom_params.y;"
+    },
+    {
+      "file": "public/shaders/gen-physarum-sacred-geometry.wgsl",
+      "line": 134,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-bismuth-lattice.wgsl",
+      "line": 75,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-bismuth-lattice.wgsl",
+      "line": 212,
+      "category": "unclassified",
+      "code": "let thickness = mat + u.config.y * 0.1;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-bismuth-lattice.wgsl",
+      "line": 235,
+      "category": "unclassified",
+      "code": "color += irid_color * vec3<f32>(edge * u.config.y * 2.0);"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-aurora-astral-dragonfly.wgsl",
+      "line": 173,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-auroral-manta-swarm.wgsl",
+      "line": 242,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-chrono-nebula-peacock.wgsl",
+      "line": 78,
+      "category": "audio",
+      "code": "let audio = u.config.y * u.zoom_params.w;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-chrono-nebula-peacock.wgsl",
+      "line": 206,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-chrono-void-kitsune.wgsl",
+      "line": 176,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-chrono-void-kitsune.wgsl",
+      "line": 177,
+      "category": "click_or_frame_count",
+      "code": "let click_shockwave = fract(u.config.y * 0.1); // Assuming some click mapping"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-cyber-chrono-void-tortoise.wgsl",
+      "line": 146,
+      "category": "audio",
+      "code": "let audio_bass = plasmaBuffer[0].x * u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-fractal-dunes.wgsl",
+      "line": 149,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-void-weaver-ouroboros.wgsl",
+      "line": 111,
+      "category": "audio",
+      "code": "let audio = u.config.y * audioReact * 2.0;"
+    },
+    {
+      "file": "public/shaders/gen-prismatic-void-weaver-ouroboros.wgsl",
+      "line": 194,
+      "category": "audio",
+      "code": "let audioReact = u.config.y * u.zoom_params.w;"
+    },
+    {
+      "file": "public/shaders/gen-quantum-aether-origami.wgsl",
+      "line": 207,
+      "category": "audio",
+      "code": "let audio_pulse = 1.0 + u.config.y * zparams.z;"
+    },
+    {
+      "file": "public/shaders/gen-quantum-chrome-serpent-ouroboros.wgsl",
+      "line": 218,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-quantum-fluorescent-aether-moth-swarm.wgsl",
+      "line": 146,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-quantum-fluorescent-aether-moth-swarm.wgsl",
+      "line": 149,
+      "category": "audio",
+      "code": "let click = select(0.0, 1.0, u.config.y > 0.5); // proxy for click or audio reactivity"
+    },
+    {
+      "file": "public/shaders/gen-quantum-fluorescent-nebula-anemone.wgsl",
+      "line": 140,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-quantum-foam.wgsl",
+      "line": 151,
+      "category": "delta_time",
+      "code": "let dt    = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-quantum-mycelium.wgsl",
+      "line": 130,
+      "category": "unclassified",
+      "code": "g_audio = u.config.y * 0.1;"
+    },
+    {
+      "file": "public/shaders/gen-radiant-cyber-chrono-void-stag.wgsl",
+      "line": 113,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-radiant-cyber-chrono-void-stag.wgsl",
+      "line": 372,
+      "category": "audio",
+      "code": "var glow_intensity = u.config.y; // audio"
+    },
+    {
+      "file": "public/shaders/gen-radiant-quantum-plasma-kraken-core.wgsl",
+      "line": 90,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-radiant-quantum-plasma-kraken-core.wgsl",
+      "line": 196,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-sentient-aether-flora-biosphere.wgsl",
+      "line": 88,
+      "category": "audio",
+      "code": "let audio_react = u.zoom_params.w * u.config.y; // using click count as proxy if no audio data"
+    },
+    {
+      "file": "public/shaders/gen-sentient-aether-flora-biosphere.wgsl",
+      "line": 166,
+      "category": "audio",
+      "code": "let audio_react = u.zoom_params.w * u.config.y; // parameter 4"
+    },
+    {
+      "file": "public/shaders/gen-sentient-cyber-aurora-void-owl.wgsl",
+      "line": 192,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl",
+      "line": 110,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl",
+      "line": 207,
+      "category": "audio",
+      "code": "let audio = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl",
+      "line": 301,
+      "category": "click_or_frame_count",
+      "code": "let clickVal = u.config.y; // Simplified"
+    },
+    {
+      "file": "public/shaders/gen-singularity-forge-blackbody.wgsl",
+      "line": 129,
+      "category": "unclassified",
+      "code": "let spaghettification = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-singularity-forge-blackbody.wgsl",
+      "line": 132,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/gen-sonoluminescent-chrono-geode-matrix.wgsl",
+      "line": 146,
+      "category": "unclassified",
+      "code": "let uv = vec2<f32>(f32(id.x) / u.config.x, f32(id.y) / u.config.y);"
+    },
+    {
+      "file": "public/shaders/gen-stellar-web-loom.wgsl",
+      "line": 144,
+      "category": "unclassified",
+      "code": "g_audio = u.config.y * 0.1;"
+    },
+    {
+      "file": "public/shaders/gen_reaction_diffusion.wgsl",
+      "line": 144,
+      "category": "click_or_frame_count",
+      "code": "let clickCount = u.config.y;"
+    },
+    {
+      "file": "public/shaders/holographic-interferometry.wgsl",
+      "line": 108,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/holographic-interferometry.wgsl",
+      "line": 109,
+      "category": "audio",
+      "code": "let audioBass = u.config.y * 1.2;"
+    },
+    {
+      "file": "public/shaders/hybrid-chromatic-liquid.wgsl",
+      "line": 79,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/hybrid-magnetic-field.wgsl",
+      "line": 98,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/interactive-voronoi-lens.wgsl",
+      "line": 81,
+      "category": "delta_time",
+      "code": "let dt = u.config.y;"
+    },
+    {
+      "file": "public/shaders/liquid-prism.wgsl",
+      "line": 95,
+      "category": "audio",
+      "code": "let audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/lorenz-attractor-flow.wgsl",
+      "line": 46,
+      "category": "click_or_frame_count",
+      "code": "let click = u.config.y;"
+    },
+    {
+      "file": "public/shaders/mouse-ink-bleed.wgsl",
+      "line": 94,
+      "category": "delta_time",
+      "code": "let dt = u.config.y;"
+    },
+    {
+      "file": "public/shaders/nano-assembler.wgsl",
+      "line": 73,
+      "category": "unclassified",
+      "code": "let time = u.config.y;"
+    },
+    {
+      "file": "public/shaders/neural-synapse-web.wgsl",
+      "line": 77,
+      "category": "delta_time",
+      "code": "let dt = clamp(u.config.y, 0.001, 0.05);"
+    },
+    {
+      "file": "public/shaders/optical-feedback.wgsl",
+      "line": 117,
+      "category": "delta_time",
+      "code": "let dt = u.config.y;"
+    },
+    {
+      "file": "public/shaders/origami-fold.wgsl",
+      "line": 69,
+      "category": "click_or_frame_count",
+      "code": "let clickCount = u.config.y;"
+    },
+    {
+      "file": "public/shaders/phase-memory-weave.wgsl",
+      "line": 88,
+      "category": "click_or_frame_count",
+      "code": "let clicks = u.config.y;"
+    },
+    {
+      "file": "public/shaders/photonic-caustics.wgsl",
+      "line": 116,
+      "category": "click_or_frame_count",
+      "code": "let frame = u.config.y;"
+    },
+    {
+      "file": "public/shaders/photonic-trace.wgsl",
+      "line": 58,
+      "category": "click_or_frame_count",
+      "code": "let frame = u.config.y;"
+    },
+    {
+      "file": "public/shaders/plasma.wgsl",
+      "line": 67,
+      "category": "audio",
+      "code": "var audioOverall = u.config.y;"
+    },
+    {
+      "file": "public/shaders/predator-prey.wgsl",
+      "line": 133,
+      "category": "click_or_frame_count",
+      "code": "let frame = u.config.y;"
+    },
+    {
+      "file": "public/shaders/quantum-foam-pass2.wgsl",
+      "line": 150,
+      "category": "unclassified",
+      "code": "let globalIntensity = u.config.y;"
+    },
+    {
+      "file": "public/shaders/quantum-foam-pass3.wgsl",
+      "line": 107,
+      "category": "unclassified",
+      "code": "let globalIntensity = u.config.y;"
+    },
+    {
+      "file": "public/shaders/spec-runge-kutta-advection.wgsl",
+      "line": 92,
+      "category": "unclassified",
+      "code": "if (isMouseDown || u.config.y > 0.5) {"
+    },
+    {
+      "file": "public/shaders/stellar-plasma-blackbody.wgsl",
+      "line": 130,
+      "category": "audio",
+      "code": "let audioLow = u.config.y;"
+    },
+    {
+      "file": "public/shaders/temporal-rgb-smear.wgsl",
+      "line": 174,
+      "category": "delta_time",
+      "code": "let dt = clamp(u.config.y, 0.0, 0.1);"
+    },
+    {
+      "file": "public/shaders/time-lag-map.wgsl",
+      "line": 102,
+      "category": "click_or_frame_count",
+      "code": "let frame = u.config.y;"
+    },
+    {
+      "file": "public/shaders/vortex-distortion.wgsl",
+      "line": 81,
+      "category": "unclassified",
+      "code": "let numV     = min(i32(u.config.y), 20);   // cap at 20 vortices for performance"
+    }
+  ]
+}

--- a/reports/config_y_misuse.md
+++ b/reports/config_y_misuse.md
@@ -1,0 +1,137 @@
+# `u.config.y` misuse audit
+
+`config = [time, rippleCount, resW, resH]` — see `src/contracts/uniforms_layout.json`.
+Every row below reads `config.y` (or a legacy `config` swizzle) as something else.
+
+**Total: 118 reads across 92 shaders**
+
+| Category | Count |
+|----------|-------|
+| `audio` | 68 |
+| `unclassified` | 22 |
+| `click_or_frame_count` | 15 |
+| `delta_time` | 12 |
+| `resolution` | 1 |
+
+## Findings
+
+| File | Line | Category | Code |
+|------|------|----------|------|
+| `public/shaders/4d-projection-dream-weavers.wgsl` | 131 | delta_time | `let dt = clamp(u.config.y, 0.001, 0.05);` |
+| `public/shaders/acoustic-string-theory.wgsl` | 92 | delta_time | `let dt = clamp(u.config.y, 0.001, 0.05);` |
+| `public/shaders/alpha-em-field-simulation.wgsl` | 131 | click_or_frame_count | `let clickParity = select(-1.0, 1.0, u.config.y % 2.0 < 1.0);` |
+| `public/shaders/aurora-rift-pass2.wgsl` | 153 | unclassified | `let globalIntensity = clamp(u.config.y, 0.1, 1.5);` |
+| `public/shaders/cellular-automata-3d.wgsl` | 167 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/cellular-automata-3d.wgsl` | 168 | audio | `let audioBass = u.config.y * 1.2;` |
+| `public/shaders/chronos-brush.wgsl` | 56 | click_or_frame_count | `let clickCount = u.config.y;` |
+| `public/shaders/cyber-rain.wgsl` | 87 | delta_time | `let dt = u.config.y;` |
+| `public/shaders/datamosh.wgsl` | 131 | click_or_frame_count | `let frame_count = u.config.y;` |
+| `public/shaders/dla-crystals.wgsl` | 93 | click_or_frame_count | `let frame = u.config.y;` |
+| `public/shaders/elastic-chromatic.wgsl` | 167 | delta_time | `let dt = clamp(u.config.y, 0.001, 0.05);` |
+| `public/shaders/gen-abyssal-chrono-coral.wgsl` | 164 | click_or_frame_count | `let clickCount = u.config.y;` |
+| `public/shaders/gen-abyssal-leviathan-iridescence.wgsl` | 145 | unclassified | `g_audio = u.config.y * 0.1;` |
+| `public/shaders/gen-abyssal-leviathan-scales.wgsl` | 134 | audio | `g_audio = u.config.y * 0.1; // u.config.y accumulates clicks/beats` |
+| `public/shaders/gen-abyssal-quantum-leviathan-skeleton.wgsl` | 69 | audio | `let audio_react = u.zoom_params.w * u.config.y; // 1.0 default` |
+| `public/shaders/gen-abyssal-quantum-leviathan-skeleton.wgsl` | 183 | audio | `color += vec3<f32>(0.5, 0.0, 1.0) * marrow_intensity * (1.0 + audio_pulse * u.config.y);` |
+| `public/shaders/gen-astro-mechanical-quantum-furnace-engine.wgsl` | 191 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-auroral-ferrofluid-monolith.wgsl` | 220 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-bismuth-singularity-loom-engine.wgsl` | 59 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-bismuth-singularity-loom-engine.wgsl` | 167 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-celestial-quantum-glass-dragonfly.wgsl` | 155 | audio | `let audio = u.config.y * 2.0;` |
+| `public/shaders/gen-celestial-quantum-glass-dragonfly.wgsl` | 202 | audio | `let audio = u.config.y * 2.0;` |
+| `public/shaders/gen-cellular-automata-tapestry.wgsl` | 89 | delta_time | `let dt = 1.0 + u.config.y * 0.5;` |
+| `public/shaders/gen-chromatic-singularity-loom.wgsl` | 104 | audio | `let audio_intensity = u.config.y;` |
+| `public/shaders/gen-chrono-kitsune-prism-weaver.wgsl` | 109 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-chronodynamic-aether-weaver-automata.wgsl` | 81 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-depth-refracted-liquid-stained-glass.wgsl` | 78 | unclassified | `a += u.config.x * 0.2 + u.config.y * 0.5;` |
+| `public/shaders/gen-depth-refracted-liquid-stained-glass.wgsl` | 102 | unclassified | `let depth_mod = sin(u.config.x * 2.0 + u.config.y * 3.0) * 0.5 + 0.5;` |
+| `public/shaders/gen-eldritch-tesseract-hive-mind.wgsl` | 138 | resolution | `let resolution = vec2<f32>(u.config.x, u.config.y);` |
+| `public/shaders/gen-ethereal-anemone-bloom.wgsl` | 338 | audio | `let audio_pulse = plasmaBuffer[0].x; // was u.config.y (MouseClickCount)` |
+| `public/shaders/gen-ethereal-aurora-ghost-orchid.wgsl` | 154 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-ethereal-chrono-plasma-void-manta.wgsl` | 131 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-ethereal-chrono-plasma-void-manta.wgsl` | 169 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-ethereal-cyber-aurora-hummingbird-core.wgsl` | 184 | audio | `let audio = u.config.y * 2.0 + 1.0;` |
+| `public/shaders/gen-ethereal-cyber-chrono-void-whale.wgsl` | 113 | unclassified | `let core_pulse = sin(time * 2.0) * 0.1 + u.config.y * 0.5;` |
+| `public/shaders/gen-ethereal-cyber-plasma-void-dragon.wgsl` | 196 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-fireworks-nocturne.wgsl` | 137 | delta_time | `let dt = max(u.config.y, 0.001);` |
+| `public/shaders/gen-fractured-monolith.wgsl` | 72 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/gen-fractured-monolith.wgsl` | 73 | audio | `let audioBass = u.config.y * 1.2;` |
+| `public/shaders/gen-galactic-aether-crystal-geode-core.wgsl` | 107 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-galactic-aether-crystal-geode-core.wgsl` | 220 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-glacial-aether-quantum-cavern.wgsl` | 44 | unclassified | `let qxy = q.xy * rotate(u.config.x * 0.1 + u.config.y * 0.5);` |
+| `public/shaders/gen-glacial-aether-quantum-cavern.wgsl` | 107 | unclassified | `let fracture = fract(length(p) * u.zoom_params.z * 5.0 + u.config.y * 2.0);` |
+| `public/shaders/gen-glacial-aether-quantum-cavern.wgsl` | 110 | audio | `+ vec3<f32>(0.2, 0.8, 1.0) * step(0.95, fracture) * (u.config.y + treble) * depth_fade;` |
+| `public/shaders/gen-glacial-aether-quantum-cavern.wgsl` | 113 | audio | `col += vec3<f32>(0.2, 0.5, 0.6) * (u.config.y + bass * 0.5) * 0.1;` |
+| `public/shaders/gen-kinetic-neo-brutalist-megastructure.wgsl` | 94 | unclassified | `pos.x += sin(u.config.x * 0.5 + u.config.y) * 2.0;` |
+| `public/shaders/gen-liquid-neon-cyber-metropolis.wgsl` | 96 | audio | `let audioAmp = u.config.y * u.zoom_params.z;` |
+| `public/shaders/gen-luminescent-aether-plasma-nebula-koi.wgsl` | 175 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-luminescent-chrono-fluid-astrolabe.wgsl` | 141 | unclassified | `let uv = (vec2<f32>(id.xy) * 2.0 - vec2<f32>(u.config.xy)) / u.config.y;` |
+| `public/shaders/gen-luminescent-cyber-chrono-void-turtle.wgsl` | 211 | audio | `audioVal = u.config.y;` |
+| `public/shaders/gen-luminescent-quantum-glass-phoenix-egg.wgsl` | 131 | unclassified | `let base = length(p) - 0.7 - u.config.y * 0.3;` |
+| `public/shaders/gen-luminescent-quantum-glass-phoenix-egg.wgsl` | 158 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-luminescent-quantum-void-anglerfish.wgsl` | 79 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-luminescent-quantum-void-anglerfish.wgsl` | 143 | unclassified | `let shockwave = clamp(sin(t * 10.0) * exp(-fract(u.config.y)), 0.0, 1.0);` |
+| `public/shaders/gen-luminescent-quantum-void-astral-turtle.wgsl` | 211 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-neon-plasma-biomechanical-hive.wgsl` | 136 | audio | `let audio = u.config.y * 2.0;` |
+| `public/shaders/gen-neuro-kinetic-liquid-gold-lotus.wgsl` | 150 | audio | `let audio_val = u.config.y; // Simplified audio metric` |
+| `public/shaders/gen-obsidian-echo-chamber.wgsl` | 156 | audio | `let audioIntensity = u.config.y * u.zoom_params.y;` |
+| `public/shaders/gen-physarum-sacred-geometry.wgsl` | 134 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-bismuth-lattice.wgsl` | 75 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-bismuth-lattice.wgsl` | 212 | unclassified | `let thickness = mat + u.config.y * 0.1;` |
+| `public/shaders/gen-prismatic-bismuth-lattice.wgsl` | 235 | unclassified | `color += irid_color * vec3<f32>(edge * u.config.y * 2.0);` |
+| `public/shaders/gen-prismatic-cyber-aurora-astral-dragonfly.wgsl` | 173 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-cyber-auroral-manta-swarm.wgsl` | 242 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-cyber-chrono-nebula-peacock.wgsl` | 78 | audio | `let audio = u.config.y * u.zoom_params.w;` |
+| `public/shaders/gen-prismatic-cyber-chrono-nebula-peacock.wgsl` | 206 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-cyber-chrono-void-kitsune.wgsl` | 176 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-cyber-chrono-void-kitsune.wgsl` | 177 | click_or_frame_count | `let click_shockwave = fract(u.config.y * 0.1); // Assuming some click mapping` |
+| `public/shaders/gen-prismatic-cyber-chrono-void-tortoise.wgsl` | 146 | audio | `let audio_bass = plasmaBuffer[0].x * u.config.y;` |
+| `public/shaders/gen-prismatic-fractal-dunes.wgsl` | 149 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-prismatic-void-weaver-ouroboros.wgsl` | 111 | audio | `let audio = u.config.y * audioReact * 2.0;` |
+| `public/shaders/gen-prismatic-void-weaver-ouroboros.wgsl` | 194 | audio | `let audioReact = u.config.y * u.zoom_params.w;` |
+| `public/shaders/gen-quantum-aether-origami.wgsl` | 207 | audio | `let audio_pulse = 1.0 + u.config.y * zparams.z;` |
+| `public/shaders/gen-quantum-chrome-serpent-ouroboros.wgsl` | 218 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-quantum-fluorescent-aether-moth-swarm.wgsl` | 146 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-quantum-fluorescent-aether-moth-swarm.wgsl` | 149 | audio | `let click = select(0.0, 1.0, u.config.y > 0.5); // proxy for click or audio reactivity` |
+| `public/shaders/gen-quantum-fluorescent-nebula-anemone.wgsl` | 140 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-quantum-foam.wgsl` | 151 | delta_time | `let dt    = u.config.y;` |
+| `public/shaders/gen-quantum-mycelium.wgsl` | 130 | unclassified | `g_audio = u.config.y * 0.1;` |
+| `public/shaders/gen-radiant-cyber-chrono-void-stag.wgsl` | 113 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-radiant-cyber-chrono-void-stag.wgsl` | 372 | audio | `var glow_intensity = u.config.y; // audio` |
+| `public/shaders/gen-radiant-quantum-plasma-kraken-core.wgsl` | 90 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-radiant-quantum-plasma-kraken-core.wgsl` | 196 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-sentient-aether-flora-biosphere.wgsl` | 88 | audio | `let audio_react = u.zoom_params.w * u.config.y; // using click count as proxy if no audio data` |
+| `public/shaders/gen-sentient-aether-flora-biosphere.wgsl` | 166 | audio | `let audio_react = u.zoom_params.w * u.config.y; // parameter 4` |
+| `public/shaders/gen-sentient-cyber-aurora-void-owl.wgsl` | 192 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl` | 110 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl` | 207 | audio | `let audio = u.config.y;` |
+| `public/shaders/gen-sentient-quantum-chrono-leviathan-moth.wgsl` | 301 | click_or_frame_count | `let clickVal = u.config.y; // Simplified` |
+| `public/shaders/gen-singularity-forge-blackbody.wgsl` | 129 | unclassified | `let spaghettification = u.config.y;` |
+| `public/shaders/gen-singularity-forge-blackbody.wgsl` | 132 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/gen-sonoluminescent-chrono-geode-matrix.wgsl` | 146 | unclassified | `let uv = vec2<f32>(f32(id.x) / u.config.x, f32(id.y) / u.config.y);` |
+| `public/shaders/gen-stellar-web-loom.wgsl` | 144 | unclassified | `g_audio = u.config.y * 0.1;` |
+| `public/shaders/gen_reaction_diffusion.wgsl` | 144 | click_or_frame_count | `let clickCount = u.config.y;` |
+| `public/shaders/holographic-interferometry.wgsl` | 108 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/holographic-interferometry.wgsl` | 109 | audio | `let audioBass = u.config.y * 1.2;` |
+| `public/shaders/hybrid-chromatic-liquid.wgsl` | 79 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/hybrid-magnetic-field.wgsl` | 98 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/interactive-voronoi-lens.wgsl` | 81 | delta_time | `let dt = u.config.y;` |
+| `public/shaders/liquid-prism.wgsl` | 95 | audio | `let audioOverall = u.config.y;` |
+| `public/shaders/lorenz-attractor-flow.wgsl` | 46 | click_or_frame_count | `let click = u.config.y;` |
+| `public/shaders/mouse-ink-bleed.wgsl` | 94 | delta_time | `let dt = u.config.y;` |
+| `public/shaders/nano-assembler.wgsl` | 73 | unclassified | `let time = u.config.y;` |
+| `public/shaders/neural-synapse-web.wgsl` | 77 | delta_time | `let dt = clamp(u.config.y, 0.001, 0.05);` |
+| `public/shaders/optical-feedback.wgsl` | 117 | delta_time | `let dt = u.config.y;` |
+| `public/shaders/origami-fold.wgsl` | 69 | click_or_frame_count | `let clickCount = u.config.y;` |
+| `public/shaders/phase-memory-weave.wgsl` | 88 | click_or_frame_count | `let clicks = u.config.y;` |
+| `public/shaders/photonic-caustics.wgsl` | 116 | click_or_frame_count | `let frame = u.config.y;` |
+| `public/shaders/photonic-trace.wgsl` | 58 | click_or_frame_count | `let frame = u.config.y;` |
+| `public/shaders/plasma.wgsl` | 67 | audio | `var audioOverall = u.config.y;` |
+| `public/shaders/predator-prey.wgsl` | 133 | click_or_frame_count | `let frame = u.config.y;` |
+| `public/shaders/quantum-foam-pass2.wgsl` | 150 | unclassified | `let globalIntensity = u.config.y;` |
+| `public/shaders/quantum-foam-pass3.wgsl` | 107 | unclassified | `let globalIntensity = u.config.y;` |
+| `public/shaders/spec-runge-kutta-advection.wgsl` | 92 | unclassified | `if (isMouseDown \|\| u.config.y > 0.5) {` |
+| `public/shaders/stellar-plasma-blackbody.wgsl` | 130 | audio | `let audioLow = u.config.y;` |
+| `public/shaders/temporal-rgb-smear.wgsl` | 174 | delta_time | `let dt = clamp(u.config.y, 0.0, 0.1);` |
+| `public/shaders/time-lag-map.wgsl` | 102 | click_or_frame_count | `let frame = u.config.y;` |
+| `public/shaders/vortex-distortion.wgsl` | 81 | unclassified | `let numV     = min(i32(u.config.y), 20);   // cap at 20 vortices for performance` |

--- a/scripts/AUTHORING.md
+++ b/scripts/AUTHORING.md
@@ -28,6 +28,29 @@ The template contains the exact 13 bindings the renderer expects, the required
 `Uniforms` struct, and a `(16, 16, 1)` workgroup size. Do not change binding
 numbers or types unless you also update the renderer.
 
+## Uniform semantics (read this before using `u.config`)
+
+The `Uniforms` struct is documented field-by-field in
+[`docs/BINDING_CONTRACT.md`](../docs/BINDING_CONTRACT.md#uniforms-struct-binding-3), generated from
+`src/contracts/uniforms_layout.json` and verified against the engine by `npm run verify:uniforms`
+(runs in CI). The three that get authored wrong most often:
+
+- `u.config.x` — time in seconds. **There is no delta-time uniform.** Older briefs claimed
+  `config.y = delta_time`; that was never true on either backend.
+- `u.config.y` — **rippleCount** (0–50). Guard ripple loops with `min(u32(u.config.y), 50u)`.
+  Never use it for audio, click count or animation speed.
+- Audio lives in `plasmaBuffer[0].xyz` (bass/mids/treble) and `extraBuffer[5..132]` (FFT bins),
+  never in `config`.
+- `u.zoom_config.yz` — mouse UV, **y = 0 at the top** (fixed 2026-07-19; do not add a flip).
+  `u.zoom_config.w > 0.5` means pressed.
+
+To find shaders that already read `config.y` as something else, run
+`npm run audit:config-y` (report-only, writes `reports/config_y_misuse.md`).
+
+If you change the packing in `src/renderer/UniformBuffer.ts` or
+`wasm_renderer/frame.cpp`, update `src/contracts/uniforms_layout.json` in the same commit —
+CI fails otherwise.
+
 ## `new_shader.py`
 
 Usage:
@@ -209,6 +232,7 @@ The immutable bind-group contract lives in:
 
 - `scripts/bindgroup_checker.py` -> `EXPECTED_BINDINGS`
 - `public/shaders/_template_canonical_compute.wgsl`
+- `src/contracts/uniforms_layout.json` (Uniforms struct field meanings; gate: `npm run verify:uniforms`)
 
 If a new renderer feature needs a different layout, update the checker and the
 template together, then re-run the gate over the whole library.

--- a/scripts/audit_config_y_misuse.py
+++ b/scripts/audit_config_y_misuse.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Audit public/shaders for `u.config.y` read as something other than rippleCount.
+
+`config = [time, rippleCount, resW, resH]` (src/contracts/uniforms_layout.json).
+Stale agent briefs claimed `config.y` was delta_time / MouseClickCount / audio, so a
+number of shaders read it as such. Those reads are not crashes — they silently produce
+a value in 0..50 that is almost always 0 — hence "looks fine" shaders with dead audio
+or frozen motion.
+
+Report only (non-blocking). Use it to triage follow-up fix PRs.
+
+    python3 scripts/audit_config_y_misuse.py [--json reports/config_y_misuse.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SHADER_DIR = ROOT / "public" / "shaders"
+
+CONFIG_Y = re.compile(r"u\.config\.y(?![a-z])")
+# Reads of config.yz / config.yzw / config.xy — legacy "audio" and "resolution" swizzles.
+CONFIG_SWIZZLE = re.compile(r"u\.config\.(yz|yzw|zyx|xy)\b")
+
+CATEGORIES = [
+    ("delta_time", re.compile(r"\b(dt|delta_?t(ime)?|deltaTime|timestep|time_step)\b", re.I)),
+    ("audio", re.compile(r"\b(audio|bass|mid|mids|treble|beat|fft|amp|amplitude|volume)\w*\b", re.I)),
+    ("click_or_frame_count", re.compile(r"\b(click|frame_?count|frame|parity|seed)\w*\b", re.I)),
+    ("resolution", re.compile(r"\b(resolution|res|aspect|dims?)\b", re.I)),
+]
+
+# Reads that are consistent with rippleCount semantics.
+RIPPLE_OK = re.compile(r"ripple|min\(\s*u32\(|u32\(\s*u\.config\.y", re.I)
+
+
+def classify(line: str) -> str | None:
+    if RIPPLE_OK.search(line):
+        return None
+    for name, pattern in CATEGORIES:
+        if pattern.search(line):
+            return name
+    return "unclassified"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", default="reports/config_y_misuse.json")
+    ap.add_argument("--markdown", default="reports/config_y_misuse.md")
+    args = ap.parse_args()
+
+    findings: list[dict] = []
+    for path in sorted(SHADER_DIR.glob("*.wgsl")):
+        for i, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("//"):
+                continue  # comments (including "was u.config.y" fix notes) are not reads
+            if not (CONFIG_Y.search(line) or CONFIG_SWIZZLE.search(line)):
+                continue
+            category = classify(line)
+            if category is None:
+                continue
+            findings.append(
+                {
+                    "file": str(path.relative_to(ROOT)),
+                    "line": i,
+                    "category": category,
+                    "code": stripped[:200],
+                }
+            )
+
+    by_category: dict[str, int] = {}
+    for f in findings:
+        by_category[f["category"]] = by_category.get(f["category"], 0) + 1
+
+    out_json = ROOT / args.json
+    out_md = ROOT / args.markdown
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps({"total": len(findings), "byCategory": by_category, "findings": findings}, indent=2))
+
+    lines = [
+        "# `u.config.y` misuse audit",
+        "",
+        "`config = [time, rippleCount, resW, resH]` — see `src/contracts/uniforms_layout.json`.",
+        "Every row below reads `config.y` (or a legacy `config` swizzle) as something else.",
+        "",
+        f"**Total: {len(findings)} reads across {len({f['file'] for f in findings})} shaders**",
+        "",
+        "| Category | Count |",
+        "|----------|-------|",
+    ]
+    for cat, count in sorted(by_category.items(), key=lambda kv: -kv[1]):
+        lines.append(f"| `{cat}` | {count} |")
+    lines += ["", "## Findings", "", "| File | Line | Category | Code |", "|------|------|----------|------|"]
+    for f in findings:
+        code = f["code"].replace("|", "\\|")
+        lines.append(f"| `{f['file']}` | {f['line']} | {f['category']} | `{code}` |")
+    out_md.write_text("\n".join(lines) + "\n")
+
+    print(f"config.y misuse audit: {len(findings)} reads in {len({f['file'] for f in findings})} shaders")
+    for cat, count in sorted(by_category.items(), key=lambda kv: -kv[1]):
+        print(f"  {cat}: {count}")
+    print(f"Reports: {args.markdown}, {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-upgrade-swarm.js
+++ b/scripts/run-upgrade-swarm.js
@@ -38,8 +38,8 @@ const BINDING_HEADER = `// ── IMMUTABLE 13-BINDING CONTRACT ─────�
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
-  zoom_config: vec4<f32>,  // x=Time, y=MouseX, z=MouseY, w=MouseDown
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
   ripples: array<vec4<f32>, 50>,
 };`;

--- a/scripts/scan-shaders-naga.py
+++ b/scripts/scan-shaders-naga.py
@@ -39,8 +39,8 @@ BINDING_HEADER = """\
 @group(0) @binding(12) var<storage, read> plasmaBuffer: array<vec4<f32>>;
 
 struct Uniforms {
-  config: vec4<f32>,       // x=Time, y=MouseClickCount, z=ResX, w=ResY
-  zoom_config: vec4<f32>,  // x=Time, y=MouseX, z=MouseY, w=MouseDown
+  config: vec4<f32>,       // .x = time (seconds), .y = rippleCount (0-50 active ripples), .zw = resolution (width, height)
+  zoom_config: vec4<f32>,  // .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)
   zoom_params: vec4<f32>,  // x=Param1, y=Param2, z=Param3, w=Param4
   ripples: array<vec4<f32>, 50>,
 };"""

--- a/scripts/test_verify_uniforms_layout.js
+++ b/scripts/test_verify_uniforms_layout.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Self-test for verify-uniforms-layout.js: the gate must actually FAIL on drift.
+ * Builds throwaway copies of the tracked files, mutates one thing at a time, and
+ * asserts the checker exits non-zero with the expected complaint.
+ *
+ * Run: node scripts/test_verify_uniforms_layout.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+const SCRIPT = path.join(__dirname, 'verify-uniforms-layout.js');
+
+const contract = JSON.parse(fs.readFileSync(path.join(ROOT, 'src/contracts/uniforms_layout.json'), 'utf8'));
+
+const TRACKED = [
+  'src/contracts/uniforms_layout.json',
+  'src/renderer/UniformBuffer.ts',
+  'src/renderer/types.ts',
+  'wasm_renderer/renderer.h',
+  'wasm_renderer/frame.cpp',
+  ...contract.authoringComment.trackedFiles,
+];
+
+function makeTree() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'uniforms-contract-'));
+  for (const rel of TRACKED) {
+    const dest = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(path.join(ROOT, rel), dest);
+  }
+  return dir;
+}
+
+function run(dir) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    env: { ...process.env, UNIFORMS_CONTRACT_ROOT: dir },
+    encoding: 'utf8',
+  });
+}
+
+function patch(dir, rel, from, to) {
+  const p = path.join(dir, rel);
+  const src = fs.readFileSync(p, 'utf8');
+  if (!src.includes(from)) throw new Error(`self-test fixture stale: "${from}" not found in ${rel}`);
+  fs.writeFileSync(p, src.replace(from, to));
+}
+
+let failures = 0;
+function check(name, fn) {
+  const dir = makeTree();
+  try {
+    fn(dir);
+    const res = run(dir);
+    if (res.status === 0) {
+      console.error(`❌ ${name}: gate passed but should have failed`);
+      failures++;
+    } else {
+      console.log(`✅ ${name}: gate failed as expected`);
+    }
+  } catch (err) {
+    console.error(`❌ ${name}: ${err.message}`);
+    failures++;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// Baseline: the untouched tree must pass.
+{
+  const dir = makeTree();
+  const res = run(dir);
+  if (res.status !== 0) {
+    console.error('❌ baseline: unmodified tree fails the gate\n' + res.stdout + res.stderr);
+    failures++;
+  } else {
+    console.log('✅ baseline: unmodified tree passes');
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+check('offset drift in UniformBuffer.ts', (dir) =>
+  patch(dir, 'src/renderer/UniformBuffer.ts', 'config_rippleCount: 4,', 'config_rippleCount: 8,'),
+);
+
+check('layout drift in types.ts', (dir) =>
+  patch(dir, 'src/renderer/types.ts', 'ZOOM_PARAMS_OFFSET: 32,', 'ZOOM_PARAMS_OFFSET: 36,'),
+);
+
+check('struct size drift in contract JSON', (dir) =>
+  patch(dir, 'src/contracts/uniforms_layout.json', '"totalSizeBytes": 848,', '"totalSizeBytes": 864,'),
+);
+
+check('C++ comment drift', (dir) =>
+  patch(
+    dir,
+    'wasm_renderer/renderer.h',
+    'float config[4];       // time, rippleCount, resolutionX, resolutionY',
+    'float config[4];       // time, deltaTime, resolutionX, resolutionY',
+  ),
+);
+
+check('agent brief reintroduces config.y = delta_time', (dir) =>
+  patch(
+    dir,
+    'agents/WGSL_BUILTINS_GENERATIVE.md',
+    '.y = rippleCount (0-50 active ripples)',
+    '.y = delta_time',
+  ),
+);
+
+check('BINDING_CONTRACT drops a documented field', (dir) =>
+  patch(dir, 'docs/BINDING_CONTRACT.md', '| `zoom_config.z` | 24 |', '| `zoomconfig.z` | 24 |'),
+);
+
+if (failures) {
+  console.error(`\n❌ ${failures} self-test(s) failed`);
+  process.exit(1);
+}
+console.log('\n✅ verify-uniforms-layout self-tests passed');

--- a/scripts/verify-uniforms-layout.js
+++ b/scripts/verify-uniforms-layout.js
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * verify-uniforms-layout.js
+ *
+ * CI check: src/contracts/uniforms_layout.json is the single source of truth for the
+ * WGSL `Uniforms` struct (binding 3). This verifies it against:
+ *   - src/renderer/UniformBuffer.ts     (UNIFORM_OFFSETS, MAX_RIPPLES, UNIFORM_FLOATS)
+ *   - src/renderer/types.ts             (UNIFORM_BUFFER_LAYOUT)
+ *   - wasm_renderer/renderer.h          (struct Uniforms field comments)
+ *   - wasm_renderer/frame.cpp           (UpdateUniformBuffer packing comments)
+ *   - tracked authoring surfaces        (docs / agent briefs / templates must not
+ *                                        claim config.y is delta_time, click count, …)
+ *
+ * Run: npm run verify:uniforms
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// UNIFORMS_CONTRACT_ROOT lets the self-test point the checker at a mutated copy of the tree.
+const ROOT = process.env.UNIFORMS_CONTRACT_ROOT || path.join(__dirname, '..');
+const CONTRACT_PATH = path.join(ROOT, 'src/contracts/uniforms_layout.json');
+const contract = JSON.parse(fs.readFileSync(CONTRACT_PATH, 'utf8'));
+
+const errors = [];
+const checks = [];
+
+function fail(msg) {
+  errors.push(msg);
+}
+function ok(msg) {
+  checks.push(msg);
+}
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+// ── 1. UNIFORM_OFFSETS in UniformBuffer.ts ──────────────────────────────────
+
+function checkUniformBufferTs() {
+  const rel = 'src/renderer/UniformBuffer.ts';
+  const src = read(rel);
+  const block = src.match(/UNIFORM_OFFSETS\s*=\s*\{([\s\S]*?)\}\s*as const;/);
+  if (!block) {
+    fail(`${rel}: UNIFORM_OFFSETS object not found`);
+    return;
+  }
+  const offsets = {};
+  for (const m of block[1].matchAll(/(\w+):\s*(\d+)\s*,/g)) {
+    offsets[m[1]] = parseInt(m[2], 10);
+  }
+
+  for (const field of contract.fields) {
+    for (const comp of field.components) {
+      const key = comp.tsOffsetKey;
+      if (!key) continue;
+      const expected = field.name === 'ripples' ? field.offset : comp.offset;
+      if (offsets[key] === undefined) {
+        fail(`${rel}: UNIFORM_OFFSETS.${key} missing (contract field ${field.name}.${comp.swizzle})`);
+      } else if (offsets[key] !== expected) {
+        fail(
+          `${rel}: UNIFORM_OFFSETS.${key} = ${offsets[key]} but contract says ${expected} ` +
+            `(${field.name}.${comp.swizzle} = ${comp.meaning})`,
+        );
+      }
+    }
+    if (field.tsOffsetKey && offsets[field.tsOffsetKey] !== field.offset) {
+      fail(`${rel}: UNIFORM_OFFSETS.${field.tsOffsetKey} = ${offsets[field.tsOffsetKey]} but contract says ${field.offset}`);
+    }
+  }
+
+  const ripples = contract.fields.find((f) => f.name === 'ripples');
+  if (offsets.ripple_stride !== ripples.strideBytes) {
+    fail(`${rel}: UNIFORM_OFFSETS.ripple_stride = ${offsets.ripple_stride} but contract says ${ripples.strideBytes}`);
+  }
+
+  const maxRipples = src.match(/const MAX_RIPPLES\s*=\s*(\d+)/);
+  if (!maxRipples || parseInt(maxRipples[1], 10) !== contract.maxRipples) {
+    fail(`${rel}: MAX_RIPPLES must be ${contract.maxRipples}`);
+  }
+
+  // Component ordering inside the setters must match the contract meanings.
+  const setterFields = {
+    setConfig: 'config',
+    setZoomConfig: 'zoom_config',
+    setZoomParams: 'zoom_params',
+  };
+  for (const [setter, fieldName] of Object.entries(setterFields)) {
+    const sig = src.match(new RegExp(`${setter}\\(([^)]*)\\):\\s*void;`));
+    if (!sig) {
+      fail(`${rel}: ${setter} signature not found`);
+      continue;
+    }
+    const argNames = sig[1]
+      .split(',')
+      .map((a) => a.trim().split(':')[0].trim())
+      .filter(Boolean);
+    const field = contract.fields.find((f) => f.name === fieldName);
+    const expectedNames = field.components.map((c) => c.meaning);
+    // Setter args use short forms (resW/resH) for the same contract meanings.
+    const TS_ARG_ALIASES = {
+      resolutionWidth: ['resW', 'resolutionWidth', 'width'],
+      resolutionHeight: ['resH', 'resolutionHeight', 'height'],
+    };
+    const mismatch = expectedNames.filter((n, i) => {
+      const accepted = TS_ARG_ALIASES[n] || [n];
+      return !accepted.includes(argNames[i]);
+    });
+    if (mismatch.length) {
+      fail(
+        `${rel}: ${setter}(${argNames.join(', ')}) does not match contract order ` +
+          `(${expectedNames.join(', ')})`,
+      );
+    }
+  }
+
+  ok(`${rel}: UNIFORM_OFFSETS + setters match contract`);
+}
+
+// ── 2. UNIFORM_BUFFER_LAYOUT in types.ts ────────────────────────────────────
+
+function checkTypesTs() {
+  const rel = 'src/renderer/types.ts';
+  const src = read(rel);
+  const block = src.match(/UNIFORM_BUFFER_LAYOUT\s*=\s*\{([\s\S]*?)\}\s*as const;/);
+  if (!block) {
+    fail(`${rel}: UNIFORM_BUFFER_LAYOUT not found`);
+    return;
+  }
+  const vals = {};
+  for (const m of block[1].matchAll(/(\w+):\s*(\d+)\s*,/g)) {
+    vals[m[1]] = parseInt(m[2], 10);
+  }
+  const expected = {
+    CONFIG_OFFSET: contract.fields.find((f) => f.name === 'config').offset,
+    ZOOM_CONFIG_OFFSET: contract.fields.find((f) => f.name === 'zoom_config').offset,
+    ZOOM_PARAMS_OFFSET: contract.fields.find((f) => f.name === 'zoom_params').offset,
+    RIPPLES_OFFSET: contract.fields.find((f) => f.name === 'ripples').offset,
+    TOTAL_SIZE: contract.totalSizeBytes,
+    MAX_RIPPLES: contract.maxRipples,
+  };
+  for (const [key, want] of Object.entries(expected)) {
+    if (vals[key] !== want) {
+      fail(`${rel}: UNIFORM_BUFFER_LAYOUT.${key} = ${vals[key]} but contract says ${want}`);
+    }
+  }
+
+  // Total size must be self-consistent with the field list.
+  const ripples = contract.fields.find((f) => f.name === 'ripples');
+  const derived = ripples.offset + ripples.count * ripples.strideBytes;
+  if (derived !== contract.totalSizeBytes) {
+    fail(`contract: totalSizeBytes ${contract.totalSizeBytes} != derived ${derived}`);
+  }
+  if (contract.floatCount * 4 !== contract.totalSizeBytes) {
+    fail(`contract: floatCount ${contract.floatCount} does not match totalSizeBytes ${contract.totalSizeBytes}`);
+  }
+
+  ok(`${rel}: UNIFORM_BUFFER_LAYOUT matches contract`);
+}
+
+// ── 3. C++ mirror ───────────────────────────────────────────────────────────
+
+/** Normalizes a comment for meaning comparison: lowercase alnum tokens. */
+function tokens(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean);
+}
+
+/** C++ comments use resolutionX/resolutionY etc.; map contract meanings to accepted aliases. */
+const CPP_ALIASES = {
+  time: ['time'],
+  rippleCount: ['ripplecount'],
+  resolutionWidth: ['resolutionx', 'resx', 'width'],
+  resolutionHeight: ['resolutiony', 'resy', 'height'],
+  mouseX: ['mousex'],
+  mouseY: ['mousey'],
+  mouseDown: ['mousedown'],
+  p1: ['param1', 'p1'],
+  p2: ['param2', 'p2'],
+  p3: ['param3', 'p3'],
+  p4: ['param4', 'p4'],
+};
+
+function checkCppComment(rel, src, pattern, fieldName) {
+  const m = src.match(pattern);
+  if (!m) {
+    fail(`${rel}: could not find ${fieldName} packing comment (pattern ${pattern})`);
+    return;
+  }
+  const commentTokens = tokens(m[1]);
+  const field = contract.fields.find((f) => f.name === fieldName);
+  field.components.forEach((comp, i) => {
+    const aliases = CPP_ALIASES[comp.meaning] || [comp.meaning.toLowerCase()];
+    if (!aliases.some((a) => commentTokens.includes(a))) {
+      fail(
+        `${rel}: ${fieldName} comment "${m[1].trim()}" does not document component ` +
+          `.${comp.swizzle} = ${comp.meaning}`,
+      );
+    }
+    const pos = commentTokens.findIndex((t) => aliases.includes(t));
+    if (pos !== -1 && pos < i) {
+      // ordering is best-effort; only flag hard misordering of distinct names
+    }
+  });
+}
+
+function checkCpp() {
+  const headerRel = 'wasm_renderer/renderer.h';
+  const header = read(headerRel);
+  checkCppComment(headerRel, header, /float\s+config\[4\];\s*\/\/([^\n]*)/, 'config');
+  checkCppComment(headerRel, header, /float\s+zoom_config\[4\];\s*\/\/([^\n]*)/, 'zoom_config');
+  checkCppComment(headerRel, header, /float\s+zoom_params\[4\];\s*\/\/([^\n]*)/, 'zoom_params');
+
+  const rippleDecl = header.match(/float\s+ripples\[(\d+)\]\[4\];/);
+  if (!rippleDecl || parseInt(rippleDecl[1], 10) !== contract.maxRipples) {
+    fail(`${headerRel}: struct Uniforms ripples[] must be [${contract.maxRipples}][4]`);
+  }
+
+  const frameRel = 'wasm_renderer/frame.cpp';
+  const frame = read(frameRel);
+  checkCppComment(frameRel, frame, /\/\/\s*config:([^\n]*)/, 'config');
+  checkCppComment(frameRel, frame, /\/\/\s*zoom_config:([^\n]*)/, 'zoom_config');
+
+  const floatCount = frame.match(/UNIFORM_FLOAT_COUNT\s*=\s*(\d+)\s*\+\s*MAX_RIPPLES\s*\*\s*(\d+)/);
+  if (!floatCount) {
+    fail(`${frameRel}: UNIFORM_FLOAT_COUNT expression not found`);
+  } else {
+    const total = parseInt(floatCount[1], 10) + contract.maxRipples * parseInt(floatCount[2], 10);
+    if (total !== contract.floatCount) {
+      fail(`${frameRel}: UNIFORM_FLOAT_COUNT resolves to ${total} floats, contract says ${contract.floatCount}`);
+    }
+  }
+
+  ok('wasm_renderer: Uniforms struct + packing comments match contract');
+}
+
+// ── 4. Authoring surfaces (docs, briefs, templates) ─────────────────────────
+
+function checkAuthoringSurfaces() {
+  const { required, forbidden, trackedFiles } = contract.authoringComment;
+  let scanned = 0;
+
+  for (const rel of trackedFiles) {
+    const abs = path.join(ROOT, rel);
+    if (!fs.existsSync(abs)) {
+      fail(`tracked authoring file missing: ${rel} (update uniforms_layout.json if it moved)`);
+      continue;
+    }
+    const lines = fs.readFileSync(abs, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      for (const fieldName of ['config', 'zoom_config']) {
+        // Match a struct field declaration with a trailing comment.
+        const decl = new RegExp(`(?:^|[^_\\w])${fieldName}\\s*:\\s*vec4<f32>\\s*,\\s*(//.*)$`);
+        const m = line.match(decl);
+        if (!m) continue;
+        if (fieldName === 'config' && /zoom_config/.test(line)) continue;
+        scanned++;
+        const comment = m[1];
+        const lower = comment.toLowerCase();
+        for (const bad of forbidden[fieldName] || []) {
+          if (lower.includes(bad.toLowerCase())) {
+            fail(
+              `${rel}:${i + 1}: \`${fieldName}\` comment claims "${bad}" — engine truth is ` +
+                `${contract.authoringComment[fieldName]}`,
+            );
+          }
+        }
+        for (const need of required[fieldName] || []) {
+          if (!lower.includes(need.toLowerCase())) {
+            fail(
+              `${rel}:${i + 1}: \`${fieldName}\` comment omits "${need}" — expected ` +
+                `${contract.authoringComment[fieldName]}`,
+            );
+          }
+        }
+      }
+    });
+  }
+
+  // Prose claims outside struct blocks (e.g. "config.y = delta_time") are also banned.
+  const proseBans = [/config\s*\.\s*y\s*(?:=|is|→|->)\s*[`"']?\s*(?:delta|dt\b)/i];
+  for (const rel of trackedFiles) {
+    const abs = path.join(ROOT, rel);
+    if (!fs.existsSync(abs)) continue;
+    const lines = fs.readFileSync(abs, 'utf8').split('\n');
+    // Lines that explicitly debunk the myth are allowed to quote it.
+    const negation = /\b(not|never|no longer|wrong|myth|stale|incorrect|was never)\b/i;
+    lines.forEach((line, i) => {
+      if (negation.test(line)) return;
+      for (const re of proseBans) {
+        if (re.test(line)) {
+          fail(`${rel}:${i + 1}: prose claims config.y is delta time — it is rippleCount`);
+        }
+      }
+    });
+  }
+
+  ok(`authoring surfaces: ${trackedFiles.length} files scanned (${scanned} Uniforms comments checked)`);
+}
+
+// ── 5. BINDING_CONTRACT.md must document every field ────────────────────────
+
+function checkBindingContractDoc() {
+  const rel = 'docs/BINDING_CONTRACT.md';
+  const src = read(rel);
+  if (!/##\s*Uniforms struct \(binding 3\)/.test(src)) {
+    fail(`${rel}: missing "## Uniforms struct (binding 3)" section`);
+    return;
+  }
+  for (const field of contract.fields) {
+    for (const comp of field.components) {
+      // Array fields are documented per element, e.g. `ripples[i].x`.
+      const accepted = field.count
+        ? [`${field.name}[i].${comp.swizzle}`, `${field.name}[].${comp.swizzle}`, `${field.name}.${comp.swizzle}`]
+        : [`${field.name}.${comp.swizzle}`];
+      const cell = accepted[0];
+      if (!accepted.some((c) => src.includes(c))) {
+        fail(`${rel}: Uniforms table does not document \`${cell}\` (${comp.meaning})`);
+      }
+    }
+    if (!src.includes(`| ${field.offset} `) && field.name !== 'ripples') {
+      // offsets are documented per component row; tolerate formatting variance
+    }
+  }
+  if (!src.includes('src/contracts/uniforms_layout.json')) {
+    fail(`${rel}: must cross-reference src/contracts/uniforms_layout.json`);
+  }
+  ok(`${rel}: Uniforms struct documented field-by-field`);
+}
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+
+checkUniformBufferTs();
+checkTypesTs();
+checkCpp();
+checkAuthoringSurfaces();
+checkBindingContractDoc();
+
+for (const c of checks) console.log(`✅ ${c}`);
+
+if (errors.length) {
+  console.error(`\n❌ Uniforms layout contract drift (${errors.length} problem(s)):\n`);
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error('\nSource of truth: src/contracts/uniforms_layout.json + src/renderer/UniformBuffer.ts');
+  process.exit(1);
+}
+
+console.log('\n✅ Uniforms layout contract in sync (TS ↔ C++ ↔ docs/briefs)');

--- a/src/contracts/uniforms_layout.json
+++ b/src/contracts/uniforms_layout.json
@@ -1,0 +1,144 @@
+{
+  "version": 1,
+  "description": "Authoritative field-by-field layout of the WGSL `Uniforms` struct (bind group 0, binding 3). Source of truth for docs, agent briefs and shader authoring. Keep in sync with src/renderer/UniformBuffer.ts (UNIFORM_OFFSETS), src/renderer/types.ts (UNIFORM_BUFFER_LAYOUT) and wasm_renderer/renderer.h + frame.cpp (Uniforms / UpdateUniformBuffer). Enforced by `npm run verify:uniforms`.",
+  "totalSizeBytes": 848,
+  "floatCount": 212,
+  "maxRipples": 50,
+  "writers": {
+    "typescript": ["src/renderer/UniformBuffer.ts", "src/renderer/webgpu/frame.ts"],
+    "cpp": ["wasm_renderer/renderer.h", "wasm_renderer/frame.cpp"]
+  },
+  "fields": [
+    {
+      "name": "config",
+      "type": "vec4<f32>",
+      "offset": 0,
+      "components": [
+        {
+          "swizzle": "x",
+          "offset": 0,
+          "tsOffsetKey": "config_time",
+          "meaning": "time",
+          "units": "seconds since renderer start (monotonic, never resets)",
+          "notes": "NOT delta time. Per-frame dt is not uploaded; derive motion from absolute time."
+        },
+        {
+          "swizzle": "y",
+          "offset": 4,
+          "tsOffsetKey": "config_rippleCount",
+          "meaning": "rippleCount",
+          "units": "count of active ripples, 0..50 (f32)",
+          "notes": "Guard ripple loops with min(u32(u.config.y), 50u). Never read as delta time, audio or click count."
+        },
+        {
+          "swizzle": "z",
+          "offset": 8,
+          "tsOffsetKey": "config_resW",
+          "meaning": "resolutionWidth",
+          "units": "render-target width in pixels (post scaling)"
+        },
+        {
+          "swizzle": "w",
+          "offset": 12,
+          "tsOffsetKey": "config_resH",
+          "meaning": "resolutionHeight",
+          "units": "render-target height in pixels (post scaling)"
+        }
+      ]
+    },
+    {
+      "name": "zoom_config",
+      "type": "vec4<f32>",
+      "offset": 16,
+      "components": [
+        {
+          "swizzle": "x",
+          "offset": 16,
+          "tsOffsetKey": "zoom_time",
+          "meaning": "time",
+          "units": "seconds — same value as config.x"
+        },
+        {
+          "swizzle": "y",
+          "offset": 20,
+          "tsOffsetKey": "zoom_mouseX",
+          "meaning": "mouseX",
+          "units": "canvas UV 0..1, 0 = left"
+        },
+        {
+          "swizzle": "z",
+          "offset": 24,
+          "tsOffsetKey": "zoom_mouseY",
+          "meaning": "mouseY",
+          "units": "canvas UV 0..1, 0 = TOP",
+          "notes": "Convention fixed 2026-07-19; do not re-flip. Matches WGSL texel/UV space, so no 1.0 - y correction is needed."
+        },
+        {
+          "swizzle": "w",
+          "offset": 28,
+          "tsOffsetKey": "zoom_mouseDown",
+          "meaning": "mouseDown",
+          "units": "1.0 pressed / 0.0 released; test with > 0.5"
+        }
+      ]
+    },
+    {
+      "name": "zoom_params",
+      "type": "vec4<f32>",
+      "offset": 32,
+      "components": [
+        { "swizzle": "x", "offset": 32, "tsOffsetKey": "params_x", "meaning": "p1", "units": "user slider 1 (range per shader JSON controls)" },
+        { "swizzle": "y", "offset": 36, "tsOffsetKey": "params_y", "meaning": "p2", "units": "user slider 2" },
+        { "swizzle": "z", "offset": 40, "tsOffsetKey": "params_z", "meaning": "p3", "units": "user slider 3" },
+        { "swizzle": "w", "offset": 44, "tsOffsetKey": "params_w", "meaning": "p4", "units": "user slider 4" }
+      ]
+    },
+    {
+      "name": "ripples",
+      "type": "array<vec4<f32>, 50>",
+      "offset": 48,
+      "strideBytes": 16,
+      "count": 50,
+      "tsOffsetKey": "ripples_start",
+      "components": [
+        { "swizzle": "x", "offset": 0, "meaning": "ripple UV x", "units": "canvas UV 0..1" },
+        { "swizzle": "y", "offset": 4, "meaning": "ripple UV y", "units": "canvas UV 0..1, 0 = top (same convention as zoom_config.z)" },
+        { "swizzle": "z", "offset": 8, "meaning": "startTime", "units": "seconds, same clock as config.x — age = u.config.x - r.z" },
+        { "swizzle": "w", "offset": 12, "meaning": "padding", "units": "always 0.0", "notes": "Reserved. Not a strength value on either backend; slots beyond rippleCount are fully zeroed." }
+      ]
+    }
+  ],
+  "authoringComment": {
+    "description": "Canonical comment text for the Uniforms struct in authoring templates, docs and agent briefs. verify-uniforms-layout.js checks tracked authoring surfaces against `required` / `forbidden`.",
+    "config": "// .x = time (seconds), .y = rippleCount (0-50), .zw = resolution (w, h)",
+    "zoom_config": "// .x = time, .yz = mouse_uv (0-1 canvas: y=0 top), .w = mouse_down (>0.5 = pressed)",
+    "zoom_params": "// .xyzw = user params p1..p4 (mapped from UI sliders)",
+    "ripples": "// .xy = ripple uv, .z = startTime (seconds), .w = padding (0)",
+    "required": {
+      "config": ["time", "rippleCount"],
+      "zoom_config": ["mouse"]
+    },
+    "forbidden": {
+      "config": ["delta_time", "deltaTime", "delta time", "ClickCount", "Click Count", "Generic1", "audio"],
+      "zoom_config": ["Generic2"]
+    },
+    "trackedFiles": [
+      "agents/WGSL_BUILTINS_GENERATIVE.md",
+      "agents/FIREWORKS_CONTRIBUTOR_KIT.md",
+      "agents/FIREWORKS_LIBRARY_GUIDE.md",
+      "agents/CLOUD_UPGRADE.md",
+      "agents/upgrade_swarm.md",
+      "agents/shader-upgrade-round-2026-05.md",
+      "agents/claude_opus_tier1_integration_prompt.md",
+      "docs/BINDING_CONTRACT.md",
+      "docs/TEXTURE_OPTIMIZATIONS.md",
+      "docs/SHADER_TEMPLATES.md",
+      "scripts/AUTHORING.md",
+      "scripts/scan-shaders-naga.py",
+      "scripts/run-upgrade-swarm.js",
+      "public/shaders/_template_canonical_compute.wgsl",
+      "public/shaders/_template_shared_memory.wgsl",
+      "public/shaders/_template_workgroup_atomics.wgsl"
+    ]
+  }
+}

--- a/src/renderer/uniformsLayoutContract.test.ts
+++ b/src/renderer/uniformsLayoutContract.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Contract test: src/contracts/uniforms_layout.json is the source of truth for the
+ * WGSL `Uniforms` struct. UNIFORM_OFFSETS / UNIFORM_BUFFER_LAYOUT must not drift from it.
+ * Cross-backend + docs drift is enforced separately by `npm run verify:uniforms` in CI.
+ */
+
+import contract from '../contracts/uniforms_layout.json';
+import { UNIFORM_OFFSETS, UNIFORM_FLOATS, MAX_RIPPLES, createUniformBufferView } from './UniformBuffer';
+import { UNIFORM_BUFFER_LAYOUT } from './types';
+
+type OffsetKey = keyof typeof UNIFORM_OFFSETS;
+
+const field = (name: string) => {
+  const f = contract.fields.find((x) => x.name === name);
+  if (!f) throw new Error(`contract missing field ${name}`);
+  return f;
+};
+
+describe('uniforms layout contract (shared JSON)', () => {
+  it('exports the expected contract version', () => {
+    expect(contract.version).toBe(1);
+  });
+
+  it('matches UNIFORM_OFFSETS for every documented component', () => {
+    for (const f of contract.fields) {
+      for (const comp of f.components) {
+        const key = (comp as { tsOffsetKey?: string }).tsOffsetKey;
+        if (!key) continue;
+        expect(UNIFORM_OFFSETS[key as OffsetKey]).toBe(f.name === 'ripples' ? f.offset : comp.offset);
+      }
+    }
+    expect(UNIFORM_OFFSETS.ripple_stride).toBe(field('ripples').strideBytes);
+  });
+
+  it('matches UNIFORM_BUFFER_LAYOUT offsets and size', () => {
+    expect(UNIFORM_BUFFER_LAYOUT.CONFIG_OFFSET).toBe(field('config').offset);
+    expect(UNIFORM_BUFFER_LAYOUT.ZOOM_CONFIG_OFFSET).toBe(field('zoom_config').offset);
+    expect(UNIFORM_BUFFER_LAYOUT.ZOOM_PARAMS_OFFSET).toBe(field('zoom_params').offset);
+    expect(UNIFORM_BUFFER_LAYOUT.RIPPLES_OFFSET).toBe(field('ripples').offset);
+    expect(UNIFORM_BUFFER_LAYOUT.TOTAL_SIZE).toBe(contract.totalSizeBytes);
+    expect(UNIFORM_BUFFER_LAYOUT.MAX_RIPPLES).toBe(contract.maxRipples);
+    expect(MAX_RIPPLES).toBe(contract.maxRipples);
+    expect(UNIFORM_FLOATS).toBe(contract.floatCount);
+    expect(UNIFORM_FLOATS * 4).toBe(contract.totalSizeBytes);
+  });
+
+  it('documents config.y as rippleCount, never delta time', () => {
+    const cfg = field('config');
+    expect(cfg.components.map((c) => c.meaning)).toEqual([
+      'time',
+      'rippleCount',
+      'resolutionWidth',
+      'resolutionHeight',
+    ]);
+
+    const view = createUniformBufferView();
+    view.setConfig(12.5, 3, 1920, 1080);
+    const data = view.data;
+    expect(data[UNIFORM_OFFSETS.config_time / 4]).toBeCloseTo(12.5);
+    expect(data[UNIFORM_OFFSETS.config_rippleCount / 4]).toBe(3);
+    expect(data[UNIFORM_OFFSETS.config_resW / 4]).toBe(1920);
+    expect(data[UNIFORM_OFFSETS.config_resH / 4]).toBe(1080);
+  });
+
+  it('writes zoom_config as [time, mouseX, mouseY, mouseDown] with top-down Y', () => {
+    expect(field('zoom_config').components.map((c) => c.meaning)).toEqual([
+      'time',
+      'mouseX',
+      'mouseY',
+      'mouseDown',
+    ]);
+
+    const view = createUniformBufferView();
+    view.setZoomConfig(1, 0.25, 0.75, 1);
+    const data = view.data;
+    expect(data[UNIFORM_OFFSETS.zoom_mouseX / 4]).toBeCloseTo(0.25);
+    // No flip: the value written is the value the shader reads.
+    expect(data[UNIFORM_OFFSETS.zoom_mouseY / 4]).toBeCloseTo(0.75);
+    expect(data[UNIFORM_OFFSETS.zoom_mouseDown / 4]).toBe(1);
+  });
+
+  it('packs ripples at the documented stride with zero padding', () => {
+    const view = createUniformBufferView();
+    view.setRipple(2, 0.1, 0.2, 5);
+    const base = (UNIFORM_OFFSETS.ripples_start + 2 * UNIFORM_OFFSETS.ripple_stride) / 4;
+    expect(view.data[base]).toBeCloseTo(0.1);
+    expect(view.data[base + 1]).toBeCloseTo(0.2);
+    expect(view.data[base + 2]).toBe(5);
+    expect(view.data[base + 3]).toBe(0);
+  });
+});

--- a/wasm_renderer/renderer.h
+++ b/wasm_renderer/renderer.h
@@ -109,12 +109,18 @@ struct ShaderSlot {
 // Uniform structure matching the WGSL shaders
 // PERF: MEDIUM - Structure is 848 bytes (212 floats). Consider alignment hints
 // to ensure GPU layout matches exactly. Add static_assert for size validation.
+// Field-by-field meanings: src/contracts/uniforms_layout.json (verified by
+// `npm run verify:uniforms`). config[1] is rippleCount — NOT delta time, audio or click count.
 struct Uniforms {
     float config[4];       // time, rippleCount, resolutionX, resolutionY
-    float zoom_config[4];  // time, mouseX, mouseY, mouseDown
+    float zoom_config[4];  // time, mouseX, mouseY (canvas UV, 0 = top), mouseDown
     float zoom_params[4];  // param1, param2, param3, param4
-    float ripples[50][4];  // x, y, startTime, unused
+    float ripples[50][4];  // x, y, startTime, padding (always 0)
 };
+
+// Must match UNIFORM_BUFFER_LAYOUT.TOTAL_SIZE (src/renderer/types.ts) and
+// uniforms_layout.json totalSizeBytes.
+static_assert(sizeof(Uniforms) == 848, "Uniforms must stay 848 bytes (212 floats) — see src/contracts/uniforms_layout.json");
 
 struct RipplePoint {
     float x, y;


### PR DESCRIPTION
## Summary

Two foundation changes, both landed on this branch because it is the designated development branch and this PR is still open. They are independent commits and can be split if you'd rather review them separately.

1. **`8842cf8` — Uniforms struct source of truth (#1038).** The engine packs `config = [time, rippleCount, resW, resH]`, but agent briefs still said `config.y = delta_time` (older ones `MouseClickCount` / `Generic1`). Adds a machine-checked contract, documents the struct field-by-field, fixes every live authoring surface, and gates it in CI.
2. **`7e3198a` — Format-tier bench harness, FP32 pin, fail-soft rewrite.** Tier behavior on real iGPUs is unmeasured; this lands the measurement machinery plus the hardening designing it surfaced.

---

## 1. Uniforms source of truth

- **`src/contracts/uniforms_layout.json`** (new) — offsets, meanings and units for `config`, `zoom_config`, `zoom_params`, `ripples[50]`, including the top-down mouse-Y convention (fixed 2026-07-19) and `ripples[i].w = padding` — *not* strength; both backends write 0.
- **`docs/BINDING_CONTRACT.md`** — new "Uniforms struct (binding 3)" section: canonical WGSL snippet, byte-offset table, do-not-reintroduce list.
- **Stale briefs fixed** — `agents/WGSL_BUILTINS_GENERATIVE.md`, `FIREWORKS_CONTRIBUTOR_KIT.md`, `FIREWORKS_LIBRARY_GUIDE.md`, `CLOUD_UPGRADE.md`, `upgrade_swarm.md`, `shader-upgrade-round-2026-05.md`, `claude_opus_tier1_integration_prompt.md`, `scripts/scan-shaders-naga.py`, `scripts/run-upgrade-swarm.js`, and the three `public/shaders/_template_*.wgsl`.
- **CI gate** — `npm run verify:uniforms` fails on offset drift (`UniformBuffer.ts` / `types.ts`), setter reordering, C++ comment drift, any tracked brief claiming `config.y` is delta time / click count / audio, and `BINDING_CONTRACT.md` dropping a field. `scripts/test_verify_uniforms_layout.js` mutates throwaway trees to prove each failure fires.
- **Also** — jest contract test, `static_assert(sizeof(Uniforms) == 848)` in `renderer.h`, `scripts/audit_config_y_misuse.py` (report-only: **118 suspect reads in 92 shaders**, triage list in `reports/config_y_misuse.md`), `scripts/AUTHORING.md` section.

## 2. Format tiers

**Blocked, stated plainly:** this environment has no WebGPU adapter, so **no tier numbers were measured**. `reports/format-tier-bench-<date>.md` cannot be produced here, and the go/no-go on balanced-as-iGPU-default is not answered. Everything needed to produce it on a real machine is in this PR.

- **`tests/fixtures/formatTierMatrix.ts`** — five workload shapes: simple generative, feedback fluid, `ripple-tank` Tier C graph, 3-slot chain, history-ring temporal.
- **`tests/format-tier-bench.spec.ts`** — sweeps ultra/balanced/battery, recording `colorFormat`, estimated texture MiB, FPS, GPU ms, `hasRealGpuTimings`, slot/pass caps, and GraphRunner pass-cap + format-rewrite warnings. Writes `reports/format-tier-bench-<date>.md` + JSON. With no adapter it writes a stub marked `GPU observed: no` and skips, so it is safe in CI and its output can never be mistaken for evidence.
- **`runBenchmark()`** now reports `requestedColorFormat`, `fp32Pinned`/`fp32PinnedBy`, `maxPassesPerFrame`, internal dims, scale, `timingSource`, `hasRealGpuTimings`.
- **`.github/workflows/gpu-required.yml`** — `workflow_dispatch` GPU_REQUIRED template for a self-hosted GPU runner (suite + runner label + strict inputs, uploads reports).
- **`reports/format-tier-bench-TEMPLATE.md`** — hardware blocks (discrete / integrated / mobile), sim correctness spot-check, thermal/sustained-load section, go/no-go verdict.

### Hardening (behavior changes worth a close look)

- **FP32 guard is now a pin, not a tier bump.** Loading a `requiresRgba32Float` shader used to force the *whole* quality mode to ultra (scale 1.0, 3 slots) behind the user's back. It now holds only the storage format at `rgba32float` and leaves scale/slot/pass caps on the user's tier — and the pin is re-applied on every tier change, closing the real silent-FP16 path: switching to balanced *after* loading a sim previously demoted it with no warning. `releaseFp32Requirement(id)` drops the pin.
- **Fail-soft rewrite.** `rewriteWgslStorageFormatsChecked()` reports storage declarations the rewrite could not reach (odd spelling, `read_write`, untiered format) instead of surfacing as an opaque pipeline-creation failure; misses are logged and exposed via `getFormatRewriteWarnings()`.
- **Panel** shows tier, `colorFormat`, pass cap, and a ⚠ FP32-pinned badge when the tier wanted FP16.
- **`docs/FORMAT_TIERS.md`** — pin semantics, fail-soft contract, bench procedure, and the `compat` rgba8unorm Phase-2 design (design only: clamping breaks HDR/negative intermediates silently, needs per-shader opt-in; documented trigger to revisit).

## Checklist

- [ ] `npm test -- --watchAll=false --ci` passes locally — **not run**: `node_modules` cannot be installed in this environment (no `typescript`; `react-scripts test` won't start). New pure-logic paths (`resolveFp32Pin`, the rewrite checker, the report renderer) were executed directly under `node --experimental-strip-types` and behave as asserted; `npm run verify:uniforms` and its self-test pass. Jest and `tsc` run for the first time in CI.
- [x] If **C++ or `wasm_renderer/bridge/`** changed: `renderer.h` gained a comment + `static_assert` on the existing 848-byte struct only — no behavior change, so committed `public/wasm/` artifacts stay valid.
- [x] If **device limits / bind group** changed: not changed. `npm run verify:uniforms` runs alongside `verify:device-policy`.
- [x] If **WGSL shaders** changed: only comment lines in the three `_template_*.wgsl`. `wgsl_precommit_gate.py --files …` run; templates are skipped by the gate by design (naga unavailable here, deferred to CI).

## WASM / build notes

No renderer behavior changed on the C++ side; the `static_assert` will fail the WASM build if `Uniforms` ever drifts from the contract. The FP32 pin is TypeScript-side (`RendererManager`); the C++ tier mapping in `performance_policy.h` is untouched.