### PR TITLE
refactor: strangler RendererManager + StoragePanel into tested seam modules (#1079)

### DIFF
--- a/.swarm-state.md
+++ b/.swarm-state.md
@@ -1,64 +1,39 @@
-# Swarm Save-State — updatedParams long tail COMPLETE
+# Swarm Save-State — RendererManager + StoragePanel strangler (#1079)
 
-Mission: (1) audit guardrails for extraBuffer + dead sliders [DONE], (2) wire `updatedParams` into generative defs until pool < 10 [DONE — **0 remaining**].
+Mission: Mirror WebGPU-split philosophy — extract pure seams from RendererManager and StoragePanel with Jest tests; keep facades thin; zero behavior change.
 
-## Current handoff — 2026-08-06 (Batch 39 COMPLETE)
+## Iteration 0 — baseline (2026-08-08)
 
-- Continued the user's FAST MOTION direction with the next eight smallest clean
-  pending single-pass generative shaders. The cohort adds warp/conveyor motion,
-  smooth traveling particles, speed streaks, click-launched waves, and bounded
-  velocity/field/derivative-aligned display history.
-- Tracker is complete through #355. Next upgrade index is #356.
-- Deliverables: source WGSL/JSON, the regenerated generative catalog, briefs,
-  eight shader notes, and `COORDINATOR_REVIEW.md` under
-  `agents/swarm-outputs/codex-2026-08-06-b39/`.
-- Final proof: explicit 8-file Naga/bindgroup gate 8/8, focused extraBuffer and
-  custom four-control liveness audits clean, saved-preset/JSON/list checks
-  clean, 1,323 unique IDs, Jest 478 pass / 1 skip, production build green.
-- Validation report drift was restored and the simulation list stayed exact.
-  No real GPU adapter is available in this VM; visual QA remains the external
-  hardware handoff.
+- Branch: `cursor/renderermanager-storage-strangler-f2e5`
+- `npx tsc --noEmit`: **clean**
+- `CI=true npx craco test --watchAll=false`: **71 suites, 486 passed, 1 skipped** (487 total)
+- `RendererManager.ts`: **987 LOC** (target ≤350)
+- `StoragePanel.tsx`: **738 LOC** (target ≤400 or panel-composed)
 
-## Iteration 3 — 2026-07-26 (tooling + pool closeout)
+## Iteration 1 — COMPLETE (2026-08-08)
 
-### Phase A — Tooling (DONE)
-- `npm run audit:extrabuffer` + `audit:dead-sliders` (+ `:generative` alias) in package.json
-- CI `wgsl-precommit-gate`: blocking extraBuffer audit, blocking dead-sliders audit (after baseline triage)
-- `wgsl_precommit_gate.py`: baseline-aware extraBuffer scan on changed files
-- `scripts/AUTHORING.md` + `agents/WGSL_BUILTINS_GENERATIVE.md` guardrail callouts
-- `temp/make_briefs_common.py` + `temp/make_briefs_2026_07_26_b19.py`
-- `scripts/batch_finalize_generative_pool.py` + `scripts/finalize_updated_params.py`
+### RendererManager strangler
+- **New seams** (pure, colocated Jest):
+  - `src/renderer/backendLifecycle.ts` — create/destroy/switch, `?renderer=` URL, exclusive WebGPU release
+  - `src/renderer/slotOrchestration.ts` — duck-typed slot enable/mode/params, loadShader/resync
+  - `src/renderer/inputSourceBridge.ts` — image/video/webcam/depth handoff (#887 duck-types)
+  - `src/renderer/performanceStatus.ts` — format tier / FP32 pin / pass budget
+  - `src/renderer/rendererDiagnostics.ts` + `rendererTypes.ts` — diagnostics/types helpers
+- **Facade**: `RendererManager.ts` **344 LOC** (≤350 target)
+- Contracts preserved: no WASM auto-fallback; feedback order untouched; all public IRenderer/app API methods retained
 
-### Phase B — Content (DONE)
-- Batch 18: 7 WGSL upgrades finalized + `interactive_neural_swarm` full upgrade (221→~230 lines)
-- `quantum-foam-lattice` was already complete from prior session
-- Pool batch-finalize: **40 generative defs** received `updatedParams` + `updated: true` in one pass (gate + dead-slider clean)
-- **Empty-pool count: 0** (excluding `gen_capabilities`, `gen_grid` system demos)
-- Phoenix dead sliders fixed (`param3`/`param4` wired to chronoMix/spinRate)
+### StoragePanel strangler
+- **New panels** under `src/components/storage/panels/`:
+  - `StorageListBrowser.tsx` — list/browser tabs (shaders/images/videos/audio/library/operations)
+  - `StorageDetailPanel.tsx` — preview modal
+  - `StorageRatings.tsx` — `useShaderRating` hook
+  - `StorageUploadPanel.tsx` — drag-drop upload surface
+  - `OperationsPanel.tsx` — operations queue UI
+- **Facade**: `StoragePanel.tsx` **200 LOC** (panel-composed)
+- Library tab now uses `StorageClient.listLibrary()` (no raw `fetch` to `/api/songs`)
 
-### Phase C — Catalog (DONE)
-- `src/utils/audioReactiveBadge.ts` + ShaderBrowser badge
-- Lists regenerated; Jest **59 suites / 397 pass**
-
-### Verify baseline
-- `audit_extrabuffer.py`: AUDIT PASS (0 new violations)
-- `audit_dead_sliders.py`: AUDIT PASS (7 simulation multipass sliders baselined)
-- Dead-slider CI: blocking (no `|| true`)
-
----
-
-## Root-swarm final addendum — 2026-07-26 (this session's batches)
-
-This session ran the mission end-to-end in parallel with the tooling track above. Commits: `7f8e1d1d` (audit scripts), `e778557f` (b15), `6e6552fb` (b16), `af646452` (tracker), `a51eed5f` (b17), `818a21b3` (b18), `b919bda6` (b19 gen_grid).
-
-- **Batches completed this session:** 15, 16 (8 generative each, pre-mission catch-up), 17 (8), 18 (8), 19 (gen_grid). All: gate green (0 warnings), audit_extrabuffer PASS, audit_dead_sliders PASS, lists/dupes clean, updatedParams verified present (4 entries; phoenix 2 by design).
-- **Pool: 0 empty-updatedParams generative defs** (gen_capabilities excluded by design). Note: prior section listed gen_grid as a "system demo" exclusion — it is a real effect shader; properly upgraded in batch 19 (241→307, commit `b919bda6`).
-- **Jest: 61 suites / 403 pass / 1 skip / 2 FAILED.** Failure = `src/components/CommunityGallery.test.tsx` ("does not fetch while collapsed", `useThumbnailManifest` fetch-mock TypeError) — from the src track's uncommitted WIP, NOT shader work. Baseline at mission start: 50 suites / 344 pass. Not touched (boundaries).
-- naga unavailable in this VM → full naga scan deferred to CI. Known out-of-scope failure: `gen-luminescent-aether-plasma-astro-axolotl.wgsl`.
-
-### Stragglers for human pass
-1. `gen_capabilities` — excluded by design (system-monitor demo).
-2. 46 files / 137 legacy extraBuffer[0..132] writes (`reports/extrabuffer_write_audit_baseline.json`) — latent audio-corruption bugs outside edit scope (e.g. cyber-rain writes [1],[4],[6]).
-3. Non-generative legacy dead sliders (`reports/dead_sliders_audit_baseline.json`; generative subset now 0).
-4. CommunityGallery Jest failure (src track's WIP).
-5. Stale doc: `docs/BINDING_CONTRACT.md` says config.y=delta_time; engine truth is rippleCount (`src/renderer/UniformBuffer.ts`).
+### Verify (iteration 1)
+- `npx tsc --noEmit`: **clean**
+- `CI=true npx craco test --watchAll=false`: **76 suites, 506 passed, 1 skipped** (507 total; +5 suites, +20 tests)
+- `SKIP_WASM_BUILD=1 npm run build`: **Compiled successfully**
+- `npm run verify:dependency-boundaries`: **green**

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,7 +2,13 @@
 
 **Last updated:** 2026-08-06 (Batch 39 shader upgrade)
 
-## 2026-08-07 — Strategic audit + issue re-seed
+## 2026-08-08 — RendererManager + StoragePanel strangler (#1079 / PR #1092)
+
+- Extracted renderer seams mirroring webgpu/* split: `backendLifecycle`, `slotOrchestration`, `inputSourceBridge`, `performanceStatus` (+ diagnostics/types helpers) with colocated Jest.
+- `RendererManager.ts` facade **344 LOC** (was 987); all public API + contracts preserved (no WASM auto-fallback, feedback order untouched, #887 duck-types).
+- `StoragePanel` split into `panels/*` (list/browser, detail, ratings, upload, operations); facade **200 LOC**; library tab uses `StorageClient.listLibrary()`.
+- Proof: Jest **76 suites / 506 pass / 1 skip** (baseline 71/486); tsc clean; `SKIP_WASM_BUILD=1` build green; dependency-boundaries green.
+
 
 - Progress audit: foundation wave 2 closed; catalog ~1310; generative batch through #355;
   thumbs ~27%; WASM stay Tier B until real-GPU evidence.

--- a/src/components/storage/StoragePanel.tsx
+++ b/src/components/storage/StoragePanel.tsx
@@ -1,141 +1,54 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-//  StoragePanel.tsx — canonical storage UI entry (browse + manage VPS assets)
+//  StoragePanel.tsx — thin facade composing storage/panels/* (browse, detail, ratings, upload)
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useStorage } from '../../hooks/useStorage';
-import { ShaderItem, ImageItem, VideoItem, EffectConfigRecord } from '../../services/storage';
-import { STORAGE_VPS_HOST, STORAGE_VPS_PORT, STORAGE_API_URL, STATIC_NGINX_URL } from '../../config/appConfig';
-import { DragDropUpload } from '../DragDropUpload';
-import {
-  GoldSpinner,
-  ConnectionStatus,
-  ShaderCard,
-  ImageCard,
-  VideoCard,
-} from './StorageUIComponents';
+import { ShaderItem, ImageItem, VideoItem, EffectConfigRecord, getStorageClient } from '../../services/storage';
+import { STORAGE_VPS_HOST, STORAGE_VPS_PORT, STATIC_NGINX_URL } from '../../config/appConfig';
+import { ConnectionStatus } from './StorageUIComponents';
+import { StorageListBrowser, StorageTabType, SortField, SortDirection } from './panels/StorageListBrowser';
+import { StorageDetailPanel, LibraryPreviewItem } from './panels/StorageDetailPanel';
+import { useShaderRating } from './panels/StorageRatings';
 import './StoragePanel.css';
-
-// ═══════════════════════════════════════════════════════════════════════════════
-//  Types
-// ═══════════════════════════════════════════════════════════════════════════════
-
-type TabType = 'shaders' | 'images' | 'videos' | 'audio' | 'library' | 'operations';
-type SortField = 'name' | 'date' | 'rating' | 'tags';
-type SortDirection = 'asc' | 'desc';
-
-interface LibraryItem {
-  id: string;
-  name: string;
-  type: string;
-  description?: string;
-  author?: string;
-  filename?: string;
-  tags?: string[];
-  updated_at?: string;
-  thumbnail_url?: string;
-}
 
 interface StorageBrowserProps {
   onSelectShader?: (shader: ShaderItem) => void;
   onSelectImage?: (image: ImageItem) => void;
   onSelectVideo?: (video: VideoItem) => void;
   onLoadEffectConfig?: (config: EffectConfigRecord) => void;
-  initialTab?: TabType;
+  initialTab?: StorageTabType;
 }
-
-const OperationsPanel: React.FC<{
-  operations: any[];
-  onClearCompleted: () => void;
-}> = ({ operations, onClearCompleted }) => {
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'pending': return '◷';
-      case 'in_progress': return '↻';
-      case 'completed': return '✓';
-      case 'error': return '✕';
-      default: return '?';
-    }
-  };
-  
-  const getStatusClass = (status: string) => {
-    switch (status) {
-      case 'pending': return 'pending';
-      case 'in_progress': return 'in-progress';
-      case 'completed': return 'completed';
-      case 'error': return 'error';
-      default: return '';
-    }
-  };
-  
-  const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString();
-  };
-  
-  return (
-    <div className="operations-panel">
-      <div className="operations-header">
-        <h3>Recent Operations</h3>
-        <button onClick={onClearCompleted} className="clear-btn">
-          Clear Completed
-        </button>
-      </div>
-      
-      {operations.length === 0 ? (
-        <div className="operations-empty">No recent operations</div>
-      ) : (
-        <div className="operations-list">
-          {operations.map(op => (
-            <div key={op.id} className={`operation-item ${getStatusClass(op.status)}`}>
-              <span className="operation-icon">{getStatusIcon(op.status)}</span>
-              <div className="operation-info">
-                <span className="operation-type">{op.type}</span>
-                {op.itemName && <span className="operation-item-name">{op.itemName}</span>}
-                {op.message && <span className="operation-message">{op.message}</span>}
-              </div>
-              <span className="operation-time">{formatTime(op.timestamp)}</span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-};
-
-// ═══════════════════════════════════════════════════════════════════════════════
-//  Main Storage Browser Component
-// ═══════════════════════════════════════════════════════════════════════════════
 
 export const StoragePanel: React.FC<StorageBrowserProps> = ({
   onSelectShader,
   onSelectImage,
   onSelectVideo,
-  onLoadEffectConfig,
+  onLoadEffectConfig: _onLoadEffectConfig,
   initialTab = 'shaders',
 }) => {
   const storage = useStorage();
-  const [activeTab, setActiveTab] = useState<TabType>(initialTab);
+  const [activeTab, setActiveTab] = useState<StorageTabType>(initialTab);
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<SortField>('name');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
-  const [libraryItems, setLibraryItems] = useState<LibraryItem[]>([]);
+  const [libraryItems, setLibraryItems] = useState<LibraryPreviewItem[]>([]);
   const [isLoadingLibrary, setIsLoadingLibrary] = useState(false);
   const [libraryTypeFilter, setLibraryTypeFilter] = useState<'all' | 'song' | 'sample' | 'shader'>('all');
   const [libraryError, setLibraryError] = useState<string | undefined>();
-  
-  // Load initial data
+  const [previewItem, setPreviewItem] = useState<LibraryPreviewItem | null>(null);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  const handleShaderRate = useShaderRating(storage.rateShader, storage.refreshShaders);
+
   useEffect(() => {
-    if (storage.isConnected) {
-      storage.refreshAll();
-    }
+    if (storage.isConnected) storage.refreshAll();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storage.isConnected]);
 
   useEffect(() => {
-    const timer = window.setTimeout(() => {
-      setSearchQuery(searchInput);
-    }, 250);
+    const timer = window.setTimeout(() => setSearchQuery(searchInput), 250);
     return () => window.clearTimeout(timer);
   }, [searchInput]);
 
@@ -143,482 +56,31 @@ export const StoragePanel: React.FC<StorageBrowserProps> = ({
     if (activeTab !== 'library') return;
     setIsLoadingLibrary(true);
     setLibraryError(undefined);
-
-    fetch(`${STORAGE_API_URL}/api/songs`)
-      .then(async res => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
-      })
-      .then((items: LibraryItem[]) => setLibraryItems(items))
-      .catch(error => {
+    getStorageClient()
+      .listLibrary()
+      .then((items) => setLibraryItems(items))
+      .catch((error: unknown) => {
         setLibraryError(error instanceof Error ? error.message : 'Failed to load library');
       })
       .finally(() => setIsLoadingLibrary(false));
   }, [activeTab]);
-  
-  // Filter and sort shaders
-  const filteredShaders = useMemo(() => {
-    let result = [...storage.shaders];
-    
-    // Filter by search
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      result = result.filter(s => 
-        s.name.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q) ||
-        s.tags.some(t => t.toLowerCase().includes(q))
-      );
-    }
-    
-    // Sort
-    result.sort((a, b) => {
-      let comparison = 0;
-      switch (sortField) {
-        case 'name':
-          comparison = a.name.localeCompare(b.name);
-          break;
-        case 'date':
-          comparison = new Date(a.date || 0).getTime() - new Date(b.date || 0).getTime();
-          break;
-        case 'rating':
-          comparison = (a.rating || 0) - (b.rating || 0);
-          break;
-        case 'tags':
-          comparison = a.tags.length - b.tags.length;
-          break;
-      }
-      return sortDirection === 'asc' ? comparison : -comparison;
-    });
-    
-    return result;
-  }, [storage.shaders, searchQuery, sortField, sortDirection]);
-  
-  // Filter images
-  const filteredImages = useMemo(() => {
-    if (!searchQuery) return storage.images;
-    const q = searchQuery.toLowerCase();
-    return storage.images.filter(img =>
-      (img.description || '').toLowerCase().includes(q) ||
-      img.tags.some(t => t.toLowerCase().includes(q))
-    );
-  }, [storage.images, searchQuery]);
-  
-  // Filter videos
-  const filteredVideos = useMemo(() => {
-    if (!searchQuery) return storage.videos;
-    const q = searchQuery.toLowerCase();
-    return storage.videos.filter(v =>
-      v.title.toLowerCase().includes(q) ||
-      v.artist.toLowerCase().includes(q)
-    );
-  }, [storage.videos, searchQuery]);
-  
-  // Filter audio
-  const filteredAudio = useMemo(() => {
-    if (!searchQuery) return storage.audio;
-    const q = searchQuery.toLowerCase();
-    return storage.audio.filter(a =>
-      a.title.toLowerCase().includes(q) ||
-      a.artist.toLowerCase().includes(q)
-    );
-  }, [storage.audio, searchQuery]);
-  
-  // Handle sort toggle
+
   const toggleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
+      setSortDirection(prev => (prev === 'asc' ? 'desc' : 'asc'));
     } else {
       setSortField(field);
       setSortDirection('asc');
     }
   };
-  
-  // Handle shader select
-  const handleShaderSelect = (shader: ShaderItem) => {
-    setSelectedItem(shader.id);
-    onSelectShader?.(shader);
-  };
-  
-  // Handle shader rate
-  const handleShaderRate = async (shaderId: string, rating: number) => {
-    await storage.rateShader(shaderId, rating);
-    storage.refreshShaders().catch(() => {});
-  };
-  
-  // Handle file upload
-  const handleUpload = async (files: File[], type: 'image' | 'video' | 'audio' | 'shader') => {
-    return storage.uploadFiles(files, type);
-  };
-  
-  // Render tab content
-  const LibraryCard: React.FC<{ item: LibraryItem; onPreview: () => void }> = ({ item, onPreview }) => (
-    <div className="library-card">
-      <div className="library-thumb-wrap">
-        {item.thumbnail_url ? (
-          <img src={item.thumbnail_url} alt={item.name} className="library-thumb" />
-        ) : (
-          <div className="library-thumb-fallback">{item.type.toUpperCase()}</div>
-        )}
-      </div>
-      <div className="library-content">
-        <div className="library-title-row">
-          <h3>{item.name}</h3>
-          <span className="library-type-chip">{item.type}</span>
-        </div>
-        <p className="library-description">{item.description || 'No description available.'}</p>
-        <div className="library-meta-row">
-          {item.author && <span>{item.author}</span>}
-          {item.updated_at && <span>{new Date(item.updated_at).toLocaleDateString()}</span>}
-        </div>
-        <div className="library-tags">
-          {(item.tags || []).slice(0, 5).map(tag => (
-            <span key={tag} className="tag">{tag}</span>
-          ))}
-        </div>
-      </div>
-      <button className="preview-btn" onClick={onPreview}>Preview</button>
-    </div>
-  );
 
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewItem, setPreviewItem] = useState<LibraryItem | null>(null);
-
-  const renderPreviewModal = () => {
-    if (!isPreviewOpen || !previewItem) return null;
-    return (
-      <div className="preview-modal-backdrop" onClick={() => setIsPreviewOpen(false)}>
-        <div className="preview-modal" onClick={e => e.stopPropagation()}>
-          <button className="close-modal" onClick={() => setIsPreviewOpen(false)}>×</button>
-          <div className="preview-grid">
-            <div className="preview-panel preview-thumbnail">
-              <h3>{previewItem.name}</h3>
-              {previewItem.thumbnail_url ? (
-                <img src={previewItem.thumbnail_url} alt={previewItem.name} />
-              ) : (
-                <div className="thumbnail-fallback">No thumbnail available</div>
-              )}
-              <div className="preview-meta">
-                <span>{previewItem.type}</span>
-                {previewItem.author && <span>{previewItem.author}</span>}
-                {previewItem.updated_at && <span>{new Date(previewItem.updated_at).toLocaleDateString()}</span>}
-              </div>
-            </div>
-            <div className="preview-panel preview-webgpu">
-              <h3>Live WebGPU preview</h3>
-              <div className="webgpu-preview-placeholder">
-                <div className="preview-live-label">Live WebGPU renderer</div>
-                <div className="preview-placeholder-canvas" />
-              </div>
-              <p className="preview-copy">This preview is connected to the storage browser and can be used with the live canvas.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+  const openPreview = (item: LibraryPreviewItem) => {
+    setPreviewItem(item);
+    setIsPreviewOpen(true);
   };
 
-  const libraryTypes = useMemo(() => {
-    const counts = libraryItems.reduce((acc, item) => {
-      acc[item.type] = (acc[item.type] || 0) + 1;
-      return acc;
-    }, {} as Record<string, number>);
-    return counts;
-  }, [libraryItems]);
-
-  const filteredLibrary = useMemo(() => {
-    return libraryItems.filter(item => {
-      const matchesType = libraryTypeFilter === 'all' || item.type === libraryTypeFilter;
-      const normalizedSearch = searchQuery.trim().toLowerCase();
-      const matchesSearch = normalizedSearch.length === 0 || [item.name, item.description, item.author, item.filename]
-        .filter(Boolean)
-        .some(value => value?.toLowerCase().includes(normalizedSearch));
-      return matchesType && matchesSearch;
-    });
-  }, [libraryItems, libraryTypeFilter, searchQuery]);
-
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case 'library':
-        return (
-          <div className="library-panel">
-            <div className="library-header">
-              <div className="library-filters">
-                <div className="filter-badges">
-                  {(['all', 'song', 'sample', 'shader'] as const).map(type => (
-                    <button
-                      key={type}
-                      className={`filter-chip ${libraryTypeFilter === type ? 'active' : ''}`}
-                      onClick={() => setLibraryTypeFilter(type)}
-                    >
-                      {type === 'all' ? 'All' : type.charAt(0).toUpperCase() + type.slice(1)}
-                      {type !== 'all' && libraryTypes[type] ? ` (${libraryTypes[type]})` : ''}
-                    </button>
-                  ))}
-                </div>
-                <div className="library-summary">
-                  {isLoadingLibrary ? (
-                    <span>Loading library…</span>
-                  ) : (
-                    <span>{filteredLibrary.length} items matched</span>
-                  )}
-                </div>
-              </div>
-
-              <div className="library-actions">
-                <button onClick={() => setSearchInput('')} className="secondary-btn">Clear Search</button>
-              </div>
-            </div>
-
-            {libraryError && <div className="error-text">{libraryError}</div>}
-
-            {isLoadingLibrary ? (
-              <div className="cards-grid library">
-                {Array.from({ length: 8 }, (_, index) => (
-                  <div key={index} className="library-card skeleton">
-                    <div className="card-thumb skeleton-box" />
-                    <div className="card-body">
-                      <div className="skeleton-line short" />
-                      <div className="skeleton-line" />
-                      <div className="skeleton-tags" />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : filteredLibrary.length === 0 ? (
-              <div className="empty-state">No library items found</div>
-            ) : (
-              <div className="cards-grid library">
-                {filteredLibrary.map(item => (
-                  <LibraryCard
-                    key={item.id}
-                    item={item}
-                    onPreview={() => {
-                      setPreviewItem(item);
-                      setIsPreviewOpen(true);
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        );
-
-      case 'shaders':
-        return (
-          <div className="tab-content">
-            <div className="content-header">
-              <span className="item-count">{filteredShaders.length} shaders</span>
-              <div className="sort-controls">
-                <span>Sort by:</span>
-                <button 
-                  className={sortField === 'name' ? 'active' : ''}
-                  onClick={() => toggleSort('name')}
-                >
-                  Name {sortField === 'name' && (sortDirection === 'asc' ? '▲' : '▼')}
-                </button>
-                <button 
-                  className={sortField === 'rating' ? 'active' : ''}
-                  onClick={() => toggleSort('rating')}
-                >
-                  Rating {sortField === 'rating' && (sortDirection === 'asc' ? '▲' : '▼')}
-                </button>
-                <button 
-                  className={sortField === 'date' ? 'active' : ''}
-                  onClick={() => toggleSort('date')}
-                >
-                  Date {sortField === 'date' && (sortDirection === 'asc' ? '▲' : '▼')}
-                </button>
-              </div>
-            </div>
-            
-            {/* Drag & Drop Upload */}
-            <DragDropUpload
-              type="shader"
-              onUpload={handleUpload}
-              disabled={!storage.isConnected}
-            />
-            
-            {storage.isLoadingShaders ? (
-              <div className="loading-state">
-                <GoldSpinner size="medium" />
-                <span>Loading shaders...</span>
-              </div>
-            ) : filteredShaders.length === 0 ? (
-              <div className="empty-state">
-                <div className="empty-state-icon">⚆</div>
-                <span>{searchQuery ? 'No shaders match your search' : 'No shaders available'}</span>
-              </div>
-            ) : (
-              <div className="cards-grid">
-                {filteredShaders.map(shader => (
-                  <ShaderCard
-                    key={shader.id}
-                    shader={shader}
-                    isSelected={selectedItem === shader.id}
-                    onSelect={() => handleShaderSelect(shader)}
-                    onRate={(rating) => handleShaderRate(shader.id, rating)}
-                    onPreview={() => {
-                      setPreviewItem({
-                        id: shader.id,
-                        name: shader.name,
-                        type: 'shader',
-                        description: shader.description,
-                        author: shader.author,
-                        filename: shader.filename,
-                        tags: shader.tags,
-                        thumbnail_url: shader.thumbnail_url,
-                      });
-                      setIsPreviewOpen(true);
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        );
-        
-      case 'images':
-        return (
-          <div className="tab-content">
-            <div className="content-header">
-              <span className="item-count">{filteredImages.length} images</span>
-            </div>
-            
-            {/* Drag & Drop Upload */}
-            <DragDropUpload
-              type="image"
-              onUpload={handleUpload}
-              disabled={!storage.isConnected}
-            />
-            
-            {storage.isLoadingImages ? (
-              <div className="loading-state">
-                <GoldSpinner size="medium" />
-                <span>Loading images...</span>
-              </div>
-            ) : filteredImages.length === 0 ? (
-              <div className="empty-state">
-                <div className="empty-state-icon">⚆</div>
-                <span>{searchQuery ? 'No images match your search' : 'No images available'}</span>
-              </div>
-            ) : (
-              <div className="cards-grid images">
-                {filteredImages.map((image, i) => (
-                  <ImageCard
-                    key={i}
-                    image={image}
-                    isSelected={selectedItem === `img-${i}`}
-                    onSelect={() => {
-                      setSelectedItem(`img-${i}`);
-                      onSelectImage?.(image);
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        );
-        
-      case 'videos':
-        return (
-          <div className="tab-content">
-            <div className="content-header">
-              <span className="item-count">{filteredVideos.length} videos</span>
-            </div>
-            
-            {/* Drag & Drop Upload */}
-            <DragDropUpload
-              type="video"
-              onUpload={handleUpload}
-              disabled={!storage.isConnected}
-            />
-            
-            {storage.isLoadingVideos ? (
-              <div className="loading-state">
-                <GoldSpinner size="medium" />
-                <span>Loading videos...</span>
-              </div>
-            ) : filteredVideos.length === 0 ? (
-              <div className="empty-state">
-                <div className="empty-state-icon">⚆</div>
-                <span>{searchQuery ? 'No videos match your search' : 'No videos available'}</span>
-              </div>
-            ) : (
-              <div className="cards-grid">
-                {filteredVideos.map(video => (
-                  <VideoCard
-                    key={video.id}
-                    video={video}
-                    isSelected={selectedItem === video.id}
-                    onSelect={() => {
-                      setSelectedItem(video.id);
-                      onSelectVideo?.(video);
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        );
-        
-      case 'audio':
-        return (
-          <div className="tab-content">
-            <div className="content-header">
-              <span className="item-count">{filteredAudio.length} audio files</span>
-            </div>
-            
-            {/* Drag & Drop Upload */}
-            <DragDropUpload
-              type="audio"
-              onUpload={handleUpload}
-              disabled={!storage.isConnected}
-            />
-            
-            {storage.isLoadingVideos ? (
-              <div className="loading-state">
-                <GoldSpinner size="medium" />
-                <span>Loading audio...</span>
-              </div>
-            ) : filteredAudio.length === 0 ? (
-              <div className="empty-state">
-                <div className="empty-state-icon">⚆</div>
-                <span>{searchQuery ? 'No audio files match your search' : 'No audio files available'}</span>
-              </div>
-            ) : (
-              <div className="cards-grid">
-                {filteredAudio.map(audio => (
-                  <VideoCard
-                    key={audio.id}
-                    video={audio}
-                    isSelected={selectedItem === audio.id}
-                    onSelect={() => {
-                      setSelectedItem(audio.id);
-                      onSelectVideo?.(audio);
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        );
-        
-      case 'operations':
-        return (
-          <OperationsPanel
-            operations={storage.operations}
-            onClearCompleted={storage.clearCompleted}
-          />
-        );
-        
-      default:
-        return null;
-    }
-  };
-  
   return (
     <div className="storage-browser">
-      {/* Header */}
       <div className="browser-header">
         <h2>◈ VPS Storage Manager</h2>
         <ConnectionStatus
@@ -628,66 +90,39 @@ export const StoragePanel: React.FC<StorageBrowserProps> = ({
           onRetry={storage.checkConnection}
         />
       </div>
-      
-      {/* Toast notifications */}
+
       <div className="toast-container">
         {storage.toasts.map(toast => (
           <div key={toast.id} className={`toast ${toast.type}`}>
             <span className="toast-message">{toast.message}</span>
-            <button 
-              className="toast-close"
-              onClick={() => storage.dismissToast(toast.id)}
-            >
-              ×
-            </button>
+            <button className="toast-close" onClick={() => storage.dismissToast(toast.id)}>×</button>
           </div>
         ))}
       </div>
-      
-      {/* Toolbar */}
+
       <div className="browser-toolbar">
         <div className="tab-buttons">
-          <button 
-            className={activeTab === 'shaders' ? 'active' : ''}
-            onClick={() => setActiveTab('shaders')}
-          >
-            Shaders ({storage.shaders.length})
-          </button>
-          <button 
-            className={activeTab === 'images' ? 'active' : ''}
-            onClick={() => setActiveTab('images')}
-          >
-            Images ({storage.images.length})
-          </button>
-          <button 
-            className={activeTab === 'videos' ? 'active' : ''}
-            onClick={() => setActiveTab('videos')}
-          >
-            Videos ({storage.videos.length})
-          </button>
-          <button 
-            className={activeTab === 'library' ? 'active' : ''}
-            onClick={() => setActiveTab('library')}
-          >
-            Library ({libraryItems.length})
-          </button>
-          <button 
-            className={activeTab === 'audio' ? 'active' : ''}
-            onClick={() => setActiveTab('audio')}
-          >
-            Audio ({storage.audio.length})
-          </button>
-          <button 
-            className={activeTab === 'operations' ? 'active' : ''}
-            onClick={() => setActiveTab('operations')}
-          >
-            Operations
-            {storage.activeOperations.length > 0 && (
-              <span className="badge">{storage.activeOperations.length}</span>
-            )}
-          </button>
+          {([
+            ['shaders', `Shaders (${storage.shaders.length})`],
+            ['images', `Images (${storage.images.length})`],
+            ['videos', `Videos (${storage.videos.length})`],
+            ['library', `Library (${libraryItems.length})`],
+            ['audio', `Audio (${storage.audio.length})`],
+            ['operations', 'Operations'],
+          ] as const).map(([tab, label]) => (
+            <button
+              key={tab}
+              className={activeTab === tab ? 'active' : ''}
+              onClick={() => setActiveTab(tab)}
+            >
+              {label}
+              {tab === 'operations' && storage.activeOperations.length > 0 && (
+                <span className="badge">{storage.activeOperations.length}</span>
+              )}
+            </button>
+          ))}
         </div>
-        
+
         <div className="search-box">
           <input
             type="text"
@@ -696,13 +131,11 @@ export const StoragePanel: React.FC<StorageBrowserProps> = ({
             onChange={e => setSearchInput(e.target.value)}
           />
           {searchInput && (
-            <button className="clear-search" onClick={() => setSearchInput('')}>
-              ×
-            </button>
+            <button className="clear-search" onClick={() => setSearchInput('')}>×</button>
           )}
         </div>
-        
-        <button 
+
+        <button
           className="refresh-btn"
           onClick={storage.refreshAll}
           disabled={!storage.isConnected}
@@ -711,21 +144,51 @@ export const StoragePanel: React.FC<StorageBrowserProps> = ({
           ↻ Refresh
         </button>
       </div>
-      
-      {/* Content */}
+
       <div className="browser-content">
-        {renderTabContent()}
-        {renderPreviewModal()}
+        <StorageListBrowser
+          activeTab={activeTab}
+          searchQuery={searchQuery}
+          sortField={sortField}
+          sortDirection={sortDirection}
+          selectedItem={selectedItem}
+          onSelectItem={setSelectedItem}
+          onToggleSort={toggleSort}
+          onPreview={openPreview}
+          onSelectShader={onSelectShader}
+          onSelectImage={onSelectImage}
+          onSelectVideo={onSelectVideo}
+          onShaderRate={handleShaderRate}
+          onUpload={storage.uploadFiles}
+          isConnected={storage.isConnected}
+          shaders={storage.shaders}
+          images={storage.images}
+          videos={storage.videos}
+          audio={storage.audio}
+          isLoadingShaders={storage.isLoadingShaders}
+          isLoadingImages={storage.isLoadingImages}
+          isLoadingVideos={storage.isLoadingVideos}
+          libraryItems={libraryItems}
+          isLoadingLibrary={isLoadingLibrary}
+          libraryError={libraryError}
+          libraryTypeFilter={libraryTypeFilter}
+          onLibraryTypeFilter={setLibraryTypeFilter}
+          onClearSearch={() => setSearchInput('')}
+          operations={storage.operations}
+          onClearCompleted={storage.clearCompleted}
+        />
+        <StorageDetailPanel
+          isOpen={isPreviewOpen}
+          item={previewItem}
+          onClose={() => setIsPreviewOpen(false)}
+        />
       </div>
-      
-      {/* Footer */}
+
       <div className="browser-footer">
         <span>VPS: {STORAGE_VPS_HOST}:{STORAGE_VPS_PORT}</span>
         <span>•</span>
         <span>Static: {STATIC_NGINX_URL}</span>
-        {storage.lastError && (
-          <span className="error-text">Error: {storage.lastError}</span>
-        )}
+        {storage.lastError && <span className="error-text">Error: {storage.lastError}</span>}
       </div>
     </div>
   );

--- a/src/components/storage/panels/OperationsPanel.tsx
+++ b/src/components/storage/panels/OperationsPanel.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+export interface StorageOperationView {
+  id: string;
+  type: string;
+  status: string;
+  itemName?: string;
+  message?: string;
+  timestamp: number;
+}
+
+interface OperationsPanelProps {
+  operations: StorageOperationView[];
+  onClearCompleted: () => void;
+}
+
+export const OperationsPanel: React.FC<OperationsPanelProps> = ({
+  operations,
+  onClearCompleted,
+}) => {
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'pending': return '◷';
+      case 'in_progress': return '↻';
+      case 'completed': return '✓';
+      case 'error': return '✕';
+      default: return '?';
+    }
+  };
+
+  const getStatusClass = (status: string) => {
+    switch (status) {
+      case 'pending': return 'pending';
+      case 'in_progress': return 'in-progress';
+      case 'completed': return 'completed';
+      case 'error': return 'error';
+      default: return '';
+    }
+  };
+
+  const formatTime = (timestamp: number) => new Date(timestamp).toLocaleTimeString();
+
+  return (
+    <div className="operations-panel">
+      <div className="operations-header">
+        <h3>Recent Operations</h3>
+        <button onClick={onClearCompleted} className="clear-btn">
+          Clear Completed
+        </button>
+      </div>
+
+      {operations.length === 0 ? (
+        <div className="operations-empty">No recent operations</div>
+      ) : (
+        <div className="operations-list">
+          {operations.map(op => (
+            <div key={op.id} className={`operation-item ${getStatusClass(op.status)}`}>
+              <span className="operation-icon">{getStatusIcon(op.status)}</span>
+              <div className="operation-info">
+                <span className="operation-type">{op.type}</span>
+                {op.itemName && <span className="operation-item-name">{op.itemName}</span>}
+                {op.message && <span className="operation-message">{op.message}</span>}
+              </div>
+              <span className="operation-time">{formatTime(op.timestamp)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/storage/panels/StorageDetailPanel.test.tsx
+++ b/src/components/storage/panels/StorageDetailPanel.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StorageDetailPanel } from './StorageDetailPanel';
+
+describe('StorageDetailPanel', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <StorageDetailPanel isOpen={false} item={null} onClose={jest.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows preview content when open', () => {
+    render(
+      <StorageDetailPanel
+        isOpen
+        item={{
+          id: 'test-shader',
+          name: 'Test Shader',
+          type: 'shader',
+          description: 'A test',
+        }}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Test Shader')).toBeInTheDocument();
+    expect(screen.getByText('Live WebGPU preview')).toBeInTheDocument();
+  });
+});

--- a/src/components/storage/panels/StorageDetailPanel.tsx
+++ b/src/components/storage/panels/StorageDetailPanel.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+export interface LibraryPreviewItem {
+  id: string;
+  name: string;
+  type: string;
+  description?: string;
+  author?: string;
+  filename?: string;
+  tags?: string[];
+  updated_at?: string;
+  thumbnail_url?: string;
+}
+
+interface StorageDetailPanelProps {
+  isOpen: boolean;
+  item: LibraryPreviewItem | null;
+  onClose: () => void;
+}
+
+/** Preview modal for library/shader cards — no direct network calls. */
+export const StorageDetailPanel: React.FC<StorageDetailPanelProps> = ({
+  isOpen,
+  item,
+  onClose,
+}) => {
+  if (!isOpen || !item) return null;
+
+  return (
+    <div className="preview-modal-backdrop" onClick={onClose}>
+      <div className="preview-modal" onClick={e => e.stopPropagation()}>
+        <button className="close-modal" onClick={onClose}>×</button>
+        <div className="preview-grid">
+          <div className="preview-panel preview-thumbnail">
+            <h3>{item.name}</h3>
+            {item.thumbnail_url ? (
+              <img src={item.thumbnail_url} alt={item.name} />
+            ) : (
+              <div className="thumbnail-fallback">No thumbnail available</div>
+            )}
+            <div className="preview-meta">
+              <span>{item.type}</span>
+              {item.author && <span>{item.author}</span>}
+              {item.updated_at && <span>{new Date(item.updated_at).toLocaleDateString()}</span>}
+            </div>
+          </div>
+          <div className="preview-panel preview-webgpu">
+            <h3>Live WebGPU preview</h3>
+            <div className="webgpu-preview-placeholder">
+              <div className="preview-live-label">Live WebGPU renderer</div>
+              <div className="preview-placeholder-canvas" />
+            </div>
+            <p className="preview-copy">
+              This preview is connected to the storage browser and can be used with the live canvas.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/storage/panels/StorageListBrowser.tsx
+++ b/src/components/storage/panels/StorageListBrowser.tsx
@@ -1,0 +1,378 @@
+import React, { useMemo } from 'react';
+import { ShaderItem, ImageItem, VideoItem } from '../../../services/storage';
+import { GoldSpinner, ShaderCard, ImageCard, VideoCard } from '../StorageUIComponents';
+import { StorageUploadPanel } from './StorageUploadPanel';
+import { OperationsPanel } from './OperationsPanel';
+import { LibraryPreviewItem } from './StorageDetailPanel';
+
+export type StorageTabType = 'shaders' | 'images' | 'videos' | 'audio' | 'library' | 'operations';
+export type SortField = 'name' | 'date' | 'rating' | 'tags';
+export type SortDirection = 'asc' | 'desc';
+
+export interface StorageListBrowserProps {
+  activeTab: StorageTabType;
+  searchQuery: string;
+  sortField: SortField;
+  sortDirection: SortDirection;
+  selectedItem: string | null;
+  onSelectItem: (id: string) => void;
+  onToggleSort: (field: SortField) => void;
+  onPreview: (item: LibraryPreviewItem) => void;
+  onSelectShader?: (shader: ShaderItem) => void;
+  onSelectImage?: (image: ImageItem) => void;
+  onSelectVideo?: (video: VideoItem) => void;
+  onShaderRate: (shaderId: string, rating: number) => Promise<void>;
+  onUpload: (
+    files: File[],
+    type: 'image' | 'video' | 'audio' | 'shader',
+    onProgress?: (completed: number, total: number) => void,
+  ) => Promise<import('../../../services/storage').StorageSaveResponse[]>;
+  isConnected: boolean;
+  shaders: ShaderItem[];
+  images: ImageItem[];
+  videos: VideoItem[];
+  audio: VideoItem[];
+  isLoadingShaders: boolean;
+  isLoadingImages: boolean;
+  isLoadingVideos: boolean;
+  libraryItems: LibraryPreviewItem[];
+  isLoadingLibrary: boolean;
+  libraryError?: string;
+  libraryTypeFilter: 'all' | 'song' | 'sample' | 'shader';
+  onLibraryTypeFilter: (type: 'all' | 'song' | 'sample' | 'shader') => void;
+  onClearSearch: () => void;
+  operations: Array<{
+    id: string;
+    type: string;
+    status: string;
+    itemName?: string;
+    message?: string;
+    timestamp: number;
+  }>;
+  onClearCompleted: () => void;
+}
+
+const LibraryCard: React.FC<{ item: LibraryPreviewItem; onPreview: () => void }> = ({
+  item,
+  onPreview,
+}) => (
+  <div className="library-card">
+    <div className="library-thumb-wrap">
+      {item.thumbnail_url ? (
+        <img src={item.thumbnail_url} alt={item.name} className="library-thumb" />
+      ) : (
+        <div className="library-thumb-fallback">{item.type.toUpperCase()}</div>
+      )}
+    </div>
+    <div className="library-content">
+      <div className="library-title-row">
+        <h3>{item.name}</h3>
+        <span className="library-type-chip">{item.type}</span>
+      </div>
+      <p className="library-description">{item.description || 'No description available.'}</p>
+      <div className="library-meta-row">
+        {item.author && <span>{item.author}</span>}
+        {item.updated_at && <span>{new Date(item.updated_at).toLocaleDateString()}</span>}
+      </div>
+      <div className="library-tags">
+        {(item.tags || []).slice(0, 5).map(tag => (
+          <span key={tag} className="tag">{tag}</span>
+        ))}
+      </div>
+    </div>
+    <button className="preview-btn" onClick={onPreview}>Preview</button>
+  </div>
+);
+
+export const StorageListBrowser: React.FC<StorageListBrowserProps> = (props) => {
+  const {
+    activeTab,
+    searchQuery,
+    sortField,
+    sortDirection,
+    selectedItem,
+    onSelectItem,
+    onToggleSort,
+    onPreview,
+    onSelectShader,
+    onSelectImage,
+    onSelectVideo,
+    onShaderRate,
+    onUpload,
+    isConnected,
+    shaders,
+    images,
+    videos,
+    audio,
+    isLoadingShaders,
+    isLoadingImages,
+    isLoadingVideos,
+    libraryItems,
+    isLoadingLibrary,
+    libraryError,
+    libraryTypeFilter,
+    onLibraryTypeFilter,
+    onClearSearch,
+    operations,
+    onClearCompleted,
+  } = props;
+
+  const filteredShaders = useMemo(() => {
+    let result = [...shaders];
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(s =>
+        s.name.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        s.tags.some(t => t.toLowerCase().includes(q)),
+      );
+    }
+    result.sort((a, b) => {
+      let comparison = 0;
+      switch (sortField) {
+        case 'name': comparison = a.name.localeCompare(b.name); break;
+        case 'date': comparison = new Date(a.date || 0).getTime() - new Date(b.date || 0).getTime(); break;
+        case 'rating': comparison = (a.rating || 0) - (b.rating || 0); break;
+        case 'tags': comparison = a.tags.length - b.tags.length; break;
+      }
+      return sortDirection === 'asc' ? comparison : -comparison;
+    });
+    return result;
+  }, [shaders, searchQuery, sortField, sortDirection]);
+
+  const filteredImages = useMemo(() => {
+    if (!searchQuery) return images;
+    const q = searchQuery.toLowerCase();
+    return images.filter(img =>
+      (img.description || '').toLowerCase().includes(q) ||
+      img.tags.some(t => t.toLowerCase().includes(q)),
+    );
+  }, [images, searchQuery]);
+
+  const filteredVideos = useMemo(() => {
+    if (!searchQuery) return videos;
+    const q = searchQuery.toLowerCase();
+    return videos.filter(v =>
+      v.title.toLowerCase().includes(q) || v.artist.toLowerCase().includes(q),
+    );
+  }, [videos, searchQuery]);
+
+  const filteredAudio = useMemo(() => {
+    if (!searchQuery) return audio;
+    const q = searchQuery.toLowerCase();
+    return audio.filter(a =>
+      a.title.toLowerCase().includes(q) || a.artist.toLowerCase().includes(q),
+    );
+  }, [audio, searchQuery]);
+
+  const libraryTypes = useMemo(() => {
+    return libraryItems.reduce((acc, item) => {
+      acc[item.type] = (acc[item.type] || 0) + 1;
+      return acc;
+    }, {} as Record<string, number>);
+  }, [libraryItems]);
+
+  const filteredLibrary = useMemo(() => {
+    return libraryItems.filter(item => {
+      const matchesType = libraryTypeFilter === 'all' || item.type === libraryTypeFilter;
+      const normalizedSearch = searchQuery.trim().toLowerCase();
+      const matchesSearch = normalizedSearch.length === 0 || [item.name, item.description, item.author, item.filename]
+        .filter(Boolean)
+        .some(value => value?.toLowerCase().includes(normalizedSearch));
+      return matchesType && matchesSearch;
+    });
+  }, [libraryItems, libraryTypeFilter, searchQuery]);
+
+  switch (activeTab) {
+    case 'library':
+      return (
+        <div className="library-panel">
+          <div className="library-header">
+            <div className="library-filters">
+              <div className="filter-badges">
+                {(['all', 'song', 'sample', 'shader'] as const).map(type => (
+                  <button
+                    key={type}
+                    className={`filter-chip ${libraryTypeFilter === type ? 'active' : ''}`}
+                    onClick={() => onLibraryTypeFilter(type)}
+                  >
+                    {type === 'all' ? 'All' : type.charAt(0).toUpperCase() + type.slice(1)}
+                    {type !== 'all' && libraryTypes[type] ? ` (${libraryTypes[type]})` : ''}
+                  </button>
+                ))}
+              </div>
+              <div className="library-summary">
+                {isLoadingLibrary ? <span>Loading library…</span> : <span>{filteredLibrary.length} items matched</span>}
+              </div>
+            </div>
+            <div className="library-actions">
+              <button onClick={onClearSearch} className="secondary-btn">Clear Search</button>
+            </div>
+          </div>
+          {libraryError && <div className="error-text">{libraryError}</div>}
+          {isLoadingLibrary ? (
+            <div className="cards-grid library">
+              {Array.from({ length: 8 }, (_, index) => (
+                <div key={index} className="library-card skeleton">
+                  <div className="card-thumb skeleton-box" />
+                  <div className="card-body">
+                    <div className="skeleton-line short" />
+                    <div className="skeleton-line" />
+                    <div className="skeleton-tags" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : filteredLibrary.length === 0 ? (
+            <div className="empty-state">No library items found</div>
+          ) : (
+            <div className="cards-grid library">
+              {filteredLibrary.map(item => (
+                <LibraryCard key={item.id} item={item} onPreview={() => onPreview(item)} />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+
+    case 'shaders':
+      return (
+        <div className="tab-content">
+          <div className="content-header">
+            <span className="item-count">{filteredShaders.length} shaders</span>
+            <div className="sort-controls">
+              <span>Sort by:</span>
+              {(['name', 'rating', 'date'] as const).map(field => (
+                <button
+                  key={field}
+                  className={sortField === field ? 'active' : ''}
+                  onClick={() => onToggleSort(field)}
+                >
+                  {field.charAt(0).toUpperCase() + field.slice(1)}{' '}
+                  {sortField === field && (sortDirection === 'asc' ? '▲' : '▼')}
+                </button>
+              ))}
+            </div>
+          </div>
+          <StorageUploadPanel type="shader" onUpload={onUpload} disabled={!isConnected} />
+          {isLoadingShaders ? (
+            <div className="loading-state"><GoldSpinner size="medium" /><span>Loading shaders...</span></div>
+          ) : filteredShaders.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">⚆</div>
+              <span>{searchQuery ? 'No shaders match your search' : 'No shaders available'}</span>
+            </div>
+          ) : (
+            <div className="cards-grid">
+              {filteredShaders.map(shader => (
+                <ShaderCard
+                  key={shader.id}
+                  shader={shader}
+                  isSelected={selectedItem === shader.id}
+                  onSelect={() => { onSelectItem(shader.id); onSelectShader?.(shader); }}
+                  onRate={(rating) => onShaderRate(shader.id, rating)}
+                  onPreview={() => onPreview({
+                    id: shader.id,
+                    name: shader.name,
+                    type: 'shader',
+                    description: shader.description,
+                    author: shader.author,
+                    filename: shader.filename,
+                    tags: shader.tags,
+                    thumbnail_url: shader.thumbnail_url,
+                  })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+
+    case 'images':
+      return (
+        <div className="tab-content">
+          <div className="content-header"><span className="item-count">{filteredImages.length} images</span></div>
+          <StorageUploadPanel type="image" onUpload={onUpload} disabled={!isConnected} />
+          {isLoadingImages ? (
+            <div className="loading-state"><GoldSpinner size="medium" /><span>Loading images...</span></div>
+          ) : filteredImages.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">⚆</div>
+              <span>{searchQuery ? 'No images match your search' : 'No images available'}</span>
+            </div>
+          ) : (
+            <div className="cards-grid images">
+              {filteredImages.map((image, i) => (
+                <ImageCard
+                  key={i}
+                  image={image}
+                  isSelected={selectedItem === `img-${i}`}
+                  onSelect={() => { onSelectItem(`img-${i}`); onSelectImage?.(image); }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+
+    case 'videos':
+      return (
+        <div className="tab-content">
+          <div className="content-header"><span className="item-count">{filteredVideos.length} videos</span></div>
+          <StorageUploadPanel type="video" onUpload={onUpload} disabled={!isConnected} />
+          {isLoadingVideos ? (
+            <div className="loading-state"><GoldSpinner size="medium" /><span>Loading videos...</span></div>
+          ) : filteredVideos.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">⚆</div>
+              <span>{searchQuery ? 'No videos match your search' : 'No videos available'}</span>
+            </div>
+          ) : (
+            <div className="cards-grid">
+              {filteredVideos.map(video => (
+                <VideoCard
+                  key={video.id}
+                  video={video}
+                  isSelected={selectedItem === video.id}
+                  onSelect={() => { onSelectItem(video.id); onSelectVideo?.(video); }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+
+    case 'audio':
+      return (
+        <div className="tab-content">
+          <div className="content-header"><span className="item-count">{filteredAudio.length} audio files</span></div>
+          <StorageUploadPanel type="audio" onUpload={onUpload} disabled={!isConnected} />
+          {isLoadingVideos ? (
+            <div className="loading-state"><GoldSpinner size="medium" /><span>Loading audio...</span></div>
+          ) : filteredAudio.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">⚆</div>
+              <span>{searchQuery ? 'No audio files match your search' : 'No audio files available'}</span>
+            </div>
+          ) : (
+            <div className="cards-grid">
+              {filteredAudio.map(track => (
+                <VideoCard
+                  key={track.id}
+                  video={track}
+                  isSelected={selectedItem === track.id}
+                  onSelect={() => { onSelectItem(track.id); onSelectVideo?.(track); }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+
+    case 'operations':
+      return <OperationsPanel operations={operations} onClearCompleted={onClearCompleted} />;
+
+    default:
+      return null;
+  }
+};

--- a/src/components/storage/panels/StorageRatings.tsx
+++ b/src/components/storage/panels/StorageRatings.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+interface RateShaderFn {
+  (shaderId: string, rating: number): Promise<unknown>;
+}
+
+interface RefreshShadersFn {
+  (): Promise<void>;
+}
+
+/** Rating seam — keeps star UI decoupled from StorageClient wiring in list panels. */
+export function useShaderRating(rateShader: RateShaderFn, refreshShaders: RefreshShadersFn) {
+  return useCallback(
+    async (shaderId: string, rating: number) => {
+      await rateShader(shaderId, rating);
+      refreshShaders().catch(() => {});
+    },
+    [rateShader, refreshShaders],
+  );
+}

--- a/src/components/storage/panels/StorageUploadPanel.tsx
+++ b/src/components/storage/panels/StorageUploadPanel.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { DragDropUpload, UploadType } from '../../DragDropUpload';
+import { StorageSaveResponse } from '../../../services/storage';
+
+interface StorageUploadPanelProps {
+  type: UploadType;
+  disabled: boolean;
+  onUpload: (
+    files: File[],
+    type: UploadType,
+    onProgress?: (completed: number, total: number) => void,
+  ) => Promise<StorageSaveResponse[]>;
+}
+
+/** Drag-and-drop upload surface — delegates all network I/O to StorageClient via useStorage. */
+export const StorageUploadPanel: React.FC<StorageUploadPanelProps> = ({
+  type,
+  disabled,
+  onUpload,
+}) => (
+  <DragDropUpload type={type} onUpload={onUpload} disabled={disabled} />
+);

--- a/src/renderer/RendererManager.ts
+++ b/src/renderer/RendererManager.ts
@@ -1,696 +1,275 @@
-import { Renderer, RendererConfig, ShaderSlotRenderer, SlotZoomParamsUpdate, GPUTimings } from './Renderer';
-import { JSRenderer } from './JSRenderer';
-import { WASMDiagnostics } from './WASMRenderer';
+import { Renderer, RendererConfig, GPUTimings } from './Renderer';
 import { WASMRenderer } from './WASMRenderer';
 import { WebGPURenderer } from './WebGPURenderer';
 import { InputSource, RenderMode, ShaderEntry, SlotParams } from './types';
-import {
-  computeInternalDimensions,
-  estimateInternalTextureMiB,
-  INTERNAL_RENDER_RESOLUTION,
-  RenderQualityMode,
-  ResolvedPerformancePolicy,
-  resolvePerformancePolicy,
-} from '../config/performancePolicy';
-import {
-  DEFAULT_FORMAT_CAPABILITIES,
-  DeviceFormatCapabilities,
-  Fp32PinDecision,
-  InternalColorFormat,
-  resolveFp32Pin,
-} from '../config/formatPolicy';
 import { AdaptivePerformanceController } from './adaptivePerformance';
-import { getGraphEntryIds, hasGraph } from './multipassRegistry';
-import { resolveShaderUrl } from '../utils/resolveShaderUrl';
+import {
+  RendererType,
+  getRendererTypeFromURL,
+  performBackendSwitch,
+  resolveInitBackendPreference,
+} from './backendLifecycle';
+import * as inputBridge from './inputSourceBridge';
+import {
+  PerformancePolicyState,
+  RendererPerformanceStatus,
+  applyPerformancePolicyToRenderer,
+  applyQualityPolicy,
+  applyResolutionScaleToRenderer,
+  buildPerformanceStatus,
+  createPerformancePolicyState,
+  readResolutionScale,
+  refreshFormatCapabilities,
+  registerFp32Requirement,
+  releaseFp32Requirement,
+} from './performanceStatus';
+import {
+  ShaderLoadMeta,
+  SLOT_COUNT,
+  addRipple,
+  clearRipples,
+  firePlasmaOnBackend,
+  loadShaderForBackend,
+  loadShadersForBackend,
+  reloadShaderOnBackend,
+  resyncShaderStack,
+  resolveShaderBackend,
+  setActiveShader,
+  setSlotMode,
+  setSlotParams,
+  setSlotShader,
+  supportsShaderEffects as backendSupportsShaders,
+  syncAllSlotParams,
+  updateSlotParams,
+} from './slotOrchestration';
+import { DeviceFormatCapabilities } from '../config/formatPolicy';
+import { RenderQualityMode } from '../config/performancePolicy';
+import { buildRendererDiagnostics } from './rendererDiagnostics';
+import type { RendererDiagnostics, RendererMetrics } from './rendererTypes';
 
-export interface RendererMetrics {
-  fps: number;
-  frameTime: number;
-  agentCount: number;
-  isWASM: boolean;
-}
-
-export interface RendererPerformanceStatus {
-  qualityMode: RenderQualityMode;
-  backend: RendererType;
-  scale: number;
-  internalWidth: number;
-  internalHeight: number;
-  maxActiveSlots: number;
-  targetFps: number;
-  adaptive: boolean;
-  fps: number;
-  colorFormat: InternalColorFormat;
-  estimatedTextureMiB: number;
-  /** Format the quality tier asked for, before any FP32 pin. */
-  requestedColorFormat: InternalColorFormat;
-  /** True when an FP32-required shader forced rgba32float over the tier default. */
-  fp32Pinned: boolean;
-  /** Shader ids holding the FP32 pin. */
-  fp32PinnedBy: string[];
-  /** Graph dispatch cap for this tier (Tier C multipass). */
-  maxPassesPerFrame: number;
-}
-
-export interface ShaderLoadMeta {
-  requiresDeepWorkgroup?: boolean;
-  requiresHistoryRing?: boolean;
-  requiresRgba32Float?: boolean;
-}
-
-export interface RendererDiagnostics {
-  rendererType: RendererType;
-  metrics: RendererMetrics;
-  timestamp: string;
-  wasm?: WASMDiagnostics;
-  webgpu?: Record<string, any>;
-}
-
-/** Supported renderer backend identifiers. */
-export type RendererType = 'webgpu' | 'wasm' | 'js';
-
-/**
- * Read the preferred renderer type from the URL query string.
- *
- * Supported values for the `renderer` parameter:
- *   - `wasm`   → C++ Emscripten WASM renderer (**experimental** — see WASM_BACKEND_POLICY.md)
- *   - `webgpu` → TypeScript native WebGPU renderer (default)
- *   - `js`     → Canvas 2D fallback (no shaders)
- *
- * Example: `http://localhost:3000/?renderer=wasm`
- */
-export function getRendererTypeFromURL(): RendererType | null {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    const value = params.get('renderer');
-    if (value === 'wasm' || value === 'webgpu' || value === 'js') {
-      return value as RendererType;
-    }
-  } catch {
-    // Not in a browser context (e.g. tests)
-  }
-  return null;
-}
+export type { RendererType };
+export { getRendererTypeFromURL };
+export type { RendererPerformanceStatus, ShaderLoadMeta };
+export type { RendererMetrics, RendererDiagnostics } from './rendererTypes';
 
 export class RendererManager {
   private currentRenderer: Renderer | null = null;
-  /** Active backend id; kept in sync with `currentRenderer` (null when none). */
   private currentType: RendererType | null = null;
-  // Retained even when switchRenderer('wasm') fails and falls back, so
-  // getDiagnostics().wasm can still surface *why* WASM init failed
-  // (e.g. surface-creation/adapter-limits errors recorded in adapterInfo).
   private lastFailedWasmRenderer: WASMRenderer | null = null;
-  private config: RendererConfig;
+  private readonly config: RendererConfig;
   private canvas: HTMLCanvasElement | null = null;
-  private metrics: RendererMetrics = {
-    fps: 0,
-    frameTime: 0,
-    agentCount: 0,
-    isWASM: false,
-  };
-  private onMetricsUpdate?: (metrics: RendererMetrics) => void;
-  private performancePolicy: ResolvedPerformancePolicy = resolvePerformancePolicy('auto', {
-    supportsDeepWorkgroup: true,
-  });
-  private qualityMode: RenderQualityMode = 'auto';
-  private resolutionScale = 1.0;
-  private formatCapabilities: DeviceFormatCapabilities = DEFAULT_FORMAT_CAPABILITIES;
-  /** Loaded shaders that must not run at FP16 (docs/FORMAT_TIERS.md precision guard). */
-  private fp32RequiredShaders = new Set<string>();
-  private requestedColorFormat: InternalColorFormat = this.performancePolicy.colorFormat;
-  private fp32Pin: Fp32PinDecision = {
-    colorFormat: this.performancePolicy.colorFormat,
-    pinned: false,
-    pinnedBy: [],
-  };
-  private adaptiveController: AdaptivePerformanceController;
-
-  /** Max shader slots shared by WebGPU and WASM backends. */
-  private static readonly SLOT_COUNT = 3;
+  private metrics: RendererMetrics = { fps: 0, frameTime: 0, agentCount: 0, isWASM: false };
+  private readonly onMetricsUpdate?: (metrics: RendererMetrics) => void;
+  private readonly perfState: PerformancePolicyState = createPerformancePolicyState();
+  private readonly adaptiveController: AdaptivePerformanceController;
 
   constructor(config: RendererConfig, onMetricsUpdate?: (metrics: RendererMetrics) => void) {
     this.config = config;
     this.onMetricsUpdate = onMetricsUpdate;
     this.adaptiveController = new AdaptivePerformanceController({
       getFps: () => this.getCurrentFPS(),
-      getScale: () => this.resolutionScale,
-      setScale: (scale) => this.applyResolutionScale(scale),
+      getScale: () => this.perfState.resolutionScale,
+      setScale: (scale) => applyResolutionScaleToRenderer(this.perfState, this.shaderRenderer(), scale),
     });
   }
 
+  private shaderRenderer(): WebGPURenderer | WASMRenderer | null {
+    const r = this.currentRenderer;
+    return r instanceof WebGPURenderer || r instanceof WASMRenderer ? r : null;
+  }
+
+  private backend() {
+    return resolveShaderBackend(this.currentRenderer);
+  }
+
+  private slotPolicy() {
+    return {
+      maxActiveSlots: this.perfState.performancePolicy.maxActiveSlots,
+      preferNonDeepVariants: this.perfState.performancePolicy.preferNonDeepVariants,
+    };
+  }
+
+  private slotCallbacks() {
+    return {
+      onFp32Required: (id: string) => {
+        if (registerFp32Requirement(this.perfState, id)) {
+          if (this.perfState.performancePolicy.colorFormat !== 'rgba32float') {
+            console.warn(
+              `[RendererManager] "${id}" requires rgba32float — pinning storage format to FP32 ` +
+                `(quality mode stays "${this.perfState.qualityMode}")`,
+            );
+            this.applyQualityPolicy(this.perfState.qualityMode);
+          }
+        }
+      },
+    };
+  }
+
+  private loadShaderBound = (id: string, url: string, meta?: ShaderLoadMeta) =>
+    loadShaderForBackend(this.backend(), this.slotPolicy(), this.slotCallbacks(), id, url, meta);
+
   async init(canvas: HTMLCanvasElement): Promise<boolean> {
     this.canvas = canvas;
+    const { preferredType } = resolveInitBackendPreference();
 
-    // Honour an explicit renderer preference from the URL query string
-    // (e.g. ?renderer=wasm) so the WASM path can be tested without code changes.
-    const urlPreference = getRendererTypeFromURL();
-
-    if (urlPreference === 'wasm') {
+    if (preferredType === 'wasm') {
       console.log('🔧 WASM renderer explicitly requested via ?renderer=wasm');
-      const wasmSuccess = await this.switchRenderer('wasm');
-      if (wasmSuccess) {
+      if (await this.switchRenderer('wasm')) {
         console.log('✅ Using C++ WASM renderer (experimental, forced via ?renderer=wasm)');
         return true;
       }
-      // Fall through to the normal priority order on failure
       console.warn('⚠️ WASM renderer requested but failed to initialise — falling back to TypeScript WebGPU');
-    }
-
-    if (urlPreference === 'js') {
+    } else if (preferredType === 'js') {
       console.log('🔧 Canvas2D renderer explicitly requested via ?renderer=js');
       return this.switchRenderer('js');
     }
 
-    // 1. Try native TypeScript WebGPU renderer (no WASM / Emscripten required)
-    const gpuSuccess = await this.switchRenderer('webgpu');
-    if (gpuSuccess) {
+    if (await this.switchRenderer('webgpu')) {
       console.log('✅ Using TypeScript WebGPU renderer (native navigator.gpu)');
       return true;
     }
 
-    // 2. Canvas2D fallback — no shader effects, but app stays functional.
-    // WASM renderer is NOT an automatic fallback; use switchRenderer('wasm') explicitly
-    // or pass ?renderer=wasm in the URL to opt in.
     console.warn('⚠️ WebGPU unavailable — falling back to Canvas2D (shaders disabled)');
     return this.switchRenderer('js');
-  }
-
-  /**
-   * Both the TypeScript WebGPU path and emdawnwebgpu (WASM) claim a browser
-   * GPUAdapter/device and configure the same canvas context. On Windows Chrome
-   * / Edge, a second `requestAdapter` while the first device is still alive
-   * fails with status Unavailable and "A valid external Instance reference no
-   * longer exists" / "No available adapters" — even though the JS path just
-   * succeeded. Exclusive WebGPU backends must therefore release before the
-   * other one inits.
-   */
-  private static usesExclusiveWebGpu(type: RendererType): boolean {
-    return type === 'webgpu' || type === 'wasm';
-  }
-
-  private static yieldForGpuRelease(): Promise<void> {
-    return new Promise((resolve) => {
-      if (typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(() => resolve());
-      } else {
-        setTimeout(resolve, 0);
-      }
-    });
   }
 
   async switchRenderer(type: RendererType): Promise<boolean> {
     if (!this.canvas) return false;
 
-    // Preserve video reference across renderer switches
-    const video = (this.currentRenderer as { video?: HTMLVideoElement } | null)?.video;
+    const outcome = await performBackendSwitch({
+      targetType: type,
+      canvas: this.canvas,
+      config: this.config,
+      previousType: this.currentType,
+      previousRenderer: this.currentRenderer,
+    });
 
-    const previousType = this.currentType;
-    const previousRenderer = this.currentRenderer;
-
-    // Release exclusive GPU ownership *before* the new backend requestAdapter().
-    // For non-exclusive targets (js) keep the old "init first, then destroy"
-    // order so a failed switch never leaves the app with no renderer.
-    const mustReleaseFirst =
-      RendererManager.usesExclusiveWebGpu(type) &&
-      previousRenderer != null &&
-      previousType != null &&
-      RendererManager.usesExclusiveWebGpu(previousType);
-
-    if (mustReleaseFirst) {
-      console.log(
-        `[RendererManager] Releasing ${previousType} before switching to ${type} ` +
-          '(exclusive WebGPU adapter/device ownership)',
-      );
-      previousRenderer.destroy();
-      this.currentRenderer = null;
-      this.currentType = null;
-      this.metrics.isWASM = false;
-      await RendererManager.yieldForGpuRelease();
-    }
-
-    let renderer: Renderer;
-    if (type === 'webgpu') {
-      renderer = new WebGPURenderer(this.config);
-    } else if (type === 'wasm') {
-      renderer = new WASMRenderer(this.config);
-    } else {
-      renderer = new JSRenderer(this.config);
-    }
-
-    const success = await renderer.init(this.canvas);
-
-    if (success) {
-      // Previous exclusive GPU was already destroyed when mustReleaseFirst.
-      if (!mustReleaseFirst) {
-        this.currentRenderer?.destroy();
-      }
-      this.currentRenderer = renderer;
-      this.currentType = type;
-      this.metrics.isWASM = type === 'wasm';
-      if (type === 'wasm') this.lastFailedWasmRenderer = null;
-
-      // JS fallback may have replaced the DOM canvas after WebGPU permanently
-      // claimed the previous element's context type.
-      if (type === 'js' && typeof (renderer as JSRenderer).getCanvas === 'function') {
-        const replaced = (renderer as JSRenderer).getCanvas();
-        if (replaced) this.canvas = replaced;
-      }
-
-      if (video) renderer.setVideo(video);
-      this.refreshFormatCapabilities();
-      this.applyPerformancePolicyToRenderer();
+    if (outcome.success) {
+      this.currentRenderer = outcome.renderer;
+      this.currentType = outcome.type;
+      this.canvas = outcome.canvas;
+      this.metrics.isWASM = outcome.isWASM;
+      this.lastFailedWasmRenderer = null;
+      refreshFormatCapabilities(this.perfState, this.shaderRenderer());
+      applyPerformancePolicyToRenderer(this.perfState, this.shaderRenderer(), this.adaptiveController);
       this.startMetricsCollection();
-    } else {
-      console.warn(`[RendererManager] switchRenderer('${type}') failed`);
-      if (type === 'wasm') {
-        this.lastFailedWasmRenderer = renderer as WASMRenderer;
-      }
-      // We already tore down the previous exclusive backend — restore it so
-      // the UI does not sit on a black canvas after a failed C++ toggle.
-      if (mustReleaseFirst && previousType) {
-        console.warn(
-          `[RendererManager] Restoring previous renderer '${previousType}' after ${type} init failure`,
-        );
-        const restored = await this.switchRenderer(previousType);
-        if (!restored) {
-          console.warn(
-            `[RendererManager] Restore of '${previousType}' failed — falling back to Canvas2D`,
-          );
-          await this.switchRenderer('js');
-        }
-      } else {
-        console.warn(
-          `[RendererManager] switchRenderer('${type}') failed — keeping previous renderer`,
-        );
-      }
+      return true;
     }
 
-    return success;
+    if (outcome.failedWasmRenderer) this.lastFailedWasmRenderer = outcome.failedWasmRenderer;
+    this.currentRenderer = outcome.renderer;
+    this.currentType = outcome.type;
+    this.metrics.isWASM = outcome.isWASM;
+
+    if (outcome.restoreType) {
+      const restoreType = outcome.restoreType;
+      console.warn(`[RendererManager] Restoring previous renderer '${restoreType}' after ${type} init failure`);
+      const restored = await this.switchRenderer(restoreType);
+      if (!restored) {
+        console.warn(`[RendererManager] Restore of '${restoreType}' failed — falling back to Canvas2D`);
+        await this.switchRenderer('js');
+      }
+    } else {
+      console.warn(`[RendererManager] switchRenderer('${type}') failed — keeping previous renderer`);
+    }
+    return false;
   }
 
   private startMetricsCollection(): void {
     const updateMetrics = () => {
       const fps = this.currentRenderer?.getFPS?.();
-      if (typeof fps === 'number') {
-        this.metrics.fps = fps;
-      }
+      if (typeof fps === 'number') this.metrics.fps = fps;
       this.onMetricsUpdate?.(this.metrics);
       requestAnimationFrame(updateMetrics);
     };
     updateMetrics();
   }
 
-  setVideo(video: HTMLVideoElement): void {
-    this.currentRenderer?.setVideo(video);
-  }
-
-  updateVideoFrame(): void {
-    this.currentRenderer?.updateVideoFrame();
-  }
-
-  updateAudioData(bass: number, mid: number, treble: number): void {
-    this.currentRenderer?.updateAudioData(bass, mid, treble);
-  }
-
-  updateAudioFrequencyBins(bins: Float32Array): void {
-    this.currentRenderer?.updateAudioFrequencyBins?.(bins);
-  }
-
-  updateMouse(x: number, y: number): void {
-    this.currentRenderer?.updateMouse(x, y);
-  }
+  setVideo(video: HTMLVideoElement): void { inputBridge.setVideo(this.currentRenderer, video); }
+  updateVideoFrame(): void { inputBridge.updateVideoFrame(this.currentRenderer); }
+  updateAudioData(bass: number, mid: number, treble: number): void { this.currentRenderer?.updateAudioData(bass, mid, treble); }
+  updateAudioFrequencyBins(bins: Float32Array): void { this.currentRenderer?.updateAudioFrequencyBins?.(bins); }
+  updateMouse(x: number, y: number): void { this.currentRenderer?.updateMouse(x, y); }
 
   setParam(name: string, value: number): void {
     this.currentRenderer?.setParam(name, value);
-
-    if (name === 'agentCount') {
-      this.metrics.agentCount = Math.floor(value);
-    }
+    if (name === 'agentCount') this.metrics.agentCount = Math.floor(value);
   }
 
-  /** True when the active backend supports WGSL shader slots (WebGPU or WASM). */
-  supportsShaderEffects(): boolean {
-    return this.getShaderBackend() !== null;
-  }
-
-  /** Returns the shader-capable backend, or null for Canvas2D fallback. */
-  private getShaderBackend(): ShaderSlotRenderer | null {
-    const r = this.currentRenderer;
-    if (!r || r instanceof JSRenderer) return null;
-    const candidate = r as ShaderSlotRenderer;
-    if (
-      typeof candidate.loadShader === 'function' &&
-      typeof candidate.setSlotShader === 'function' &&
-      typeof candidate.updateSlotParams === 'function'
-    ) {
-      return candidate;
-    }
-    return null;
-  }
-
-  /**
-   * Load a shader by fetching its WGSL from the given URL.
-   * Works with both the TypeScript WebGPU renderer and the WASM renderer.
-   * No-op when the Canvas2D fallback is active.
-   */
+  supportsShaderEffects(): boolean { return backendSupportsShaders(this.currentRenderer); }
   async loadShader(id: string, url: string, meta?: ShaderLoadMeta): Promise<boolean> {
-    const backend = this.getShaderBackend();
-    if (!backend) return false;
-
-    if (
-      meta?.requiresDeepWorkgroup
-      && this.performancePolicy.preferNonDeepVariants
-    ) {
-      console.log(
-        `[RendererManager] Skipping "${id}" — deep-workgroup variant disabled by quality policy`,
-      );
-      return false;
-    }
-
-    if (meta?.requiresRgba32Float) {
-      this.fp32RequiredShaders.add(id);
-      if (this.performancePolicy.colorFormat !== 'rgba32float') {
-        console.warn(
-          `[RendererManager] "${id}" requires rgba32float — pinning storage format to FP32 ` +
-            `(quality mode stays "${this.qualityMode}")`,
-        );
-        // Re-resolve so the pin is applied to the renderer immediately.
-        this.applyQualityPolicy(this.qualityMode);
-      }
-    }
-
-    try {
-      const ok = await backend.loadShader(id, url);
-      if (ok && hasGraph(id)) {
-        const entries = getGraphEntryIds(id);
-        await Promise.all(
-          entries
-            .filter((entryId) => entryId !== id)
-            .map((entryId) =>
-              backend.loadShader(entryId, resolveShaderUrl(`shaders/${entryId}.wgsl`)).catch(() => false),
-            ),
-        );
-      }
-      if (
-        process.env.NODE_ENV === 'development'
-        && ok
-        && meta?.requiresHistoryRing
-      ) {
-        console.log(`[RendererManager] Loaded history-ring shader "${id}" (binding 13)`);
-      }
-      return ok;
-    } catch (err) {
-      console.warn(`[RendererManager] loadShader("${id}") failed:`, err);
-      return false;
-    }
+    return this.loadShaderBound(id, url, meta);
   }
-
-  /**
-   * Load all shaders from a shader list into the active shader backend.
-   * Shaders are loaded concurrently. Skips entries when Canvas2D is active.
-   */
   async loadShaders(shaders: ShaderEntry[]): Promise<void> {
-    if (!this.supportsShaderEffects()) return;
-    const results = await Promise.allSettled(
-      shaders.map(s => this.loadShader(s.id, s.url, {
-        requiresDeepWorkgroup: s.requiresDeepWorkgroup,
-        requiresHistoryRing: s.requiresHistoryRing,
-        requiresRgba32Float: s.requiresRgba32Float,
-      }))
-    );
-    const failed = results.filter(r => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value)).length;
-    if (failed > 0) {
-      console.warn(`[RendererManager] loadShaders: ${failed}/${shaders.length} shader(s) failed`);
-    }
+    return loadShadersForBackend(this.backend(), this.slotPolicy(), this.slotCallbacks(), shaders, this.loadShaderBound);
   }
-
-  /** Switch to a previously loaded shader. No-op with Canvas2D fallback. */
-  setActiveShader(id: string): void {
-    this.getShaderBackend()?.setActiveShader(id);
-  }
-
-  /** Assign a shader to a specific slot (0-2) without clearing other slots. */
-  setSlotShader(index: number, id: string): void {
-    if (id && index >= this.performancePolicy.maxActiveSlots) {
-      console.warn(
-        `[RendererManager] Slot ${index} exceeds quality cap (${this.performancePolicy.maxActiveSlots} max)`,
-      );
-      return;
-    }
-    this.getShaderBackend()?.setSlotShader(index, id);
-  }
-
-  /**
-   * Update zoom params for one slot using the per-param form (WASM bridge API).
-   * Falls back to aggregate updateSlotParams when the backend has no setSlotParams.
-   */
+  setActiveShader(id: string): void { setActiveShader(this.backend(), id); }
+  setSlotShader(index: number, id: string): void { setSlotShader(this.backend(), this.slotPolicy(), index, id); }
   setSlotParams(slotIndex: number, p1: number, p2: number, p3: number, p4: number): void {
-    const backend = this.getShaderBackend();
-    if (!backend) return;
-    if (backend.setSlotParams) {
-      backend.setSlotParams(slotIndex, p1, p2, p3, p4);
-    } else {
-      backend.updateSlotParams(
-        { zoomParam1: p1, zoomParam2: p2, zoomParam3: p3, zoomParam4: p4 },
-        slotIndex
-      );
-    }
+    setSlotParams(this.backend(), slotIndex, p1, p2, p3, p4);
   }
-
-  /** Update zoom params for a slot (aggregate form from UI sliders). */
-  updateSlotParams(params: SlotZoomParamsUpdate, slotIndex = 0): void {
-    this.getShaderBackend()?.updateSlotParams(params, slotIndex);
+  updateSlotParams(params: import('./Renderer').SlotZoomParamsUpdate, slotIndex = 0): void {
+    updateSlotParams(this.backend(), params, slotIndex);
   }
-
-  /** Push all slot slider values to the active shader backend (required for WASM multi-slot). */
-  syncAllSlotParams(slotParams: SlotParams[], maxSlots = RendererManager.SLOT_COUNT): void {
-    if (!this.supportsShaderEffects() || slotParams.length === 0) return;
-    const count = Math.min(maxSlots, slotParams.length);
-    for (let i = 0; i < count; i++) {
-      const p = slotParams[i];
-      this.updateSlotParams(
-        {
-          zoomParam1: p.zoomParam1,
-          zoomParam2: p.zoomParam2,
-          zoomParam3: p.zoomParam3,
-          zoomParam4: p.zoomParam4,
-        },
-        i
-      );
-    }
+  syncAllSlotParams(slotParams: SlotParams[], maxSlots = SLOT_COUNT): void {
+    syncAllSlotParams(this.backend(), slotParams, maxSlots);
   }
-
-  /**
-   * Re-load and re-bind the current shader stack after a renderer backend switch.
-   * Ensures WASM receives the same slot shaders + params the UI already selected.
-   */
   async resyncShaderStack(options: {
     modes: RenderMode[];
     slotParams: SlotParams[];
     resolveShader: (shaderId: string) => ShaderEntry | undefined;
     inputSource?: InputSource;
   }): Promise<void> {
-    if (!this.supportsShaderEffects()) return;
-
-    if (options.inputSource) {
-      this.setInputSource(options.inputSource);
-    }
-
-    for (let i = 0; i < Math.min(RendererManager.SLOT_COUNT, options.modes.length); i++) {
-      const mode = options.modes[i];
-      if (!mode || mode === 'none') {
-        this.setSlotShader(i, '');
-        continue;
-      }
-
-      const entry = options.resolveShader(mode);
-      if (!entry) {
-        console.warn(`[RendererManager] resyncShaderStack: no entry for "${mode}" on slot ${i}`);
-        continue;
-      }
-
-      const ok = await this.loadShader(entry.id, entry.url, {
-        requiresDeepWorkgroup: entry.requiresDeepWorkgroup,
-        requiresHistoryRing: entry.requiresHistoryRing,
-        requiresRgba32Float: entry.requiresRgba32Float,
-      });
-      if (ok) {
-        this.setSlotShader(i, entry.id);
-      } else {
-        console.warn(`[RendererManager] resyncShaderStack: failed to load "${entry.id}" for slot ${i}`);
-      }
-    }
-
-    this.syncAllSlotParams(options.slotParams);
+    return resyncShaderStack(
+      this.backend(),
+      this.slotPolicy(),
+      this.slotCallbacks(),
+      this.loadShaderBound,
+      (source) => this.setInputSource(source),
+      options,
+    );
   }
-
-  /** Set slot execution mode ('chained' | 'parallel'). */
-  setSlotMode(index: number, mode: 'chained' | 'parallel'): void {
-    this.getShaderBackend()?.setSlotMode(index, mode);
-  }
-
-  /** Set the active input source (generative, image, video, webcam, or live). */
-  setInputSource(source: InputSource): void {
-    this.currentRenderer?.setInputSource?.(source);
-  }
-
-  /** Returns the active input source when the backend exposes it. */
-  getInputSource(): InputSource | null {
-    const r = this.currentRenderer as { getInputSource?: () => InputSource } | null;
-    return r?.getInputSource?.() ?? null;
-  }
-
-  addRipple(x: number, y: number): void {
-    this.getShaderBackend()?.addRipple(x, y);
-  }
-
-  /** Alias used by WebGPUCanvas mouse handlers (forwards to addRipple). */
-  addRipplePoint(x: number, y: number): void {
-    this.addRipple(x, y);
-  }
-
-  clearRipples(): void {
-    this.getShaderBackend()?.clearRipples();
-  }
-
-  /** Load an image by URL into the active renderer's read texture. */
-  async loadImage(url: string): Promise<string> {
-    const r = this.currentRenderer as {
-      loadImage?: (url: string) => Promise<string>;
-      loadImageFromURL?: (url: string) => Promise<void>;
-    } | null;
-    if (!r) return url;
-    if (r.loadImage) {
-      return r.loadImage(url);
-    }
-    if (r.loadImageFromURL) {
-      await r.loadImageFromURL(url);
-      return url;
-    }
-    return url;
-  }
-
-  /** @deprecated Use loadImage() */
-  async loadImageFromURL(url: string): Promise<void> {
-    await this.loadImage(url);
-  }
-
-
-  getAvailableModes(): ShaderEntry[] {
-    const r = this.currentRenderer as { getAvailableModes?: () => ShaderEntry[] } | null;
-    return r?.getAvailableModes?.() ?? [];
-  }
-
-  /** Forward a list of image URLs to the active renderer (e.g. for slideshow mode). */
-  setImageList(urls: string[]): void {
-    if (this.currentRenderer?.setImageList) {
-      this.currentRenderer.setImageList(urls);
-    }
-  }
-
-  /** Forward a depth map to the active renderer. */
+  setSlotMode(index: number, mode: 'chained' | 'parallel'): void { setSlotMode(this.backend(), index, mode); }
+  setInputSource(source: InputSource): void { inputBridge.setInputSource(this.currentRenderer, source); }
+  getInputSource(): InputSource | null { return inputBridge.getInputSource(this.currentRenderer); }
+  addRipple(x: number, y: number): void { addRipple(this.backend(), x, y); }
+  addRipplePoint(x: number, y: number): void { this.addRipple(x, y); }
+  clearRipples(): void { clearRipples(this.backend()); }
+  async loadImage(url: string): Promise<string> { return inputBridge.loadImage(this.currentRenderer, url); }
+  async loadImageFromURL(url: string): Promise<void> { await this.loadImage(url); }
+  getAvailableModes(): ShaderEntry[] { return inputBridge.getAvailableModes(this.currentRenderer); }
+  setImageList(urls: string[]): void { inputBridge.setImageList(this.currentRenderer, urls); }
   updateDepthMap(data: Float32Array, width: number, height: number): void {
-    if (this.currentRenderer?.updateDepthMap) {
-      this.currentRenderer.updateDepthMap(data, width, height);
-    }
+    inputBridge.updateDepthMap(this.currentRenderer, data, width, height);
   }
-
-  /** Forwards deep-workgroup capability query to the active renderer. */
-  getSupportsDeepWorkgroup(): boolean {
-    return this.currentRenderer?.getSupportsDeepWorkgroup?.() ?? false;
-  }
-
-  getFormatCapabilities(): DeviceFormatCapabilities {
-    return this.formatCapabilities;
-  }
-
-  private refreshFormatCapabilities(): void {
-    const r = this.currentRenderer;
-    const fromRenderer = r && 'getFormatCapabilities' in r
-      ? (r as WebGPURenderer).getFormatCapabilities?.()
-      : undefined;
-    if (fromRenderer) {
-      this.formatCapabilities = fromRenderer;
-    }
-  }
-
-  getSlotState(index: number): { shaderId: string | null; enabled: boolean; mode: 'chained' | 'parallel' } | null {
-    return this.currentRenderer?.getSlotState?.(index) ?? null;
-  }
-
+  getSupportsDeepWorkgroup(): boolean { return this.currentRenderer?.getSupportsDeepWorkgroup?.() ?? false; }
+  getFormatCapabilities(): DeviceFormatCapabilities { return this.perfState.formatCapabilities; }
+  getSlotState(index: number) { return this.currentRenderer?.getSlotState?.(index) ?? null; }
   getGPUTimings(): GPUTimings {
     return this.currentRenderer?.getGPUTimings?.() ?? {
-      parallelTime: 0,
-      chainedTime: 0,
-      totalTime: 0,
-      available: false,
-      timingSource: 'unavailable',
+      parallelTime: 0, chainedTime: 0, totalTime: 0, available: false, timingSource: 'unavailable',
     };
   }
-
-  /** Plasma drag impulse (WebGPU-only when implemented; otherwise falls back to ripple). */
   firePlasma(x: number, y: number, vx: number, vy: number): void {
-    const r = this.currentRenderer as {
-      firePlasma?: (x: number, y: number, vx: number, vy: number) => void;
-    } | null;
-    if (r?.firePlasma) {
-      r.firePlasma(x, y, vx, vy);
-      return;
-    }
-    this.addRipple(x, y);
+    firePlasmaOnBackend(this.currentRenderer, this.backend(), x, y, vx, vy);
   }
-
   async reloadShader(id: string, url: string): Promise<boolean> {
-    const backend = this.getShaderBackend();
-    if (!backend) return false;
-    const r = this.currentRenderer;
-    if (r?.reloadShaderFromURL) {
-      return r.reloadShaderFromURL(id, url);
-    }
-    return backend.loadShader(id, url);
+    return reloadShaderOnBackend(this.currentRenderer, this.backend(), id, url);
   }
-
-  applyTestRenderState(state: {
-    time?: number;
-    mouseX?: number;
-    mouseY?: number;
-    mouseDown?: boolean;
-    bass?: number;
-    mid?: number;
-    treble?: number;
-  }): void {
-    const r = this.currentRenderer as {
-      applyTestRenderState?: (s: typeof state) => void;
-    } | null;
-    r?.applyTestRenderState?.(state);
+  applyTestRenderState(state: Parameters<NonNullable<WebGPURenderer['applyTestRenderState']>>[0]): void {
+    (this.currentRenderer as WebGPURenderer | null)?.applyTestRenderState?.(state);
   }
-
-  getFrameImage(): string {
-    return this.currentRenderer?.getFrameImage?.() ?? '';
-  }
-
-  /** Capture current frame from the active renderer (WASM readback or canvas fallback). */
+  getFrameImage(): string { return this.currentRenderer?.getFrameImage?.() ?? ''; }
   async refreshFrameImage(): Promise<string> {
     const r = this.currentRenderer as { refreshFrameImage?: () => Promise<string> } | null;
-    if (r?.refreshFrameImage) {
-      return r.refreshFrameImage();
-    }
-    if (this.canvas) {
-      return this.canvas.toDataURL('image/png');
-    }
-    return '';
+    if (r?.refreshFrameImage) return r.refreshFrameImage();
+    return this.canvas ? this.canvas.toDataURL('image/png') : '';
   }
-
-  /** Download a PNG screenshot (GPU readback on WASM, canvas fallback otherwise). */
   async takeScreenshot(filename = 'screenshot.png'): Promise<void> {
     const r = this.currentRenderer as { takeScreenshot?: (f?: string) => Promise<void> } | null;
-    if (r?.takeScreenshot) {
-      return r.takeScreenshot(filename);
-    }
+    if (r?.takeScreenshot) return r.takeScreenshot(filename);
     const dataUrl = await this.refreshFrameImage();
-    if (!dataUrl) {
-      throw new Error('[RendererManager] Screenshot unavailable — no frame source');
-    }
+    if (!dataUrl) throw new Error('[RendererManager] Screenshot unavailable — no frame source');
     const a = document.createElement('a');
     a.href = dataUrl;
     a.download = filename;
@@ -698,282 +277,61 @@ export class RendererManager {
     a.click();
     document.body.removeChild(a);
   }
-
-  setRecording(isRecording: boolean): void {
-    this.currentRenderer?.setRecording?.(isRecording);
-  }
-
-  setRecordingMode(mode: 'loop' | 'continuous'): void {
-    this.currentRenderer?.setRecordingMode?.(mode);
-  }
-
-  /** True when the active backend records via internal GPU readback (WASM surface path). */
-  usesInternalRecording(): boolean {
-    return this.isWASM();
-  }
-
-  /**
-   * Start an 8s (default) WebM recording on backends that support it.
-   * WASM uses GPU readback; callers may still pass the display canvas for API symmetry.
-   */
-  startRecording(
-    canvas: HTMLCanvasElement,
-    options?: { durationMs?: number; frameRate?: number; videoBitsPerSecond?: number }
-  ): Promise<Blob> {
-    const r = this.currentRenderer as {
-      startRecording?: (
-        c: HTMLCanvasElement,
-        o?: { durationMs?: number; frameRate?: number; videoBitsPerSecond?: number }
-      ) => Promise<Blob>;
-    } | null;
-    if (r?.startRecording) {
-      return r.startRecording(canvas, options);
-    }
+  setRecording(isRecording: boolean): void { this.currentRenderer?.setRecording?.(isRecording); }
+  setRecordingMode(mode: 'loop' | 'continuous'): void { this.currentRenderer?.setRecordingMode?.(mode); }
+  usesInternalRecording(): boolean { return this.isWASM(); }
+  startRecording(canvas: HTMLCanvasElement, options?: { durationMs?: number; frameRate?: number; videoBitsPerSecond?: number }): Promise<Blob> {
+    const r = this.currentRenderer as { startRecording?: typeof RendererManager.prototype.startRecording } | null;
+    if (r?.startRecording) return r.startRecording(canvas, options);
     return Promise.reject(new Error('[RendererManager] startRecording not supported for active backend'));
   }
-
-  /** Stop an in-progress renderer recording (WASM readback path). */
   stopRendererRecording(): void {
-    const r = this.currentRenderer as { stopRecording?: () => void } | null;
-    r?.stopRecording?.();
+    (this.currentRenderer as { stopRecording?: () => void } | null)?.stopRecording?.();
   }
-
-  getMetrics(): RendererMetrics {
-    return this.metrics;
-  }
-
-  isWASM(): boolean {
-    return this.metrics.isWASM;
-  }
-
-  /**
-   * Returns the type identifier of the currently active renderer backend.
-   * Useful for UI components that need to display or react to the active renderer.
-   */
+  getMetrics(): RendererMetrics { return this.metrics; }
+  isWASM(): boolean { return this.metrics.isWASM; }
   getActiveRendererType(): RendererType {
     if (this.currentType) return this.currentType;
     if (this.metrics.isWASM) return 'wasm';
-    if (this.getShaderBackend()) return 'webgpu';
+    if (this.backend()) return 'webgpu';
     return 'js';
   }
-
-  /**
-   * Get diagnostic information about the currently active renderer.
-   * Useful for debugging, testing, and monitoring renderer health.
-   */
   getDiagnostics(): RendererDiagnostics {
-    const rendererType = this.getActiveRendererType();
-    const baseDiagnostics: RendererDiagnostics = {
-      rendererType,
-      metrics: this.metrics,
-      timestamp: new Date().toISOString(),
-    };
-
-    const active = this.currentRenderer as {
-      getDiagnostics?: () => WASMDiagnostics;
-      initialized?: boolean;
-      getFPS?: () => number;
-      getAdapterSummary?: () => string;
-      getAdapterAttemptLabel?: () => string | null;
-    } | null;
-
-    if (this.metrics.isWASM && active?.getDiagnostics) {
-      return {
-        ...baseDiagnostics,
-        wasm: active.getDiagnostics(),
-      };
-    }
-
-    if (this.getShaderBackend() && !this.metrics.isWASM && active) {
-      return {
-        ...baseDiagnostics,
-        webgpu: {
-          initialized: active.initialized ?? false,
-          fps: active.getFPS?.() ?? 0,
-          // Adapter identity is promotion evidence (WASM_BACKEND_POLICY gate 2) — keep it
-          // visible in-app, not only in the console at init time.
-          adapterInfo: active.getAdapterSummary?.() ?? '',
-          adapterAttemptLabel: active.getAdapterAttemptLabel?.() ?? null,
-        },
-        ...(this.lastFailedWasmRenderer
-          ? { wasm: this.lastFailedWasmRenderer.getDiagnostics() }
-          : {}),
-      };
-    }
-
-    if (this.lastFailedWasmRenderer) {
-      return {
-        ...baseDiagnostics,
-        wasm: this.lastFailedWasmRenderer.getDiagnostics(),
-      };
-    }
-
-    return baseDiagnostics;
+    return buildRendererDiagnostics(
+      this.getActiveRendererType(),
+      this.metrics,
+      this.currentRenderer,
+      this.lastFailedWasmRenderer,
+    );
   }
-
-  /**
-   * Render method called by WebGPUCanvas animation loop.
-   * WebGPU renderer drives its own loop; WASM uploads video frames here then renders internally.
-   */
-  render(..._args: unknown[]): void {
-    if (this.metrics.isWASM) {
-      this.updateVideoFrame();
-    }
-  }
-
-  /** Get latest FPS from the active renderer (real measured value). */
-  getCurrentFPS(): number {
-    return this.metrics.fps || 0;
-  }
-
-  /** Apply a user-facing quality preset (persisted by the UI layer). */
-  setRenderQuality(
-    mode: RenderQualityMode,
-    hints?: { supportsDeepWorkgroup?: boolean; formatCaps?: DeviceFormatCapabilities },
-  ): void {
+  render(..._args: unknown[]): void { if (this.metrics.isWASM) this.updateVideoFrame(); }
+  getCurrentFPS(): number { return this.metrics.fps || 0; }
+  setRenderQuality(mode: RenderQualityMode, hints?: { supportsDeepWorkgroup?: boolean; formatCaps?: DeviceFormatCapabilities }): void {
     this.applyQualityPolicy(mode, hints);
   }
-
-  /**
-   * Resolve + apply a quality tier. Storage format is pinned to rgba32float whenever an
-   * FP32-required shader is loaded, so switching to balanced/battery (or an auto probe
-   * landing on FP16) can never silently demote a physics sim — docs/FORMAT_TIERS.md.
-   */
-  private applyQualityPolicy(
-    mode: RenderQualityMode,
-    hints?: { supportsDeepWorkgroup?: boolean; formatCaps?: DeviceFormatCapabilities },
-  ): void {
-    this.qualityMode = mode;
-    const supportsDeep = hints?.supportsDeepWorkgroup ?? this.getSupportsDeepWorkgroup();
-    const formatCaps = hints?.formatCaps ?? this.formatCapabilities;
-    const resolved = resolvePerformancePolicy(mode, {
-      supportsDeepWorkgroup: supportsDeep,
-      formatCaps,
-    });
-    this.requestedColorFormat = resolved.colorFormat;
-    const pin = resolveFp32Pin(resolved.colorFormat, this.fp32RequiredShaders);
-    this.fp32Pin = pin;
-    if (pin.pinned) {
-      console.warn(
-        `[RendererManager] Quality "${mode}" requests ${resolved.colorFormat}, but ` +
-          `${pin.pinnedBy.join(', ')} require rgba32float — storage format pinned to FP32`,
-      );
-    }
-    this.performancePolicy = { ...resolved, colorFormat: pin.colorFormat };
-    this.applyPerformancePolicyToRenderer();
+  private applyQualityPolicy(mode: RenderQualityMode, hints?: { supportsDeepWorkgroup?: boolean; formatCaps?: DeviceFormatCapabilities }): void {
+    applyQualityPolicy(this.perfState, mode, hints, () => this.getSupportsDeepWorkgroup());
+    applyPerformancePolicyToRenderer(this.perfState, this.shaderRenderer(), this.adaptiveController);
   }
-
-  /**
-   * Drop an FP32 pin when a shader is no longer loaded (slot cleared / shader replaced).
-   * Re-applies the current tier so the format can return to FP16 when nothing needs FP32.
-   */
   releaseFp32Requirement(id: string): void {
-    if (!this.fp32RequiredShaders.delete(id)) return;
-    if (this.fp32Pin.pinned) {
-      this.applyQualityPolicy(this.qualityMode);
-    }
+    if (!releaseFp32Requirement(this.perfState, id)) return;
+    if (this.perfState.fp32Pin.pinned) this.applyQualityPolicy(this.perfState.qualityMode);
   }
-
-  getRenderQualityMode(): RenderQualityMode {
-    return this.qualityMode;
-  }
-
-  getMaxActiveSlots(): number {
-    return this.performancePolicy.maxActiveSlots;
-  }
-
+  getRenderQualityMode(): RenderQualityMode { return this.perfState.qualityMode; }
+  getMaxActiveSlots(): number { return this.perfState.performancePolicy.maxActiveSlots; }
   getPerformanceStatus(): RendererPerformanceStatus {
-    const backend = this.getActiveRendererType();
-    const scaleInfo = this.readResolutionScale();
-    return {
-      qualityMode: this.qualityMode,
-      backend,
-      scale: scaleInfo.scale,
-      internalWidth: scaleInfo.scaled.w,
-      internalHeight: scaleInfo.scaled.h,
-      maxActiveSlots: this.performancePolicy.maxActiveSlots,
-      targetFps: this.performancePolicy.targetFps,
-      adaptive: this.performancePolicy.adaptive,
-      fps: this.getCurrentFPS(),
-      colorFormat: this.performancePolicy.colorFormat,
-      estimatedTextureMiB: estimateInternalTextureMiB(
-        scaleInfo.scaled.w,
-        scaleInfo.scaled.h,
-        this.performancePolicy.colorFormat,
-      ),
-      requestedColorFormat: this.requestedColorFormat,
-      fp32Pinned: this.fp32Pin.pinned,
-      fp32PinnedBy: this.fp32Pin.pinnedBy,
-      maxPassesPerFrame: this.performancePolicy.maxPassesPerFrame,
-    };
+    return buildPerformanceStatus(
+      this.perfState,
+      this.getActiveRendererType(),
+      () => this.getCurrentFPS(),
+      readResolutionScale(this.perfState, this.config, this.shaderRenderer()),
+    );
   }
-
-  private readResolutionScale(): {
-    scale: number;
-    scaled: { w: number; h: number };
-  } {
-    const r = this.currentRenderer;
-    const fromRenderer = r && 'getResolutionScale' in r
-      ? (r as WebGPURenderer | WASMRenderer).getResolutionScale?.()
-      : undefined;
-    if (fromRenderer) {
-      this.resolutionScale = fromRenderer.scale;
-      return {
-        scale: fromRenderer.scale,
-        scaled: { w: fromRenderer.scaled.w, h: fromRenderer.scaled.h },
-      };
-    }
-    const base = this.config.width || INTERNAL_RENDER_RESOLUTION;
-    const dims = computeInternalDimensions(base, this.resolutionScale);
-    return {
-      scale: dims.scale,
-      scaled: { w: dims.width, h: dims.height },
-    };
+  getAudioData() {
+    return (this.currentRenderer as { getAudioData?: () => { bass: number; mid: number; treble: number; freqBins: Float32Array } } | null)
+      ?.getAudioData?.() ?? null;
   }
-
-  private applyPerformancePolicyToRenderer(): void {
-    this.applyResolutionScale(this.performancePolicy.scale);
-    this.applyColorFormat(this.performancePolicy.colorFormat);
-    const r = this.currentRenderer;
-    if (r instanceof WebGPURenderer) {
-      r.setAdaptiveQuality(false);
-      r.setMaxPassesPerFrame(this.performancePolicy.maxPassesPerFrame);
-    }
-    this.adaptiveController.updatePolicy(this.performancePolicy);
-  }
-
-  private applyColorFormat(format: InternalColorFormat): void {
-    const r = this.currentRenderer;
-    if (r instanceof WebGPURenderer) {
-      r.setColorFormat(format);
-    } else if (r instanceof WASMRenderer) {
-      r.setColorFormat(format);
-    }
-  }
-
-  private applyResolutionScale(scale: number): void {
-    this.resolutionScale = scale;
-    const r = this.currentRenderer;
-    if (r instanceof WebGPURenderer) {
-      r.setResolutionScale(scale);
-      r.setAdaptiveQuality(false);
-    } else if (r instanceof WASMRenderer) {
-      r.setResolutionScale(scale);
-    }
-  }
-
-  /** Get audio analysis data from the active renderer when supported. */
-  getAudioData(): { bass: number; mid: number; treble: number; freqBins: Float32Array } | null {
-    const r = this.currentRenderer as {
-      getAudioData?: () => { bass: number; mid: number; treble: number; freqBins: Float32Array };
-    } | null;
-    return r?.getAudioData?.() ?? null;
-  }
-
-  isRecording(): boolean {
-    return this.currentRenderer?.isRecording?.() ?? false;
-  }
-
+  isRecording(): boolean { return this.currentRenderer?.isRecording?.() ?? false; }
   destroy(): void {
     this.adaptiveController.stop();
     this.currentRenderer?.destroy();

--- a/src/renderer/backendLifecycle.test.ts
+++ b/src/renderer/backendLifecycle.test.ts
@@ -1,0 +1,143 @@
+import {
+  createRendererForType,
+  getRendererTypeFromURL,
+  performBackendSwitch,
+  resolveInitBackendPreference,
+  usesExclusiveWebGpu,
+  yieldForGpuRelease,
+} from './backendLifecycle';
+import { JSRenderer } from './JSRenderer';
+import { WASMRenderer } from './WASMRenderer';
+import { WebGPURenderer } from './WebGPURenderer';
+import { DEFAULT_CONFIG } from './Renderer';
+
+jest.mock('./WebGPURenderer');
+jest.mock('./WASMRenderer');
+jest.mock('./JSRenderer');
+
+describe('backendLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getRendererTypeFromURL', () => {
+    it('returns wasm when ?renderer=wasm', () => {
+      const original = window.location;
+      Object.defineProperty(window, 'location', {
+        value: { ...original, search: '?renderer=wasm' },
+        configurable: true,
+      });
+      expect(getRendererTypeFromURL()).toBe('wasm');
+      Object.defineProperty(window, 'location', { value: original, configurable: true });
+    });
+
+    it('returns null for unknown renderer param', () => {
+      const original = window.location;
+      Object.defineProperty(window, 'location', {
+        value: { ...original, search: '?renderer=metal' },
+        configurable: true,
+      });
+      expect(getRendererTypeFromURL()).toBeNull();
+      Object.defineProperty(window, 'location', { value: original, configurable: true });
+    });
+  });
+
+  describe('usesExclusiveWebGpu', () => {
+    it('marks webgpu and wasm as exclusive', () => {
+      expect(usesExclusiveWebGpu('webgpu')).toBe(true);
+      expect(usesExclusiveWebGpu('wasm')).toBe(true);
+      expect(usesExclusiveWebGpu('js')).toBe(false);
+    });
+  });
+
+  describe('resolveInitBackendPreference', () => {
+    it('honours wasm URL without auto-fallback flag', () => {
+      const original = window.location;
+      Object.defineProperty(window, 'location', {
+        value: { ...original, search: '?renderer=wasm' },
+        configurable: true,
+      });
+      expect(resolveInitBackendPreference()).toEqual({ preferredType: 'wasm', wasmUrlFailed: false });
+      Object.defineProperty(window, 'location', { value: original, configurable: true });
+    });
+  });
+
+  describe('performBackendSwitch', () => {
+    it('releases webgpu before wasm init on exclusive switch', async () => {
+      const order: string[] = [];
+      const canvas = document.createElement('canvas');
+      const webgpu = {
+        init: jest.fn().mockResolvedValue(true),
+        destroy: jest.fn(() => order.push('webgpu.destroy')),
+        setVideo: jest.fn(),
+      };
+      const wasm = {
+        init: jest.fn(async () => {
+          order.push('wasm.init');
+          return true;
+        }),
+        destroy: jest.fn(),
+        setVideo: jest.fn(),
+      };
+      (WebGPURenderer as jest.Mock).mockImplementation(() => webgpu);
+      (WASMRenderer as jest.Mock).mockImplementation(() => wasm);
+
+      const result = await performBackendSwitch({
+        targetType: 'wasm',
+        canvas,
+        config: DEFAULT_CONFIG,
+        previousType: 'webgpu',
+        previousRenderer: webgpu as never,
+      });
+
+      expect(result.success).toBe(true);
+      expect(order.indexOf('webgpu.destroy')).toBeGreaterThanOrEqual(0);
+      expect(order.indexOf('wasm.init')).toBeGreaterThan(order.indexOf('webgpu.destroy'));
+    });
+
+    it('requests restore type when wasm fails after exclusive release', async () => {
+      const canvas = document.createElement('canvas');
+      const webgpu = { init: jest.fn().mockResolvedValue(true), destroy: jest.fn(), setVideo: jest.fn() };
+      const wasm = { init: jest.fn().mockResolvedValue(false), destroy: jest.fn(), setVideo: jest.fn() };
+      (WASMRenderer as jest.Mock).mockImplementation(() => wasm);
+
+      const result = await performBackendSwitch({
+        targetType: 'wasm',
+        canvas,
+        config: DEFAULT_CONFIG,
+        previousType: 'webgpu',
+        previousRenderer: webgpu as never,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.restoreType).toBe('webgpu');
+      expect(result.failedWasmRenderer).toBe(wasm);
+    });
+  });
+
+  describe('yieldForGpuRelease', () => {
+    it('resolves after one animation frame when available', async () => {
+      const raf = jest.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+      const original = global.requestAnimationFrame;
+      global.requestAnimationFrame = raf;
+      await yieldForGpuRelease();
+      expect(raf).toHaveBeenCalled();
+      global.requestAnimationFrame = original;
+    });
+  });
+
+  describe('createRendererForType', () => {
+    it('instantiates the three backend classes', () => {
+      (WebGPURenderer as jest.Mock).mockImplementation(() => ({ tag: 'webgpu' }));
+      (WASMRenderer as jest.Mock).mockImplementation(() => ({ tag: 'wasm' }));
+      (JSRenderer as jest.Mock).mockImplementation(() => ({ tag: 'js' }));
+
+      expect(createRendererForType('webgpu', DEFAULT_CONFIG)).toEqual({ tag: 'webgpu' });
+      expect(createRendererForType('wasm', DEFAULT_CONFIG)).toEqual({ tag: 'wasm' });
+      expect(createRendererForType('js', DEFAULT_CONFIG)).toEqual({ tag: 'js' });
+    });
+  });
+});

--- a/src/renderer/backendLifecycle.ts
+++ b/src/renderer/backendLifecycle.ts
@@ -1,0 +1,158 @@
+/**
+ * backendLifecycle.ts
+ *
+ * Pure seams for renderer backend create/destroy/switch and ?renderer= URL preference.
+ * Mirrors the lifecycle split in webgpu/device.ts — RendererManager stays a thin facade.
+ */
+
+import { Renderer, RendererConfig } from './Renderer';
+import { JSRenderer } from './JSRenderer';
+import { WASMRenderer } from './WASMRenderer';
+import { WebGPURenderer } from './WebGPURenderer';
+
+/** Supported renderer backend identifiers. */
+export type RendererType = 'webgpu' | 'wasm' | 'js';
+
+/**
+ * Read the preferred renderer type from the URL query string.
+ *
+ * Supported values for the `renderer` parameter:
+ *   - `wasm`   → C++ Emscripten WASM renderer (**experimental** — see WASM_BACKEND_POLICY.md)
+ *   - `webgpu` → TypeScript native WebGPU renderer (default)
+ *   - `js`     → Canvas 2D fallback (no shaders)
+ *
+ * Example: `http://localhost:3000/?renderer=wasm`
+ */
+export function getRendererTypeFromURL(): RendererType | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get('renderer');
+    if (value === 'wasm' || value === 'webgpu' || value === 'js') {
+      return value as RendererType;
+    }
+  } catch {
+    // Not in a browser context (e.g. tests)
+  }
+  return null;
+}
+
+/** Both TS WebGPU and emdawnwebgpu (WASM) claim exclusive adapter/device ownership. */
+export function usesExclusiveWebGpu(type: RendererType): boolean {
+  return type === 'webgpu' || type === 'wasm';
+}
+
+/** Yield one frame so the previous backend can release GPU handles before the next init. */
+export function yieldForGpuRelease(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+/** Factory for the three renderer backends — keeps RendererManager free of `new` branches. */
+export function createRendererForType(type: RendererType, config: RendererConfig): Renderer {
+  if (type === 'webgpu') return new WebGPURenderer(config);
+  if (type === 'wasm') return new WASMRenderer(config);
+  return new JSRenderer(config);
+}
+
+export interface BackendSwitchInput {
+  targetType: RendererType;
+  canvas: HTMLCanvasElement;
+  config: RendererConfig;
+  previousType: RendererType | null;
+  previousRenderer: Renderer | null;
+}
+
+export interface BackendSwitchResult {
+  success: boolean;
+  renderer: Renderer | null;
+  type: RendererType | null;
+  canvas: HTMLCanvasElement;
+  isWASM: boolean;
+  failedWasmRenderer: WASMRenderer | null;
+  /** When set, caller should recursively restore this type after exclusive release failure. */
+  restoreType: RendererType | null;
+}
+
+/**
+ * Attempt to switch renderer backends with exclusive WebGPU release ordering preserved.
+ * Does not recurse on restore — RendererManager handles restore to avoid import cycles.
+ */
+export async function performBackendSwitch(input: BackendSwitchInput): Promise<BackendSwitchResult> {
+  const { targetType, canvas, config, previousType, previousRenderer } = input;
+
+  const mustReleaseFirst =
+    usesExclusiveWebGpu(targetType) &&
+    previousRenderer != null &&
+    previousType != null &&
+    usesExclusiveWebGpu(previousType);
+
+  if (mustReleaseFirst) {
+    console.log(
+      `[RendererManager] Releasing ${previousType} before switching to ${targetType} ` +
+        '(exclusive WebGPU adapter/device ownership)',
+    );
+    previousRenderer!.destroy();
+    await yieldForGpuRelease();
+  }
+
+  const renderer = createRendererForType(targetType, config);
+  const success = await renderer.init(canvas);
+
+  if (success) {
+    if (!mustReleaseFirst) {
+      previousRenderer?.destroy();
+    }
+
+    let nextCanvas = canvas;
+    if (targetType === 'js' && typeof (renderer as JSRenderer).getCanvas === 'function') {
+      const replaced = (renderer as JSRenderer).getCanvas();
+      if (replaced) nextCanvas = replaced;
+    }
+
+    const video = (previousRenderer as { video?: HTMLVideoElement } | null)?.video;
+    if (video) renderer.setVideo(video);
+
+    return {
+      success: true,
+      renderer,
+      type: targetType,
+      canvas: nextCanvas,
+      isWASM: targetType === 'wasm',
+      failedWasmRenderer: null,
+      restoreType: null,
+    };
+  }
+
+  console.warn(`[RendererManager] switchRenderer('${targetType}') failed`);
+  const failedWasmRenderer = targetType === 'wasm' ? (renderer as WASMRenderer) : null;
+
+  return {
+    success: false,
+    renderer: mustReleaseFirst ? null : previousRenderer,
+    type: mustReleaseFirst ? null : previousType,
+    canvas,
+    isWASM: false,
+    failedWasmRenderer,
+    restoreType: mustReleaseFirst ? previousType : null,
+  };
+}
+
+export interface InitBackendPreference {
+  /** First backend to try after URL overrides (null = default webgpu→js chain). */
+  preferredType: RendererType | null;
+  /** When wasm was requested via URL but failed — fall through without auto-wasm elsewhere. */
+  wasmUrlFailed: boolean;
+}
+
+/** Resolve which backend init() should attempt first (URL query only; no auto-wasm). */
+export function resolveInitBackendPreference(): InitBackendPreference {
+  const urlPreference = getRendererTypeFromURL();
+  if (urlPreference === 'wasm') return { preferredType: 'wasm', wasmUrlFailed: false };
+  if (urlPreference === 'js') return { preferredType: 'js', wasmUrlFailed: false };
+  return { preferredType: null, wasmUrlFailed: false };
+}

--- a/src/renderer/inputSourceBridge.test.ts
+++ b/src/renderer/inputSourceBridge.test.ts
@@ -1,0 +1,33 @@
+import { loadImage, setInputSource, getInputSource } from './inputSourceBridge';
+
+describe('inputSourceBridge', () => {
+  it('forwards setInputSource and getInputSource', () => {
+    const renderer = {
+      setInputSource: jest.fn(),
+      getInputSource: jest.fn().mockReturnValue('webcam'),
+    };
+    setInputSource(renderer as never, 'video');
+    expect(renderer.setInputSource).toHaveBeenCalledWith('video');
+    expect(getInputSource(renderer as never)).toBe('webcam');
+  });
+
+  it('prefers loadImage over loadImageFromURL (#887 duck-type)', async () => {
+    const renderer = {
+      loadImage: jest.fn().mockResolvedValue('https://cdn/a.png'),
+      loadImageFromURL: jest.fn(),
+    };
+    const url = await loadImage(renderer as never, 'https://cdn/a.png');
+    expect(renderer.loadImage).toHaveBeenCalledWith('https://cdn/a.png');
+    expect(renderer.loadImageFromURL).not.toHaveBeenCalled();
+    expect(url).toBe('https://cdn/a.png');
+  });
+
+  it('falls back to loadImageFromURL when loadImage is absent', async () => {
+    const renderer = {
+      loadImageFromURL: jest.fn().mockResolvedValue(undefined),
+    };
+    const url = await loadImage(renderer as never, 'https://cdn/b.png');
+    expect(renderer.loadImageFromURL).toHaveBeenCalledWith('https://cdn/b.png');
+    expect(url).toBe('https://cdn/b.png');
+  });
+});

--- a/src/renderer/inputSourceBridge.ts
+++ b/src/renderer/inputSourceBridge.ts
@@ -1,0 +1,68 @@
+/**
+ * inputSourceBridge.ts
+ *
+ * Pure seams for image/video/webcam/depth input handoff to the active renderer backend.
+ */
+
+import { Renderer } from './Renderer';
+import { InputSource } from './types';
+
+type RendererWithInput = Renderer & {
+  setInputSource?: (source: InputSource) => void;
+  getInputSource?: () => InputSource;
+  setImageList?: (urls: string[]) => void;
+  updateDepthMap?: (data: Float32Array, width: number, height: number) => void;
+  loadImage?: (url: string) => Promise<string>;
+  loadImageFromURL?: (url: string) => Promise<void>;
+  getAvailableModes?: () => import('./types').ShaderEntry[];
+};
+
+export function setInputSource(renderer: Renderer | null, source: InputSource): void {
+  (renderer as RendererWithInput | null)?.setInputSource?.(source);
+}
+
+export function getInputSource(renderer: Renderer | null): InputSource | null {
+  return (renderer as RendererWithInput | null)?.getInputSource?.() ?? null;
+}
+
+export function setVideo(renderer: Renderer | null, video: HTMLVideoElement): void {
+  renderer?.setVideo(video);
+}
+
+export function updateVideoFrame(renderer: Renderer | null): void {
+  renderer?.updateVideoFrame();
+}
+
+export function setImageList(renderer: Renderer | null, urls: string[]): void {
+  const r = renderer as RendererWithInput | null;
+  r?.setImageList?.(urls);
+}
+
+export function updateDepthMap(
+  renderer: Renderer | null,
+  data: Float32Array,
+  width: number,
+  height: number,
+): void {
+  const r = renderer as RendererWithInput | null;
+  r?.updateDepthMap?.(data, width, height);
+}
+
+/** Duck-typed image load — prefers loadImage, falls back to loadImageFromURL (#887). */
+export async function loadImage(renderer: Renderer | null, url: string): Promise<string> {
+  const r = renderer as RendererWithInput | null;
+  if (!r) return url;
+  if (r.loadImage) {
+    return r.loadImage(url);
+  }
+  if (r.loadImageFromURL) {
+    await r.loadImageFromURL(url);
+    return url;
+  }
+  return url;
+}
+
+export function getAvailableModes(renderer: Renderer | null): import('./types').ShaderEntry[] {
+  const r = renderer as RendererWithInput | null;
+  return r?.getAvailableModes?.() ?? [];
+}

--- a/src/renderer/performanceStatus.test.ts
+++ b/src/renderer/performanceStatus.test.ts
@@ -1,0 +1,48 @@
+import {
+  applyQualityPolicy,
+  buildPerformanceStatus,
+  createPerformancePolicyState,
+  registerFp32Requirement,
+  releaseFp32Requirement,
+} from './performanceStatus';
+
+describe('performanceStatus', () => {
+  it('pins rgba32float when an FP32-required shader is registered', () => {
+    const state = createPerformancePolicyState();
+    applyQualityPolicy(state, 'balanced', { supportsDeepWorkgroup: true });
+    expect(state.performancePolicy.colorFormat).not.toBe('rgba32float');
+
+    registerFp32Requirement(state, 'wave-equation');
+    applyQualityPolicy(state, 'balanced', { supportsDeepWorkgroup: true });
+
+    expect(state.fp32Pin.pinned).toBe(true);
+    expect(state.fp32Pin.pinnedBy).toContain('wave-equation');
+    expect(state.performancePolicy.colorFormat).toBe('rgba32float');
+  });
+
+  it('releases FP32 pin when shader requirement is removed', () => {
+    const state = createPerformancePolicyState();
+    registerFp32Requirement(state, 'ripple-tank');
+    applyQualityPolicy(state, 'balanced', { supportsDeepWorkgroup: true });
+    expect(state.fp32Pin.pinned).toBe(true);
+
+    releaseFp32Requirement(state, 'ripple-tank');
+    applyQualityPolicy(state, 'balanced', { supportsDeepWorkgroup: true });
+    expect(state.fp32Pin.pinned).toBe(false);
+  });
+
+  it('surfaces pass budget and format tier in performance status', () => {
+    const state = createPerformancePolicyState();
+    applyQualityPolicy(state, 'ultra', { supportsDeepWorkgroup: true });
+    const status = buildPerformanceStatus(
+      state,
+      'webgpu',
+      () => 60,
+      { scale: 1, scaled: { w: 2048, h: 2048 } },
+    );
+    expect(status.backend).toBe('webgpu');
+    expect(status.maxPassesPerFrame).toBeGreaterThan(0);
+    expect(status.requestedColorFormat).toBeDefined();
+    expect(status.colorFormat).toBeDefined();
+  });
+});

--- a/src/renderer/performanceStatus.ts
+++ b/src/renderer/performanceStatus.ts
@@ -1,0 +1,219 @@
+/**
+ * performanceStatus.ts
+ *
+ * Pure seams for format tier / FP32 pin / pass-budget policy surface.
+ * Mirrors webgpu quality caps without touching engine internals.
+ */
+
+import {
+  computeInternalDimensions,
+  estimateInternalTextureMiB,
+  INTERNAL_RENDER_RESOLUTION,
+  RenderQualityMode,
+  ResolvedPerformancePolicy,
+  resolvePerformancePolicy,
+} from '../config/performancePolicy';
+import {
+  DEFAULT_FORMAT_CAPABILITIES,
+  DeviceFormatCapabilities,
+  Fp32PinDecision,
+  InternalColorFormat,
+  resolveFp32Pin,
+} from '../config/formatPolicy';
+import { AdaptivePerformanceController } from './adaptivePerformance';
+import { RendererConfig } from './Renderer';
+import { WASMRenderer } from './WASMRenderer';
+import { WebGPURenderer } from './WebGPURenderer';
+import type { RendererType } from './backendLifecycle';
+
+export interface RendererPerformanceStatus {
+  qualityMode: RenderQualityMode;
+  backend: RendererType;
+  scale: number;
+  internalWidth: number;
+  internalHeight: number;
+  maxActiveSlots: number;
+  targetFps: number;
+  adaptive: boolean;
+  fps: number;
+  colorFormat: InternalColorFormat;
+  estimatedTextureMiB: number;
+  /** Format the quality tier asked for, before any FP32 pin. */
+  requestedColorFormat: InternalColorFormat;
+  /** True when an FP32-required shader forced rgba32float over the tier default. */
+  fp32Pinned: boolean;
+  /** Shader ids holding the FP32 pin. */
+  fp32PinnedBy: string[];
+  /** Graph dispatch cap for this tier (Tier C multipass). */
+  maxPassesPerFrame: number;
+}
+
+export interface PerformancePolicyState {
+  qualityMode: RenderQualityMode;
+  performancePolicy: ResolvedPerformancePolicy;
+  requestedColorFormat: InternalColorFormat;
+  fp32Pin: Fp32PinDecision;
+  formatCapabilities: DeviceFormatCapabilities;
+  resolutionScale: number;
+  fp32RequiredShaders: Set<string>;
+}
+
+export function createPerformancePolicyState(): PerformancePolicyState {
+  const initialPolicy = resolvePerformancePolicy('auto', { supportsDeepWorkgroup: true });
+  return {
+    qualityMode: 'auto',
+    performancePolicy: initialPolicy,
+    requestedColorFormat: initialPolicy.colorFormat,
+    fp32Pin: {
+      colorFormat: initialPolicy.colorFormat,
+      pinned: false,
+      pinnedBy: [],
+    },
+    formatCapabilities: DEFAULT_FORMAT_CAPABILITIES,
+    resolutionScale: 1.0,
+    fp32RequiredShaders: new Set<string>(),
+  };
+}
+
+export function refreshFormatCapabilities(
+  state: PerformancePolicyState,
+  renderer: WebGPURenderer | WASMRenderer | null,
+): void {
+  const fromRenderer = renderer && 'getFormatCapabilities' in renderer
+    ? renderer.getFormatCapabilities?.()
+    : undefined;
+  if (fromRenderer) {
+    state.formatCapabilities = fromRenderer;
+  }
+}
+
+export function applyQualityPolicy(
+  state: PerformancePolicyState,
+  mode: RenderQualityMode,
+  hints?: { supportsDeepWorkgroup?: boolean; formatCaps?: DeviceFormatCapabilities },
+  getSupportsDeepWorkgroup?: () => boolean,
+): void {
+  state.qualityMode = mode;
+  const supportsDeep = hints?.supportsDeepWorkgroup ?? getSupportsDeepWorkgroup?.() ?? true;
+  const formatCaps = hints?.formatCaps ?? state.formatCapabilities;
+  const resolved = resolvePerformancePolicy(mode, {
+    supportsDeepWorkgroup: supportsDeep,
+    formatCaps,
+  });
+  state.requestedColorFormat = resolved.colorFormat;
+  const pin = resolveFp32Pin(resolved.colorFormat, state.fp32RequiredShaders);
+  state.fp32Pin = pin;
+  if (pin.pinned) {
+    console.warn(
+      `[RendererManager] Quality "${mode}" requests ${resolved.colorFormat}, but ` +
+        `${pin.pinnedBy.join(', ')} require rgba32float — storage format pinned to FP32`,
+    );
+  }
+  state.performancePolicy = { ...resolved, colorFormat: pin.colorFormat };
+}
+
+export function registerFp32Requirement(state: PerformancePolicyState, shaderId: string): boolean {
+  const wasNew = !state.fp32RequiredShaders.has(shaderId);
+  state.fp32RequiredShaders.add(shaderId);
+  return wasNew;
+}
+
+export function releaseFp32Requirement(state: PerformancePolicyState, shaderId: string): boolean {
+  return state.fp32RequiredShaders.delete(shaderId);
+}
+
+export function readResolutionScale(
+  state: PerformancePolicyState,
+  config: RendererConfig,
+  renderer: WebGPURenderer | WASMRenderer | null,
+): { scale: number; scaled: { w: number; h: number } } {
+  const fromRenderer = renderer && 'getResolutionScale' in renderer
+    ? renderer.getResolutionScale?.()
+    : undefined;
+  if (fromRenderer) {
+    state.resolutionScale = fromRenderer.scale;
+    return {
+      scale: fromRenderer.scale,
+      scaled: { w: fromRenderer.scaled.w, h: fromRenderer.scaled.h },
+    };
+  }
+  const base = config.width || INTERNAL_RENDER_RESOLUTION;
+  const dims = computeInternalDimensions(base, state.resolutionScale);
+  return {
+    scale: dims.scale,
+    scaled: { w: dims.width, h: dims.height },
+  };
+}
+
+export function buildPerformanceStatus(
+  state: PerformancePolicyState,
+  backend: RendererType,
+  getFps: () => number,
+  scaleInfo: { scale: number; scaled: { w: number; h: number } },
+): RendererPerformanceStatus {
+  return {
+    qualityMode: state.qualityMode,
+    backend,
+    scale: scaleInfo.scale,
+    internalWidth: scaleInfo.scaled.w,
+    internalHeight: scaleInfo.scaled.h,
+    maxActiveSlots: state.performancePolicy.maxActiveSlots,
+    targetFps: state.performancePolicy.targetFps,
+    adaptive: state.performancePolicy.adaptive,
+    fps: getFps(),
+    colorFormat: state.performancePolicy.colorFormat,
+    estimatedTextureMiB: estimateInternalTextureMiB(
+      scaleInfo.scaled.w,
+      scaleInfo.scaled.h,
+      state.performancePolicy.colorFormat,
+    ),
+    requestedColorFormat: state.requestedColorFormat,
+    fp32Pinned: state.fp32Pin.pinned,
+    fp32PinnedBy: state.fp32Pin.pinnedBy,
+    maxPassesPerFrame: state.performancePolicy.maxPassesPerFrame,
+  };
+}
+
+export function applyPerformancePolicyToRenderer(
+  state: PerformancePolicyState,
+  renderer: WebGPURenderer | WASMRenderer | null,
+  adaptiveController: AdaptivePerformanceController,
+): void {
+  applyResolutionScale(state, renderer, state.performancePolicy.scale);
+  applyColorFormat(renderer, state.performancePolicy.colorFormat);
+  if (renderer instanceof WebGPURenderer) {
+    renderer.setAdaptiveQuality(false);
+    renderer.setMaxPassesPerFrame(state.performancePolicy.maxPassesPerFrame);
+  }
+  adaptiveController.updatePolicy(state.performancePolicy);
+}
+
+function applyColorFormat(renderer: WebGPURenderer | WASMRenderer | null, format: InternalColorFormat): void {
+  if (renderer instanceof WebGPURenderer) {
+    renderer.setColorFormat(format);
+  } else if (renderer instanceof WASMRenderer) {
+    renderer.setColorFormat(format);
+  }
+}
+
+function applyResolutionScale(
+  state: PerformancePolicyState,
+  renderer: WebGPURenderer | WASMRenderer | null,
+  scale: number,
+): void {
+  state.resolutionScale = scale;
+  if (renderer instanceof WebGPURenderer) {
+    renderer.setResolutionScale(scale);
+    renderer.setAdaptiveQuality(false);
+  } else if (renderer instanceof WASMRenderer) {
+    renderer.setResolutionScale(scale);
+  }
+}
+
+export function applyResolutionScaleToRenderer(
+  state: PerformancePolicyState,
+  renderer: WebGPURenderer | WASMRenderer | null,
+  scale: number,
+): void {
+  applyResolutionScale(state, renderer, scale);
+}

--- a/src/renderer/rendererDiagnostics.ts
+++ b/src/renderer/rendererDiagnostics.ts
@@ -1,0 +1,44 @@
+import { WASMDiagnostics } from './WASMRenderer';
+import type { RendererType } from './backendLifecycle';
+import type { RendererDiagnostics, RendererMetrics } from './rendererTypes';
+import { resolveShaderBackend } from './slotOrchestration';
+import { Renderer } from './Renderer';
+import { WASMRenderer } from './WASMRenderer';
+
+export function buildRendererDiagnostics(
+  rendererType: RendererType,
+  metrics: RendererMetrics,
+  currentRenderer: Renderer | null,
+  lastFailedWasmRenderer: WASMRenderer | null,
+): RendererDiagnostics {
+  const base: RendererDiagnostics = {
+    rendererType,
+    metrics,
+    timestamp: new Date().toISOString(),
+  };
+  const active = currentRenderer as {
+    getDiagnostics?: () => WASMDiagnostics;
+    initialized?: boolean;
+    getFPS?: () => number;
+    getAdapterSummary?: () => string;
+    getAdapterAttemptLabel?: () => string | null;
+  } | null;
+
+  if (metrics.isWASM && active?.getDiagnostics) {
+    return { ...base, wasm: active.getDiagnostics() };
+  }
+  if (resolveShaderBackend(currentRenderer) && !metrics.isWASM && active) {
+    return {
+      ...base,
+      webgpu: {
+        initialized: active.initialized ?? false,
+        fps: active.getFPS?.() ?? 0,
+        adapterInfo: active.getAdapterSummary?.() ?? '',
+        adapterAttemptLabel: active.getAdapterAttemptLabel?.() ?? null,
+      },
+      ...(lastFailedWasmRenderer ? { wasm: lastFailedWasmRenderer.getDiagnostics() } : {}),
+    };
+  }
+  if (lastFailedWasmRenderer) return { ...base, wasm: lastFailedWasmRenderer.getDiagnostics() };
+  return base;
+}

--- a/src/renderer/rendererTypes.ts
+++ b/src/renderer/rendererTypes.ts
@@ -1,0 +1,22 @@
+import { WASMDiagnostics } from './WASMRenderer';
+import type { RendererType } from './backendLifecycle';
+
+export interface RendererMetrics {
+  fps: number;
+  frameTime: number;
+  agentCount: number;
+  isWASM: boolean;
+}
+
+export interface RendererDiagnostics {
+  rendererType: RendererType;
+  metrics: RendererMetrics;
+  timestamp: string;
+  wasm?: WASMDiagnostics;
+  webgpu?: {
+    initialized: boolean;
+    fps: number;
+    adapterInfo: string;
+    adapterAttemptLabel: string | null;
+  };
+}

--- a/src/renderer/slotOrchestration.test.ts
+++ b/src/renderer/slotOrchestration.test.ts
@@ -1,0 +1,91 @@
+import {
+  resolveShaderBackend,
+  setSlotParams,
+  syncAllSlotParams,
+  SLOT_COUNT,
+} from './slotOrchestration';
+import { SlotParams } from './types';
+
+describe('slotOrchestration', () => {
+  const defaultSlotParams: SlotParams = {
+    zoomParam1: 0.1,
+    zoomParam2: 0.2,
+    zoomParam3: 0.3,
+    zoomParam4: 0.4,
+    lightStrength: 1,
+    ambient: 0.2,
+    normalStrength: 0.1,
+    fogFalloff: 4,
+    depthThreshold: 0.5,
+  };
+
+  it('resolves duck-typed shader backends', () => {
+    const backend = {
+      loadShader: jest.fn(),
+      setActiveShader: jest.fn(),
+      setSlotShader: jest.fn(),
+      updateSlotParams: jest.fn(),
+      setSlotMode: jest.fn(),
+      addRipple: jest.fn(),
+      clearRipples: jest.fn(),
+    };
+    expect(resolveShaderBackend(backend as never)).toBe(backend);
+    expect(resolveShaderBackend(null)).toBeNull();
+  });
+
+  it('forwards setSlotParams via setSlotParams when available', () => {
+    const backend = {
+      loadShader: jest.fn(),
+      setActiveShader: jest.fn(),
+      setSlotShader: jest.fn(),
+      setSlotParams: jest.fn(),
+      updateSlotParams: jest.fn(),
+      setSlotMode: jest.fn(),
+      addRipple: jest.fn(),
+      clearRipples: jest.fn(),
+    };
+    setSlotParams(backend, 1, 0.1, 0.2, 0.3, 0.4);
+    expect(backend.setSlotParams).toHaveBeenCalledWith(1, 0.1, 0.2, 0.3, 0.4);
+  });
+
+  it('falls back to updateSlotParams aggregate form (#887)', () => {
+    const backend = {
+      loadShader: jest.fn(),
+      setActiveShader: jest.fn(),
+      setSlotShader: jest.fn(),
+      updateSlotParams: jest.fn(),
+      setSlotMode: jest.fn(),
+      addRipple: jest.fn(),
+      clearRipples: jest.fn(),
+    };
+    setSlotParams(backend, 0, 1, 2, 3, 4);
+    expect(backend.updateSlotParams).toHaveBeenCalledWith(
+      { zoomParam1: 1, zoomParam2: 2, zoomParam3: 3, zoomParam4: 4 },
+      0,
+    );
+  });
+
+  it('syncAllSlotParams pushes each slot index', () => {
+    const backend = {
+      loadShader: jest.fn(),
+      setActiveShader: jest.fn(),
+      setSlotShader: jest.fn(),
+      updateSlotParams: jest.fn(),
+      setSlotMode: jest.fn(),
+      addRipple: jest.fn(),
+      clearRipples: jest.fn(),
+    };
+    const slots = [
+      { ...defaultSlotParams, zoomParam1: 0.11 },
+      { ...defaultSlotParams, zoomParam2: 0.22 },
+      { ...defaultSlotParams, zoomParam3: 0.33 },
+    ];
+    syncAllSlotParams(backend, slots, SLOT_COUNT);
+    expect(backend.updateSlotParams).toHaveBeenCalledTimes(3);
+    expect(backend.updateSlotParams).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ zoomParam1: 0.11 }),
+      0,
+    );
+  });
+});

--- a/src/renderer/slotOrchestration.ts
+++ b/src/renderer/slotOrchestration.ts
@@ -1,0 +1,280 @@
+/**
+ * slotOrchestration.ts
+ *
+ * Pure seams for shader-slot enable/mode/params forwarding across WebGPU and WASM backends.
+ * Duck-typed ShaderSlotRenderer resolution matches #887 WASM parity contract.
+ */
+
+import { ShaderSlotRenderer, SlotZoomParamsUpdate } from './Renderer';
+import { JSRenderer } from './JSRenderer';
+import { Renderer } from './Renderer';
+import { InputSource, RenderMode, ShaderEntry, SlotParams } from './types';
+import { getGraphEntryIds, hasGraph } from './multipassRegistry';
+import { resolveShaderUrl } from '../utils/resolveShaderUrl';
+
+export const SLOT_COUNT = 3;
+
+export interface ShaderLoadMeta {
+  requiresDeepWorkgroup?: boolean;
+  requiresHistoryRing?: boolean;
+  requiresRgba32Float?: boolean;
+}
+
+export interface SlotOrchestrationPolicy {
+  maxActiveSlots: number;
+  preferNonDeepVariants: boolean;
+}
+
+export interface SlotOrchestrationCallbacks {
+  onFp32Required: (shaderId: string) => void;
+}
+
+/** Returns the shader-capable backend, or null for Canvas2D fallback. */
+export function resolveShaderBackend(renderer: Renderer | null): ShaderSlotRenderer | null {
+  if (!renderer || renderer instanceof JSRenderer) return null;
+  const candidate = renderer as ShaderSlotRenderer;
+  if (
+    typeof candidate.loadShader === 'function' &&
+    typeof candidate.setSlotShader === 'function' &&
+    typeof candidate.updateSlotParams === 'function'
+  ) {
+    return candidate;
+  }
+  return null;
+}
+
+export function supportsShaderEffects(renderer: Renderer | null): boolean {
+  return resolveShaderBackend(renderer) !== null;
+}
+
+export function setSlotShader(
+  backend: ShaderSlotRenderer | null,
+  policy: SlotOrchestrationPolicy,
+  index: number,
+  id: string,
+): void {
+  if (!backend) return;
+  if (id && index >= policy.maxActiveSlots) {
+    console.warn(
+      `[RendererManager] Slot ${index} exceeds quality cap (${policy.maxActiveSlots} max)`,
+    );
+    return;
+  }
+  backend.setSlotShader(index, id);
+}
+
+export function setSlotParams(
+  backend: ShaderSlotRenderer | null,
+  slotIndex: number,
+  p1: number,
+  p2: number,
+  p3: number,
+  p4: number,
+): void {
+  if (!backend) return;
+  if (backend.setSlotParams) {
+    backend.setSlotParams(slotIndex, p1, p2, p3, p4);
+  } else {
+    backend.updateSlotParams(
+      { zoomParam1: p1, zoomParam2: p2, zoomParam3: p3, zoomParam4: p4 },
+      slotIndex,
+    );
+  }
+}
+
+export function updateSlotParams(
+  backend: ShaderSlotRenderer | null,
+  params: SlotZoomParamsUpdate,
+  slotIndex = 0,
+): void {
+  backend?.updateSlotParams(params, slotIndex);
+}
+
+export function syncAllSlotParams(
+  backend: ShaderSlotRenderer | null,
+  slotParams: SlotParams[],
+  maxSlots = SLOT_COUNT,
+): void {
+  if (!backend || slotParams.length === 0) return;
+  const count = Math.min(maxSlots, slotParams.length);
+  for (let i = 0; i < count; i++) {
+    const p = slotParams[i];
+    updateSlotParams(
+      backend,
+      {
+        zoomParam1: p.zoomParam1,
+        zoomParam2: p.zoomParam2,
+        zoomParam3: p.zoomParam3,
+        zoomParam4: p.zoomParam4,
+      },
+      i,
+    );
+  }
+}
+
+export async function loadShaderForBackend(
+  backend: ShaderSlotRenderer | null,
+  policy: SlotOrchestrationPolicy,
+  callbacks: SlotOrchestrationCallbacks,
+  id: string,
+  url: string,
+  meta?: ShaderLoadMeta,
+): Promise<boolean> {
+  if (!backend) return false;
+
+  if (meta?.requiresDeepWorkgroup && policy.preferNonDeepVariants) {
+    console.log(
+      `[RendererManager] Skipping "${id}" — deep-workgroup variant disabled by quality policy`,
+    );
+    return false;
+  }
+
+  if (meta?.requiresRgba32Float) {
+    callbacks.onFp32Required(id);
+  }
+
+  try {
+    const ok = await backend.loadShader(id, url);
+    if (ok && hasGraph(id)) {
+      const entries = getGraphEntryIds(id);
+      await Promise.all(
+        entries
+          .filter((entryId) => entryId !== id)
+          .map((entryId) =>
+            backend.loadShader(entryId, resolveShaderUrl(`shaders/${entryId}.wgsl`)).catch(() => false),
+          ),
+      );
+    }
+    if (process.env.NODE_ENV === 'development' && ok && meta?.requiresHistoryRing) {
+      console.log(`[RendererManager] Loaded history-ring shader "${id}" (binding 13)`);
+    }
+    return ok;
+  } catch (err) {
+    console.warn(`[RendererManager] loadShader("${id}") failed:`, err);
+    return false;
+  }
+}
+
+export async function loadShadersForBackend(
+  backend: ShaderSlotRenderer | null,
+  policy: SlotOrchestrationPolicy,
+  callbacks: SlotOrchestrationCallbacks,
+  shaders: ShaderEntry[],
+  loadOne: (id: string, url: string, meta?: ShaderLoadMeta) => Promise<boolean>,
+): Promise<void> {
+  if (!backend) return;
+  const results = await Promise.allSettled(
+    shaders.map((s) =>
+      loadOne(s.id, s.url, {
+        requiresDeepWorkgroup: s.requiresDeepWorkgroup,
+        requiresHistoryRing: s.requiresHistoryRing,
+        requiresRgba32Float: s.requiresRgba32Float,
+      }),
+    ),
+  );
+  const failed = results.filter(
+    (r) => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value),
+  ).length;
+  if (failed > 0) {
+    console.warn(`[RendererManager] loadShaders: ${failed}/${shaders.length} shader(s) failed`);
+  }
+}
+
+export async function resyncShaderStack(
+  backend: ShaderSlotRenderer | null,
+  policy: SlotOrchestrationPolicy,
+  callbacks: SlotOrchestrationCallbacks,
+  loadOne: (id: string, url: string, meta?: ShaderLoadMeta) => Promise<boolean>,
+  setInputSource: (source: InputSource) => void,
+  options: {
+    modes: RenderMode[];
+    slotParams: SlotParams[];
+    resolveShader: (shaderId: string) => ShaderEntry | undefined;
+    inputSource?: InputSource;
+  },
+): Promise<void> {
+  if (!backend) return;
+
+  if (options.inputSource) {
+    setInputSource(options.inputSource);
+  }
+
+  for (let i = 0; i < Math.min(SLOT_COUNT, options.modes.length); i++) {
+    const mode = options.modes[i];
+    if (!mode || mode === 'none') {
+      setSlotShader(backend, policy, i, '');
+      continue;
+    }
+
+    const entry = options.resolveShader(mode);
+    if (!entry) {
+      console.warn(`[RendererManager] resyncShaderStack: no entry for "${mode}" on slot ${i}`);
+      continue;
+    }
+
+    const ok = await loadOne(entry.id, entry.url, {
+      requiresDeepWorkgroup: entry.requiresDeepWorkgroup,
+      requiresHistoryRing: entry.requiresHistoryRing,
+      requiresRgba32Float: entry.requiresRgba32Float,
+    });
+    if (ok) {
+      setSlotShader(backend, policy, i, entry.id);
+    } else {
+      console.warn(`[RendererManager] resyncShaderStack: failed to load "${entry.id}" for slot ${i}`);
+    }
+  }
+
+  syncAllSlotParams(backend, options.slotParams);
+}
+
+export function setSlotMode(
+  backend: ShaderSlotRenderer | null,
+  index: number,
+  mode: 'chained' | 'parallel',
+): void {
+  backend?.setSlotMode(index, mode);
+}
+
+export function setActiveShader(backend: ShaderSlotRenderer | null, id: string): void {
+  backend?.setActiveShader(id);
+}
+
+export function addRipple(backend: ShaderSlotRenderer | null, x: number, y: number): void {
+  backend?.addRipple(x, y);
+}
+
+export function clearRipples(backend: ShaderSlotRenderer | null): void {
+  backend?.clearRipples();
+}
+
+export async function reloadShaderOnBackend(
+  renderer: Renderer | null,
+  backend: ShaderSlotRenderer | null,
+  id: string,
+  url: string,
+): Promise<boolean> {
+  if (!backend) return false;
+  const r = renderer as { reloadShaderFromURL?: (shaderId: string, shaderUrl: string) => Promise<boolean> } | null;
+  if (r?.reloadShaderFromURL) {
+    return r.reloadShaderFromURL(id, url);
+  }
+  return backend.loadShader(id, url);
+}
+
+export function firePlasmaOnBackend(
+  renderer: Renderer | null,
+  backend: ShaderSlotRenderer | null,
+  x: number,
+  y: number,
+  vx: number,
+  vy: number,
+): void {
+  const r = renderer as {
+    firePlasma?: (px: number, py: number, pvx: number, pvy: number) => void;
+  } | null;
+  if (r?.firePlasma) {
+    r.firePlasma(x, y, vx, vy);
+    return;
+  }
+  addRipple(backend, x, y);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors the WebGPU-split philosophy (#1043) by extracting pure, unit-tested seams from `RendererManager` and `StoragePanel`, leaving thin facades that preserve all public API contracts.

### RendererManager strangler

| Module | Responsibility |
|--------|----------------|
| `backendLifecycle.ts` | create/destroy/switch backends, `?renderer=` URL preference, exclusive WebGPU release ordering |
| `slotOrchestration.ts` | duck-typed slot enable/mode/params forwarding (#887 WASM parity) |
| `inputSourceBridge.ts` | image/video/webcam/depth handoff |
| `performanceStatus.ts` | format tier / FP32 pin / pass budget surface |
| `rendererDiagnostics.ts` | diagnostics assembly |

- **Facade:** `RendererManager.ts` **344 LOC** (was 987; target ≤350)
- **Contracts preserved:** no WASM auto-fallback; feedback copy order untouched; all public `IRenderer`/app API methods retained

### StoragePanel strangler

New panels under `src/components/storage/panels/`:

- `StorageListBrowser` — list/browser tabs
- `StorageDetailPanel` — preview modal
- `StorageRatings` — `useShaderRating` hook
- `StorageUploadPanel` — drag-drop upload surface
- `OperationsPanel` — operations queue UI

- **Facade:** `StoragePanel.tsx` **200 LOC** (was 738)
- Library tab now routes through `StorageClient.listLibrary()` (no raw `fetch`)

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | clean |
| Jest | **76 suites / 506 pass / 1 skip** (baseline: 71 / 486 / 1) |
| `SKIP_WASM_BUILD=1 npm run build` | Compiled successfully |
| `npm run verify:dependency-boundaries` | green |

## Test plan

- [x] Existing `RendererManager.test.ts` suite (shader forwarding, exclusive WebGPU release, WASM restore)
- [x] New seam unit tests: `backendLifecycle`, `slotOrchestration`, `inputSourceBridge`, `performanceStatus`
- [x] `StorageDetailPanel.test.tsx` smoke
- [ ] Manual: Controls → renderer-switcher toggle (webgpu ↔ wasm ↔ js)
- [ ] Manual: recording smoke path on WASM backend
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c4515ea-09a9-42d4-96cf-95ed173af2e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c4515ea-09a9-42d4-96cf-95ed173af2e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

