### PR TITLE
Fix npm ERESOLVE: add legacy-peer-deps for TypeScript 5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# react-scripts@5.0.1 declares peerOptional typescript@^3 || ^4 only.
+# The project intentionally uses TypeScript 5.x (see CI "Verify TypeScript 5 compatibility").
+legacy-peer-deps=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`npm install` and `npm ci` fail on fresh clones with:

```
ERESOLVE could not resolve
peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
Found: typescript@5.4.5
```

The project intentionally uses TypeScript 5.4.5 (CI already runs a "Verify TypeScript 5 compatibility" step), but `react-scripts@5.0.1` only declares support for TypeScript 3–4 in its peer dependencies.

## Solution

Add a root `.npmrc` with `legacy-peer-deps=true`. This is the standard workaround for CRA + TypeScript 5 and matches the fallback already used in `scripts/jules-setup.sh`.

## Verification

- `npm ci` completes successfully with TypeScript 5.4.5 installed
- No changes to application code or dependency versions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfa33dcb-59c6-47af-9cf6-c0b3bcd44744?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfa33dcb-59c6-47af-9cf6-c0b3bcd44744&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to support installations with legacy peer-dependency resolution.
  * Documented the TypeScript 5 compatibility exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->